### PR TITLE
Legion & BOS Roles

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -1047,3 +1047,39 @@ Initiate
 		/obj/item/book/granter/trait/chemistry=1,
 		/obj/item/clothing/accessory/bos/initiateS=1,
 		)
+
+/*
+Off Duty
+*/
+
+/datum/job/bos/f13offduty
+	title = "Brotherhood Off-Duty"
+	flag = F13OFFDUTYBOS
+	display_order = JOB_DISPLAY_ORDER_INITIATE
+	total_positions = 4
+	spawn_positions = 4
+	description = "Whether operating in disguise or simply enjoying time from the off-shift, you are still a member of the Brotherhood and must abide by the Codex and follow the orders of your superiors. That being said, while off-duty your orders do not take precedence and you should resist issuing them when another of your rank is currently on duty, and if one does not exist, commit to going on-duty. You have a duty to safeguard what equipment you are given, especially your holotags. Ideally, you should be paired with one or more fellow off-duty members; and you would know where the bunker in the region is."
+	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
+	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
+	supervisors = "your superior rank."
+	selection_color = "#95a5a6"
+
+	exp_type = EXP_TYPE_FALLOUT
+	exp_requirements = 300
+
+	outfit = /datum/outfit/job/bos/f13offduty
+
+	access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
+	minimal_access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
+
+/datum/outfit/job/bos/f13offduty
+	name = "Brotherhood Off-Duty"
+	jobtype = /datum/job/bos/f13offduty
+	backpack = /obj/item/storage/backpack/explorer
+	ears = 			/obj/item/radio/headset/headset_bos
+	uniform =		/obj/item/clothing/under/syndicate/brotherhood
+	shoes = 		/obj/item/clothing/shoes/combat/swat
+	gloves = 		/obj/item/clothing/gloves/combat
+	backpack_contents = list(
+		/obj/item/melee/onehanded/knife/survival = 1,
+		)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -632,14 +632,14 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		/obj/item/book/granter/trait/rifleman = 1,
 		)
 
-//Assassin
+//Speculator
 
 /datum/job/CaesarsLegion/Legionnaire/f13venator
-	title = "Legion Assassin"
+	title = "Legion Speculator"
 	flag = F13VENATOR
 	total_positions = 1
 	spawn_positions = 1
-	description = "You are the assassin. With your powerful rifle and your many years of experience, you are a killing machine, capable of taking down even the most formidable targets. Note that you are not a rank-and-file legionary, and you should not be operating as such -- your job is special operations, not fighting alongside the hordes of the Legion."
+	description = "You are a member of the Legion Speculatores. With your powerful rifle and your many years of experience, you are a killing machine, capable of taking down even the most formidable targets. Note that you are not a rank-and-file legionary, and you should not be operating as such -- your job is special operations, not fighting alongside the hordes of the Legion."
 	supervisors = "the Decani and Centurion"
 	display_order = JOB_DISPLAY_ORDER_ASSASSIN
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13venator
@@ -655,7 +655,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	ADD_TRAIT(H, TRAIT_SILENT_STEP, src)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13venator
-	name = "Legion Assassin"
+	name = "Legion Speculator"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13explorer
 	id = /obj/item/card/id/dogtag/legvenator
 	head = /obj/item/clothing/head/helmet/f13/legion/assassin
@@ -1012,21 +1012,21 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 ////Support Roles ////
 //////////////////////
 
-// Immunes are mostly an off-duty role meant to attend to the camp itself and the slaves or prisoners within.
+// Legion Off-Duty - The difference between off-duty and camp follower is that off-duty is NOT expected to do a job.
 
 /datum/job/CaesarsLegion/Legionnaire/f13immune
-	title = "Legion Immune"
+	title = "Legion Off-Duty"
 	flag = F13IMMUNE
-	total_positions = 0
-	spawn_positions = 0
-	description = "An Immune is a legionnaire temporarily assigned to keeping the camp in order, according to their tasking on any given week."
+	total_positions = 4
+	spawn_positions = 4
+	description = "A Legionnaire immune from labor services for the week, granted time of recovery for their victories or injuries, or otherwise deligated to medial tasks maintaining the Legion's encampment."
 	supervisors = "the Centurion"
 	display_order = JOB_DISPLAY_ORDER_IMMUNE
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13immune
 	exp_requirements = 150
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13immune
-	name = "Immune"
+	name = "Legion Off-Duty"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13immune
 	id = /obj/item/card/id/dogtag/legimmune
 	mask = /obj/item/clothing/mask/bandana/legion/camp
@@ -1046,14 +1046,14 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		return
 	ADD_TRAIT(H, TRAIT_MARS_TEACH, src)
 
-// FORGE MASTER
+// Camp Follower - Difference intended between off-duty and Camp Follower is that camp followers may vary in background and are EXPECTED to work as an on-duty role.
 
 /datum/job/CaesarsLegion/Legionnaire/f13campfollower	// Extra materials, Blueprints
-	title = "Camp Exactor"
+	title = "Camp Follower"
 	flag = F13CAMPFOLLOWER
-	total_positions = 1
-	spawn_positions = 1
-	description = "The Camp Exactor is many things, from enforcer of discipline amongst slaves to master blacksmith to fortification engineer to even a surgeon. Whichever it might be they instill fear into other slaves throught brutality."
+	total_positions = 4
+	spawn_positions = 4
+	description = "A camp follower ranges in defintiion and purposes. Some may be not enslaved men who are simply not fit for service, termorarily or perminantly, or women who serve a purpose above stock to the Legion. Duties may vary from medical specialities, weapon crafting or other skilled-labor tasks."
 	supervisors = "the Decani and Centurion"
 	display_order = JOB_DISPLAY_ORDER_CAMPFOLLOWER
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13campfollower
@@ -1065,7 +1065,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13campfollower
-	name = "Camp Exactor"
+	name = "Camp Follower"
 	id = /obj/item/card/id/dogtag/legforgemaster
 	glasses = /obj/item/clothing/glasses/welding
 	shoes = /obj/item/clothing/shoes/f13/military/plated
@@ -1138,8 +1138,8 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 /datum/job/CaesarsLegion/slave
 	title = "Legion Slave"
 	flag = F13LEGIONSLAVE
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 0
+	spawn_positions = 0
 	description = "A slave that survives the breaking camps is given a Legion appropriate name (latin-tribal inspired) and bull tattoo. Be obedient, respectful, stay inside the camp. Work the farm, mine, make food, clean and help injured men. Do NOT escape on your own, up to you how to handle it if forcibly freed by outside forces."
 	supervisors = "Officers and Camp Exactor first, then warriors."
 	display_order = JOB_DISPLAY_ORDER_LEGIONSLAVE


### PR DESCRIPTION
## About The Pull Request
Re-Adds BOS Off-Duty role, Legion Off-Duty role (Requested by Neo) and Camp Follower roles to Legion. Also de-activates slave spots at Raptor's request in return for Camp Follower slots for people.

## Changelog
:cl:
add: Adds Legion Off-Duty role.
add: Re-adds BOS Off-Duty role.
add: Adds Legion Camp Follower role.
remove: Removes Slave Role slots. They can be opened at least.
fixes: Assassin called Speculator. Stoopid name.
/:cl:
