### PR TITLE
Gun Balancing

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1625,7 +1625,6 @@ obj/effect/spawner/bundle/f13/combat_rifle
 				/obj/item/ammo_box/magazine/m556/rifle/extended,
 				/obj/item/ammo_box/magazine/m762/ext,
 				/obj/item/ammo_box/magazine/d12g,
-				/obj/item/ammo_box/a50MG/penetrator,
 				/obj/item/ammo_casing/caseless/rocket/big,
 				/obj/item/ammo_casing/caseless/rocket/incendiary = 10,
 				/obj/item/ammo_casing/caseless/rocket/chem = 3,

--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -456,13 +456,13 @@
 	force_unwielded = 25
 
 
-// Sledgehammer			Keywords: Damage 25/65, Blacksmithing
+// Sledgehammer			Keywords: Damage 25/55, Blacksmithing
 /obj/item/twohanded/sledgehammer/simple
 	icon_state = "hammer-sledge"
 	icon_prefix = "hammer-sledge"
 	var/qualitymod = 0
 	wielded_icon = "hammer-sledge2"
-	force_wielded = 65
+	force_wielded = 55
 
 /obj/item/twohanded/sledgehammer/simple/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -476,7 +476,7 @@
 // ADVANCED TWO HANDED WEAPONS //
 /////////////////////////////////
 
-// Thermic Lance		Keywords: Damage 5/65, AP 0.3 Special Damage Type - Burn, bonus damage metal door
+// Thermic Lance		Keywords: Damage 5/60, AP 0.3 Special Damage Type - Burn, bonus damage metal door
 /obj/item/twohanded/thermic_lance
 	name = "thermic lance"
 	desc = "A versatile power-welding tool. Useful for cutting apart metal things like airlocks, bars, and probably limbs."
@@ -497,7 +497,7 @@
 	hitsound = 'sound/items/welder2.ogg'
 	wielded_icon = "thermiclance2"
 	force_unwielded = 5
-	force_wielded = 65
+	force_wielded = 60
 
 /obj/item/twohanded/thermic_lance/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -545,7 +545,7 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 
-// Super Sledge			Keywords: Damage 25/70
+// Super Sledge			Keywords: Damage 20/60
 /obj/item/twohanded/sledgehammer/supersledge
 	name = "super sledge"
 	desc = "A heavy sledgehammer manufacted from ultra-dense materials, developed by the Brotherhood of Steel. It looks like it could crush someone's skull with ease."
@@ -553,8 +553,8 @@
 	icon_prefix = "hammer-super"
 	force = 25
 	wielded_icon = "hammer-super2"
-	force_unwielded = 25
-	force_wielded = 70
+	force_unwielded = 20
+	force_wielded = 60
 
 obj/item/twohanded/sledgehammer/supersledge/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -12,7 +12,7 @@
 	color = "#eb0000"
 	taste_description = "numbness"
 	metabolization_rate = 1 * REAGENTS_METABOLISM
-	overdose_threshold = 35
+	overdose_threshold = 30
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE
 

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -596,14 +596,14 @@
  * Fire rounds
  * * * * * * * */
 
-#define BULLET_45ACP_DAMAGE_MULT 1.2
+#define BULLET_45ACP_DAMAGE_MULT 1.1
 #define BULLET_45ACP_STAMINA_MULT 1.2
 #define BULLET_45ACP_WOUND_MULT 1.3
 #define BULLET_45ACP_NAKED_WOUND_MULT 1.3
 #define BULLET_45ACP_SPEED_MULT 1.2
 
 /* 45
- * DAMAGE: 36
+ * DAMAGE: 33
  * STAMIN: 39
  * RECOIL: 3
  * WOUNDS: 6.5
@@ -645,7 +645,7 @@
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_MEDIUM
 
 /* 45 simplemob
- * DAMAGE: 36
+ * DAMAGE: 33
  * STAMIN: 32.5
  * RECOIL: 1
  * WOUNDS: 6.5
@@ -665,7 +665,7 @@
 	pixels_per_second = BULLET_SPEED_PISTOL_MEDIUM * BULLET_45ACP_SPEED_MULT
 
 /* 45 op
- * DAMAGE: 25
+ * DAMAGE: 24.75
  * STAMIN: 32.5
  * RECOIL: 1
  * WOUNDS: 6.5
@@ -690,6 +690,7 @@
  * RECOIL: 1
  * WOUNDS: 9.75
  * WNAKED: 4.8
+ * Disabled from being made - Really too fucking strong.
  */
 /obj/item/projectile/bullet/c45/rubber
 	name = ".45 rubber bullet"
@@ -707,7 +708,7 @@
 	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /* 45 fire
- * DAMAGE: 18
+ * DAMAGE: 16.5
  * STAMIN: 58
  * RECOIL: 1
  * WOUNDS: 6.5
@@ -755,9 +756,11 @@
  * Fire rounds
  * * * * * * * */
 
+#define BULLET_357_STAMINA_MULT 0.8
+
 /* 357 fmj
  * DAMAGE: 40
- * STAMIN: 40
+ * STAMIN: 32
  * RECOIL: 1
  * WOUNDS: 10
  * WNAKED: 7.5
@@ -765,7 +768,7 @@
 /obj/item/projectile/bullet/a357
 	name = ".357 FMJ bullet"
 	damage = BULLET_DAMAGE_PISTOL_HEAVY * BULLET_SURPLUS_MULT
-	stamina = BULLET_STAMINA_PISTOL_HEAVY * BULLET_SURPLUS_MULT
+	stamina = BULLET_STAMINA_PISTOL_HEAVY * BULLET_SURPLUS_MULT * BULLET_357_STAMINA_MULT
 	spread = BULLET_SPREAD_SURPLUS
 	recoil = BULLET_RECOIL_PISTOL_MEDIUM
 
@@ -778,7 +781,7 @@
 
 /* 357 handload
  * DAMAGE: 30
- * STAMIN: 30
+ * STAMIN: 24
  * RECOIL: 1
  * WOUNDS: 7.5
  * WNAKED: 7.5
@@ -786,7 +789,7 @@
 /obj/item/projectile/bullet/a357/improvised
 	name = "handloaded .357 bullet"
 	damage = BULLET_DAMAGE_PISTOL_HEAVY * BULLET_HANDLOAD_MULT
-	stamina = BULLET_STAMINA_PISTOL_HEAVY * BULLET_HANDLOAD_MULT
+	stamina = BULLET_STAMINA_PISTOL_HEAVY * BULLET_HANDLOAD_MULT * BULLET_357_STAMINA_MULT
 	spread = BULLET_SPREAD_HANDLOAD
 	recoil = BULLET_RECOIL_PISTOL_MEDIUM
 
@@ -798,7 +801,7 @@
 
 /* 357 bounce
  * DAMAGE: 40
- * STAMIN: 40
+ * STAMIN: 32
  * RECOIL: 1
  * WOUNDS: 10
  * WNAKED: 7.5
@@ -806,7 +809,7 @@
 /obj/item/projectile/bullet/a357/ricochet
 	name = ".357 ricochet bullet"
 	damage = BULLET_DAMAGE_PISTOL_HEAVY * BULLET_SURPLUS_MULT
-	stamina = BULLET_STAMINA_PISTOL_HEAVY * BULLET_SURPLUS_MULT
+	stamina = BULLET_STAMINA_PISTOL_HEAVY * BULLET_SURPLUS_MULT * BULLET_357_STAMINA_MULT
 	spread = BULLET_SPREAD_SURPLUS
 	recoil = BULLET_RECOIL_PISTOL_MEDIUM
 
@@ -896,14 +899,14 @@
  * * * * * * * */
 
 #define BULLET_44MAG_DAMAGE_MULT 1.1 //44
-#define BULLET_44MAG_STAMINA_MULT 1.3
+#define BULLET_44MAG_STAMINA_MULT 1.1
 #define BULLET_44MAG_WOUND_MULT 2
 #define BULLET_44MAG_NAKED_WOUND_MULT 2
 #define BULLET_44MAG_SPEED_MULT 2
 
 /* 44 fmj
  * DAMAGE: 44
- * STAMIN: 52
+ * STAMIN: 44
  * RECOIL: 1
  * WOUNDS: 20
  * WNAKED: 15
@@ -945,7 +948,7 @@
 
 /* 44 simple
  * DAMAGE: 44
- * STAMIN: 52
+ * STAMIN: 44
  * RECOIL: 1
  * WOUNDS: 20
  * WNAKED: 15
@@ -1017,7 +1020,7 @@
 
 /* 14mm fmj
  * DAMAGE: 52
- * STAMIN: 80
+ * STAMIN: 52
  * RECOIL: 3
  * WOUNDS: 20
  * WNAKED: 15

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -611,6 +611,7 @@
  * RECOIL: 2
  * WOUNDS: 40
  * WNAKED: 30
+ * Disabled from lathe - Too fucking strong.
  */
 /obj/item/projectile/bullet/a762/rubber
 	name = "7.62 rubber bullet"
@@ -814,6 +815,7 @@
  * RECOIL: 2
  * WOUNDS: 200
  * WNAKED: 150
+ * Disabled - Too fucking strong. Literally 1 hit KO.
  */
 /obj/item/projectile/bullet/a50MG/rubber
 	name = "rubber .50MG slug"
@@ -836,6 +838,7 @@
  * RECOIL: 2
  * WOUNDS: 200
  * WNAKED: 150
+ * Removed from loot-roation - How tf is a round rubber AND a penetrator??
  */
 /obj/item/projectile/bullet/a50MG/penetrator
 	name = "penetrator .50MG slug"
@@ -911,42 +914,21 @@
  * Microshrapnel
  * * * * * * * */
 
-#define BULLET_4570_DAMAGE_MULT 0.75
-#define BULLET_4570_STAMINA_MULT 0.5
+#define BULLET_4570_DAMAGE_MULT 0.80
+#define BULLET_4570_STAMINA_MULT 0.4
 #define BULLET_4570_WOUND_MULT 0.50
 #define BULLET_4570_NAKED_WOUND_MULT 0.50
 #define BULLET_4570_SPEED_MULT 0.50
 #define BULLET_4570_RECOIL_MULT 1
 
-/* .45-70 match
- * DAMAGE: 70
- * STAMIN: 70
+/* .45-70 surplus
+ * DAMAGE: 50
+ * STAMIN: 45
  * RECOIL: 1
  * WOUNDS: 25
  * WNAKED: 15
  */
 /obj/item/projectile/bullet/c4570
-	name = ".45-70 match bullet"
-	damage = BULLET_DAMAGE_RIFLE_HEAVY * BULLET_MATCH_MULT * BULLET_4570_DAMAGE_MULT
-	stamina = BULLET_STAMINA_RIFLE_HEAVY * BULLET_MATCH_MULT * BULLET_4570_STAMINA_MULT
-	spread = BULLET_SPREAD_MATCH
-	recoil = BULLET_RECOIL_RIFLE_HEAVY * BULLET_4570_RECOIL_MULT
-
-	wound_bonus = BULLET_WOUND_RIFLE_HEAVY * BULLET_MATCH_MULT * BULLET_4570_WOUND_MULT
-	bare_wound_bonus = BULLET_WOUND_RIFLE_HEAVY * BULLET_NAKED_WOUND_MULT * BULLET_4570_NAKED_WOUND_MULT
-	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_HEAVY
-	
-	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY * BULLET_4570_SPEED_MULT
-	damage_falloff = BULLET_FALLOFF_DEFAULT_RIFLE_HEAVY
-
-/* .45-70 surplus
- * DAMAGE: 56
- * STAMIN: 56
- * RECOIL: 1
- * WOUNDS: 25
- * WNAKED: 15
- */
-/obj/item/projectile/bullet/c4570/surplus
 	name = ".45-70 FMJ bullet"
 	damage = BULLET_DAMAGE_RIFLE_HEAVY * BULLET_SURPLUS_MULT * BULLET_4570_DAMAGE_MULT
 	stamina = BULLET_STAMINA_RIFLE_HEAVY * BULLET_SURPLUS_MULT * BULLET_4570_STAMINA_MULT
@@ -960,7 +942,7 @@
 	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY * BULLET_4570_SPEED_MULT
 
 /* .45-70 handloaded
- * DAMAGE: 42 // cant kill a ghoul
+ * DAMAGE: 45
  * STAMIN: 33
  * RECOIL: 1
  * WOUNDS: 15
@@ -1037,22 +1019,23 @@
 		reagents.reaction(M, TOUCH)
 		reagents.trans_to(M, reagents.total_volume)
 
-/* .45-70 rubber
- * DAMAGE: 7
- * STAMIN: 281
+/* .45-70 special
+ * DAMAGE: 35
+ * STAMIN: 33
  * RECOIL: 1
- * WOUNDS: 125
- * WNAKED: 75
+ * WOUNDS: 15
+ * WNAKED: 15
+ * Knockback Probability
  */
 /obj/item/projectile/bullet/c4570/knockback
 	name = ".45-70 ultradense bullet"
-	damage = BULLET_DAMAGE_RIFLE_HEAVY * BULLET_MATCH_MULT * BULLET_4570_DAMAGE_MULT * RUBBERY_DAMAGE_MULT
-	stamina = RUBBERY_STAMINA_RIFLE_HEAVY * BULLET_MATCH_MULT * BULLET_4570_STAMINA_MULT
+	damage = BULLET_DAMAGE_RIFLE_HEAVY * BULLET_MATCH_MULT * BULLET_4570_DAMAGE_MULT * BULLET_DAMAGE_EXPLOSIVE
+	stamina = BULLET_STAMINA_RIFLE_HEAVY * BULLET_HANDLOAD_MULT * BULLET_4570_STAMINA_MULT
 	spread = BULLET_SPREAD_MATCH
 	recoil = BULLET_RECOIL_RIFLE_HEAVY * BULLET_4570_RECOIL_MULT
 
-	wound_bonus = RUBBERY_WOUND_RIFLE_HEAVY * BULLET_MATCH_MULT * BULLET_4570_WOUND_MULT
-	bare_wound_bonus = RUBBERY_WOUND_RIFLE_HEAVY * BULLET_NAKED_WOUND_MULT * BULLET_4570_NAKED_WOUND_MULT
+	wound_bonus = BULLET_WOUND_RIFLE_HEAVY * BULLET_HANDLOAD_MULT * BULLET_4570_WOUND_MULT
+	bare_wound_bonus = BULLET_WOUND_RIFLE_HEAVY * BULLET_NAKED_WOUND_MULT * BULLET_4570_NAKED_WOUND_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_HEAVY
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY * BULLET_4570_SPEED_MULT
@@ -1081,17 +1064,17 @@
  * Extremely Overkill
  * * * * * * * */
 
-#define BULLET_GAUSS_DAMAGE_MULT 2
-#define BULLET_GAUSS_STAMINA_MULT 2
-#define BULLET_GAUSS_WOUND_MULT 5 // gonna feel that blender
+#define BULLET_GAUSS_DAMAGE_MULT 1.1
+#define BULLET_GAUSS_STAMINA_MULT 1
+#define BULLET_GAUSS_WOUND_MULT 2 // gonna feel that blender
 #define BULLET_GAUSS_NAKED_WOUND_MULT 10 // lol
 #define BULLET_GAUSS_SPEED_MULT 10 // lol
 
 /* 2mmEC match
- * DAMAGE: 150
- * STAMIN: 225
+ * DAMAGE: 103
+ * STAMIN: 112.5
  * RECOIL: 1
- * WOUNDS: 250
+ * WOUNDS: 100
  * WNAKED: 150
  */
 /obj/item/projectile/bullet/c2mm
@@ -1109,10 +1092,10 @@
 	damage_falloff = BULLET_FALLOFF_DEFAULT_RIFLE_HEAVY
 
 /* 2mmEC blender
- * DAMAGE: 150
- * STAMIN: 225
+ * DAMAGE: 103
+ * STAMIN: 112.5
  * RECOIL: 1
- * WOUNDS: 250
+ * WOUNDS: 100
  * WNAKED: 150
  */
 /obj/item/projectile/bullet/c2mm/blender //welcome to pain town

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -192,7 +192,7 @@
 	icon_state = "hypo_superstimpak"
 	volume = 62
 	amount_per_transfer_from_this = 62
-	list_reagents = list(/datum/reagent/medicine/super_stimpak = 30, /datum/reagent/medicine/stimpak = 20)
+	list_reagents = list(/datum/reagent/medicine/super_stimpak = 15)
 
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super/custom
 	desc = "The super version comes in a hypodermic, but with an additional vial to inject more drugs than the basic model and a leather belt to strap the needle to a limb. This particular one will deliver a tailored cocktail."

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -674,14 +674,14 @@
 	materials = list(/datum/material/iron = 12000,/datum/material/titanium = 2000, /datum/material/blackpowder = 2000)
 	build_path = /obj/item/ammo_box/m473/dumdum
 	category = list("initial", "Advanced Ammo")
-
+/*
 /datum/design/ammolathe/m473esd
 	name = "4.73mm ESD caseless ammo box"
 	id = "m473esd"
 	materials = list(/datum/material/iron = 12000, /datum/material/titanium = 2000, /datum/material/blackpowder = 2000)
 	build_path = /obj/item/ammo_box/m473/shock
 	category = list("initial", "Advanced Ammo")
-
+*/
 /datum/design/ammolathe/m473hv
 	name = "4.73mm high-velocity caseless ammo box"
 	id = "m473hv"

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -164,14 +164,14 @@
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
 	build_path = /obj/item/ammo_box/c10mm
 	category = list("initial", "Simple Ammo")
-
+/*
 /datum/design/ammolathe/c10mm/rubber
 	name = "10mm rubber ammo box"
 	id = "c10mmrubber_lathe"
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
 	build_path = /obj/item/ammo_box/c10mm/rubber
 	category = list("initial", "Simple Ammo")
-
+*/
 /datum/design/ammolathe/c9mm/rubber
 	name = "9mm rubber ammo box"
 	id = "c9mmrubber_lathe"
@@ -220,14 +220,14 @@
 	build_path = /obj/item/ammo_box/a556/sport
 	materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1000)
 	category = list("initial", "Simple Ammo")
-
+/*
 /datum/design/ammolathe/a50rubber
 	name = ".50 rubber ammo box"
 	id = "a50MGrubber"
 	materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 1500)
 	build_path = /obj/item/ammo_box/a50MGbox/rubber
 	category = list("initial", "Basic Ammo")
-
+*/
 /* --Tier 2 Ammo And Magazines-- */
 //Tier 2 Magazines
 /datum/design/ammolathe/tube44
@@ -369,7 +369,7 @@
 	build_path = /obj/item/ammo_box/c45
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
 	category = list("initial", "Basic Ammo")
-
+/*
 /datum/design/ammolathe/a45rubber
 	name = ".45 ACP rubber ammo box"
 	id = "a45rubber"
@@ -383,21 +383,21 @@
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
 	build_path = /obj/item/ammo_box/c10mm/rubber
 	category = list("initial", "Basic Ammo")
-
+*/
 /datum/design/ammolathe/a22rubber
 	name = ".22 rubber ammo box"
 	id = "m22rubber"
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
 	build_path = /obj/item/ammo_box/m22/rubber
 	category = list("initial", "Basic Ammo")
-
+/*
 /datum/design/ammolathe/a762rubber
 	name = "7.62 rubber ammo box"
 	id = "a762_lathe_rubber"
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
 	build_path = /obj/item/ammo_box/a762box/rubber
 	category = list("initial", "Basic Ammo")
-
+*/
 /* --Tier 3 Ammo and Magazines -- */
 //Tier 3 Magazines
 
@@ -735,28 +735,28 @@
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
 	build_path = /obj/item/ammo_box/c10mm/improvised
 	category = list("initial", "Handloaded Ammo")
-
+/*
 /datum/design/ammolathe/improvised/c10mm/rubber
 	name = "10mm rubber ammo box"
 	id = "handloader_c10mmrubber_lathe"
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
 	build_path = /obj/item/ammo_box/c10mm/rubber
 	category = list("initial", "Handloaded Ammo")
-
+*/
 /datum/design/ammolathe/improvised/a45fmj
 	name = ".45 bag"
 	id = "handloader_a45fmj"
 	build_path = /obj/item/ammo_box/c45/improvised
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
 	category = list("initial", "Handloaded Ammo")
-
+/*
 /datum/design/ammolathe/improvised/a45rubber
 	name = ".45 ACP rubber ammo box"
 	id = "handloader_a45rubber"
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
 	build_path = /obj/item/ammo_box/c45/rubber
 	category = list("initial", "Handloaded Ammo")
-
+*/
 /datum/design/ammolathe/improvised/c38
 	name = ".38 bag"
 	id = "handloader_c38"


### PR DESCRIPTION
## About The Pull Request
Basically reduces stamina damage for bullets across the board, balances some 'gamer-gun' calibers to no longer be as punishing. Also removes a LOT of rubber round variants (with the exception of .22, 9mm and 5.56) from being able to be made due to them almost all being 1-shot crit ammo

## Changelog
:cl:
balances: Bullet types heavily.
balances: Small changes to sledge hammers to reduce damage to avoid two-hit gaurnetees.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
