### PR TITLE
Define Melee sorting

### DIFF
--- a/_maps/RandomZLevels/VR/yuma_VR.dmm
+++ b/_maps/RandomZLevels/VR/yuma_VR.dmm
@@ -605,7 +605,7 @@
 /obj/item/clothing/head/helmet/knight/f13/metal,
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
 /obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/f13/blacksmith,
+/obj/item/clothing/gloves/blacksmith_mittens,
 /obj/item/clothing/gloves/f13/leather,
 /obj/item/clothing/gloves/f13/military,
 /obj/item/clothing/gloves/f13/leather/fingerless,

--- a/_maps/map_files/CB-WIP/Bowie_County.dmm
+++ b/_maps/map_files/CB-WIP/Bowie_County.dmm
@@ -14701,7 +14701,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/anvil/obtainable/basic,
+/obj/structure/blacksmith/anvil/obtainable/basic,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "ZL" = (

--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Lower.dmm
@@ -30785,7 +30785,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "snH" = (
-/obj/structure/anvil/obtainable/sandstone,
+/obj/structure/blacksmith/anvil/obtainable/sandstone,
 /obj/item/twohanded/sledgehammer/simple,
 /obj/item/book/manual/advice_blacksmith,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -34984,7 +34984,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "vdZ" = (
-/obj/structure/furnace,
+/obj/structure/blacksmith/furnace,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vep" = (

--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
@@ -2329,7 +2329,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "aVn" = (
-/obj/structure/furnace,
+/obj/structure/blacksmith/furnace,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aVq" = (
@@ -13038,7 +13038,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fxC" = (
-/obj/structure/furnace,
+/obj/structure/blacksmith/furnace,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fxD" = (
@@ -16174,7 +16174,7 @@
 /turf/closed/wall/f13/store,
 /area/f13/village)
 "gIs" = (
-/obj/structure/anvil/obtainable/table,
+/obj/structure/blacksmith/anvil/obtainable/table,
 /obj/item/twohanded/sledgehammer/simple,
 /obj/item/book/manual/advice_blacksmith,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20530,7 +20530,7 @@
 	},
 /area/f13/wasteland)
 "iyy" = (
-/obj/structure/anvil/obtainable/sandstone,
+/obj/structure/blacksmith/anvil/obtainable/sandstone,
 /obj/item/twohanded/sledgehammer/simple,
 /obj/item/book/manual/advice_blacksmith,
 /turf/open/indestructible/ground/outside/dirt,
@@ -23514,7 +23514,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/furnace,
+/obj/structure/blacksmith/furnace,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "jKT" = (
@@ -49354,7 +49354,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "vbF" = (
-/obj/structure/anvil/obtainable/table,
+/obj/structure/blacksmith/anvil/obtainable/table,
 /obj/item/twohanded/sledgehammer/simple,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)

--- a/_maps/map_files/Pahrump-Sunset/MapGuide.dmm
+++ b/_maps/map_files/Pahrump-Sunset/MapGuide.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/structure/furnace,
+/obj/structure/blacksmith/furnace,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -3902,7 +3902,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "OO" = (
-/obj/structure/anvil/obtainable/table,
+/obj/structure/blacksmith/anvil/obtainable/table,
 /obj/item/twohanded/sledgehammer/simple,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -34938,8 +34938,8 @@
 /obj/item/clothing/neck/apron/labor/forge,
 /obj/item/clothing/neck/apron/labor/forge,
 /obj/structure/closet/anchored,
-/obj/item/clothing/gloves/legion/forgemaster,
-/obj/item/clothing/gloves/legion/forgemaster,
+/obj/item/clothing/gloves/blacksmith_mittens,
+/obj/item/clothing/gloves/blacksmith_mittens,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/legion)
 "iQx" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -26048,7 +26048,7 @@
 	},
 /area/f13/wasteland)
 "eJy" = (
-/obj/structure/anvil/obtainable/legion,
+/obj/structure/blacksmith/anvil/obtainable/legion,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/legion)
 "eJO" = (
@@ -53401,7 +53401,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
 "rIv" = (
-/obj/structure/anvil/obtainable/table,
+/obj/structure/blacksmith/anvil/obtainable/table,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/village)
 "rIF" = (

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -969,8 +969,8 @@
 /obj/structure/closet/crate/footchest{
 	pixel_x = -8
 	},
-/obj/item/ingot/gold,
-/obj/item/ingot/gold,
+/obj/item/blacksmith/ingot/gold,
+/obj/item/blacksmith/ingot/gold,
 /obj/item/coin/gold,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
@@ -9116,9 +9116,9 @@
 	},
 /area/f13/wasteland)
 "gIH" = (
-/obj/item/ingot/silver,
-/obj/item/ingot/gold,
-/obj/item/ingot/titanium,
+/obj/item/blacksmith/ingot/silver,
+/obj/item/blacksmith/ingot/gold,
+/obj/item/blacksmith/ingot/titanium,
 /turf/open/floor/plasteel/dark,
 /area/f13/city)
 "gIL" = (
@@ -13128,7 +13128,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/raiders)
 "jFt" = (
-/obj/item/ingot/titanium,
+/obj/item/blacksmith/ingot/titanium,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/city)
@@ -30826,7 +30826,7 @@
 /area/f13/wasteland)
 "wXv" = (
 /obj/structure/closet/crate/wicker,
-/obj/item/ingot/silver{
+/obj/item/blacksmith/ingot/silver{
 	pixel_x = 5;
 	pixel_y = 2
 	},

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -10514,7 +10514,7 @@
 	},
 /area/f13/wasteland)
 "gxZ" = (
-/obj/structure/furnace,
+/obj/structure/blacksmith/furnace,
 /turf/open/floor/plasteel/cult,
 /area/f13/building)
 "gyy" = (
@@ -13602,7 +13602,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/anvil/obtainable/basic,
+/obj/structure/blacksmith/anvil/obtainable/basic,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "inZ" = (
@@ -18804,7 +18804,7 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "lrV" = (
-/obj/structure/anvil/obtainable/table,
+/obj/structure/blacksmith/anvil/obtainable/table,
 /obj/item/twohanded/sledgehammer/simple,
 /turf/open/floor/plasteel/cult,
 /area/f13/building)

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -33581,7 +33581,7 @@
 /area/f13/wasteland)
 "uQp" = (
 /obj/structure/closet/crate/large,
-/obj/item/clothing/gloves/f13/blacksmith,
+/obj/item/clothing/gloves/blacksmith_mittens,
 /obj/item/clothing/suit/armor/outfit/overalls/blacksmith,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/cult,

--- a/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
+++ b/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
@@ -2407,7 +2407,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "aVn" = (
-/obj/structure/furnace,
+/obj/structure/blacksmith/furnace,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aVq" = (
@@ -16370,7 +16370,7 @@
 /turf/closed/wall/f13/store,
 /area/f13/village)
 "gIs" = (
-/obj/structure/anvil/obtainable/table,
+/obj/structure/blacksmith/anvil/obtainable/table,
 /obj/item/twohanded/sledgehammer/simple,
 /obj/item/book/manual/advice_blacksmith,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20843,7 +20843,7 @@
 	},
 /area/f13/wasteland)
 "iyy" = (
-/obj/structure/anvil/obtainable/sandstone,
+/obj/structure/blacksmith/anvil/obtainable/sandstone,
 /obj/item/twohanded/sledgehammer/simple,
 /obj/item/book/manual/advice_blacksmith,
 /turf/open/indestructible/ground/outside/dirt,
@@ -23889,7 +23889,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/furnace,
+/obj/structure/blacksmith/furnace,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "jKT" = (

--- a/_maps/map_files/Temp Map Storage/Pahrump-Sunset-Lower - Outdated.dmm
+++ b/_maps/map_files/Temp Map Storage/Pahrump-Sunset-Lower - Outdated.dmm
@@ -30850,7 +30850,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "snH" = (
-/obj/structure/anvil/obtainable/sandstone,
+/obj/structure/blacksmith/anvil/obtainable/sandstone,
 /obj/item/twohanded/sledgehammer/simple,
 /obj/item/book/manual/advice_blacksmith,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -35059,7 +35059,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "vdZ" = (
-/obj/structure/furnace,
+/obj/structure/blacksmith/furnace,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vep" = (

--- a/code/__DEFINES/melee.dm
+++ b/code/__DEFINES/melee.dm
@@ -59,3 +59,43 @@
 #define WEAPON_BLUNT_TWOHAND_MULT 1
 /// Blunt wound addition
 #define WEAPON_BLUNT_WOUND_ADD 100 // limb wrecker
+
+
+// MORE MELEE DEFINES
+
+/// Weapon baseplate values
+#define WEAPON_FORCE_KNIFE 25
+#define WEAPON_FORCE_BIG_KNIFE 27
+#define WEAPON_FORCE_SWORD 35
+#define WEAPON_FORCE_SPEAR 24
+#define WEAPON_FORCE_SPEAR_WIELDED 32
+#define WEAPON_FORCE_CLUB 28
+#define WEAPON_FORCE_CLUB_WIELDED 39
+
+/// Thrown forces
+#define THROWING_PATHETIC 4
+#define THROWING_POOR 10
+#define THROWING_DECENT 20
+#define THROWING_EFFECTIVE 25
+#define THROWING_GOOD 30
+
+/// Melee attack speed
+#define MELEE_SPEED_FASTEST 6
+#define MELEE_SPEED_FAST 7
+#define MELEE_SPEED_NORMAL 8
+#define MELEE_SPEED_SLOW 9
+#define MELEE_SPEED_SLOWER 10
+#define MELEE_SPEED_SLOWEST 14
+
+/// Melee armor piercing
+#define PIERCING_MINOR 0.1
+#define PIERCING_MODERATE 0.2
+#define PIERCING_MAJOR 0.3
+
+/// Melee wound bonuses
+#define WOUNDING_MALUS_SHALLOW -10
+#define WOUNDING_BONUS_TINY 10
+#define WOUNDING_BONUS_MODEST 15
+#define WOUNDING_BONUS_BIG 30
+#define WOUNDING_BONUS_HUGE 60
+

--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -34,6 +34,7 @@
 #define TOOL_AWORKBENCH     "advanced workbench"
 #define TOOL_LOOM			"Loom"
 #define TOOL_CHEMMASTER		"ChemMaster / refinery"
+#define TOOL_METAL_BENCH	"metalworking bench"
 //
 #define TOOL_GUNTIER1		"Guns and Bullets: Part 1"
 #define TOOL_GUNTIER2		"Guns and Bullets: Part 2"

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -143,7 +143,7 @@
 	icon = 'icons/fallout/machines/64x32.dmi'
 	icon_state = "bench_metal"
 	bound_width = 64
-	machine_tool_behaviour = list(TOOL_FORGE)
+	machine_tool_behaviour = list(TOOL_METAL_BENCH)
 
 /obj/item/weaponcrafting/receiver
 	name = "modular receiver"

--- a/code/datums/components/crafting/recipes/recipes_forge.dm
+++ b/code/datums/components/crafting/recipes/recipes_forge.dm
@@ -92,7 +92,7 @@
 		/obj/item/stack/sheet/metal = 15,
 		/obj/item/stack/sheet/mineral/wood = 5,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_CRAFTING
 	subcategory = CAT_FORGING
 
@@ -107,7 +107,7 @@
 		/obj/item/stack/sheet/metal = 3,
 		/obj/item/stack/sheet/mineral/wood = 1,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -120,7 +120,7 @@
 		/obj/item/blacksmith/swordhandle = 1,
 		/obj/item/stack/sheet/cloth = 1,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -132,7 +132,7 @@
 		/obj/item/stack/sheet/prewar = 3,
 		/obj/item/stack/sheet/leather = 1,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -156,7 +156,7 @@
 		/obj/item/stack/sheet/metal = 2,
 		/obj/item/stack/sheet/mineral/wood = 1,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -168,7 +168,7 @@
 		/obj/item/stack/sheet/metal = 5,
 		/obj/item/blacksmith/swordhandle = 1,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -180,7 +180,7 @@
 		/obj/item/stack/sheet/metal = 2,
 		/obj/item/stack/crafting/metalparts = 1,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -193,7 +193,7 @@
 		/obj/item/blacksmith/swordhandle = 1,
 		)
 	time = 280
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -206,7 +206,7 @@
 		/obj/item/stack/sheet/cloth = 2,
 		)
 	time = 400
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -219,7 +219,7 @@
 		/obj/item/stack/sheet/plasteel = 2,
 	    )
 	time = 380
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -234,7 +234,7 @@
 		/obj/item/stack/sheet/leather = 2,
 		)
 	time = 250
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 	always_available = FALSE
@@ -250,7 +250,7 @@
 		/obj/item/stack/sheet/metal = 16,
 		/obj/item/stack/sheet/mineral/wood = 4,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -262,7 +262,7 @@
 		/obj/item/stack/sheet/metal = 2,
 		/obj/item/stack/sheet/mineral/wood = 3,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -273,7 +273,7 @@
 	result = /obj/item/melee/unarmed/brass/spiked
 	time = 140
 	reqs = list(/obj/item/stack/sheet/metal = 3)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -285,7 +285,7 @@
 		/obj/item/stack/sheet/cloth = 3,
 		/obj/item/stack/sheet/lead = 2,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -294,7 +294,7 @@
 	result = /obj/item/melee/unarmed/maceglove
 	time = 240
 	reqs = list(/obj/item/stack/sheet/metal = 20)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -338,7 +338,7 @@
 		/obj/item/stack/sheet/metal = 5,
 		/obj/item/stack/sheet/mineral/wood = 1,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -350,7 +350,7 @@
 		/obj/item/stack/sheet/metal = 5,
 		/obj/item/stack/sheet/mineral/wood = 1,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -362,7 +362,7 @@
 		/obj/item/stack/sheet/metal = 2,
 		/obj/item/stack/sheet/mineral/wood = 3,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -374,7 +374,7 @@
 		/obj/item/stack/sheet/metal = 5,
 		/obj/item/stack/sheet/mineral/wood = 2,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -387,7 +387,7 @@
 		/obj/item/stack/sheet/cloth = 1,
 		/obj/item/stack/sheet/mineral/wood = 1,
 		)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 	always_available = FALSE

--- a/code/datums/components/crafting/recipes/recipes_forge.dm
+++ b/code/datums/components/crafting/recipes/recipes_forge.dm
@@ -50,7 +50,7 @@
 	category = CAT_CRAFTING
 	subcategory = CAT_FORGING
 
-/datum/crafting_recipe/blacksmit/furnace
+/datum/crafting_recipe/blacksmith/furnace
 	name = "Furnace"
 	result = /obj/structure/blacksmith/furnace
 	time = 300

--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -429,7 +429,7 @@
 	reqs = list(/obj/item/stack/sheet/metal = 10,
 				/obj/item/stack/sheet/cloth = 5)
 	category = CAT_TRIBAL
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	always_available = FALSE
 
 /datum/crafting_recipe/tribalwar/heavytribe
@@ -439,7 +439,7 @@
 	reqs = list(/obj/item/stack/sheet/metal = 20,
 				/obj/item/stack/sheet/cloth = 5)
 	category = CAT_TRIBAL
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	always_available = FALSE
 
 /datum/crafting_recipe/tribalwar/goliathcloak

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -248,7 +248,7 @@ datum/crafting_recipe/steelbib/heavy
 	time = 600
 	reqs = list(/obj/item/stack/sheet/metal = 1,
 				/obj/item/stack/sheet/cloth = 6)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
@@ -258,7 +258,7 @@ datum/crafting_recipe/steelbib/heavy
 	time = 600
 	reqs = list(/obj/item/stack/sheet/metal = 10,
 				/obj/item/stack/sheet/cloth = 2)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
@@ -291,7 +291,7 @@ datum/crafting_recipe/steelbib/heavy
 	time = 600
 	reqs = list(/obj/item/stack/sheet/metal = 10,
 				/obj/item/stack/sheet/cloth = 2)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
@@ -310,7 +310,7 @@ datum/crafting_recipe/steelbib/heavy
 	time = 600
 	reqs = list(/obj/item/stack/sheet/metal = 4,
 				/obj/item/stack/sheet/cloth = 1)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
@@ -320,7 +320,7 @@ datum/crafting_recipe/steelbib/heavy
 	time = 600
 	reqs = list(/obj/item/stack/sheet/metal = 5,
 				/obj/item/stack/sheet/cloth = 2)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
@@ -330,7 +330,7 @@ datum/crafting_recipe/steelbib/heavy
 	time = 600
 	reqs = list(/obj/item/stack/sheet/metal = 30,
 				/obj/item/stack/sheet/cloth = 5)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
@@ -362,7 +362,7 @@ datum/crafting_recipe/steelbib/heavy
 	time = 100
 	reqs = list(/obj/item/stack/sheet/metal = 5,
 				/obj/item/stack/sheet/cloth = 5)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
@@ -374,7 +374,7 @@ datum/crafting_recipe/steelbib/heavy
 	time = 100
 	reqs = list(/obj/item/stack/sheet/metal = 5,
 				/obj/item/stack/sheet/cloth = 5)
-	tools = list(TOOL_FORGE)
+	tools = list(TOOL_METAL_BENCH)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -320,7 +320,7 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "knife_cosmic_heated"
 	item_state = "knife"
 	damtype = BURN
-	force = WEAPON_FORCE_BIG_KNIFE
+	force = (WEAPON_FORCE_BIG_KNIFE+2)
 	armour_penetration = PIERCING_MAJOR
 	throwforce = THROWING_EFFECTIVE
 	w_class = WEIGHT_CLASS_NORMAL // Its super hot, not comfy to put back in your pocket.
@@ -763,7 +763,7 @@ obj/item/melee/onehanded/knife/switchblade
 	item_state = "lacerator"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 29
-	bare_wound_bonus = 5
+	bare_wound_bonus = WOUNDING_BONUS_TINY
 	armour_penetration = 0 //my brother in christ it is razor blades on tape
 	sharpness = SHARP_EDGED
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
@@ -786,7 +786,7 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "punch_dagger"
 	item_state = "punch_dagger"
 	force = 29
-	armour_penetration = 0.12
+	armour_penetration = PIERCING_MINOR
 	sharpness = SHARP_POINTY
 	attack_verb = list("stabbed", "sliced", "pierced", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -1,7 +1,7 @@
 // In this document: Onehanded templates, Swords, Knives, Clubs, Glove weapons, Tool weapons
 
 /obj/item/melee //Melee weapon template
-	attack_speed = CLICK_CD_MELEE
+	attack_speed = MELEE_SPEED_NORMAL
 	max_integrity = 200
 	armor = ARMOR_VALUE_GENERIC_ITEM
 
@@ -54,7 +54,7 @@
 	desc = "A makeshift machete made of a lawn mower blade."
 	icon_state = "machete_imp"
 	item_state = "salvagedmachete"
-	force = 34
+	force = WEAPON_FORCE_SWORD
 	block_chance = 7
 	throwforce = 20
 	wound_bonus = 10
@@ -64,7 +64,6 @@
 	name = "machete"
 	desc = "A forged machete made of high quality steel."
 	icon_state = "machete"
-	force = 35
 	wound_bonus = 20
 	block_chance = 8
 
@@ -88,7 +87,6 @@
 	desc = "A heavy cutting blade, made for war and mass produced in Legion territory."
 	icon_state = "gladius"
 	item_state = "gladius"
-	force = 36
 	wound_bonus = 30
 	block_chance = 10
 
@@ -114,7 +112,7 @@
 	desc = "Made from materials found in the wastes, a skilled blacksmith has turned it into a thing of deadly beauty."
 	icon_state = "scrapsabre"
 	item_state = "scrapsabre"
-	force = 37
+	force = WEAPON_FORCE_SWORD
 	block_chance = 15
 
 /obj/item/throwing_star/spear
@@ -141,21 +139,19 @@
 	name = "knife template"
 	desc = "should not exist"
 	item_state = "knife"
-	flags_1 = CONDUCT_1
-	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 15
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	armour_penetration = 0.05
+	force = WEAPON_FORCE_KNIFE
+	throwforce = THROWING_DECENT
+	armour_penetration = PIERCING_MINOR
+	attack_speed = MELEE_SPEED_FAST
+	bare_wound_bonus = 5
 	throw_speed = 3
 	throw_range = 6
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = SHARP_POINTY
-	armor = ARMOR_VALUE_GENERIC_ITEM
-	var/bayonet = FALSE	//Can this be attached to a gun?
-	bare_wound_bonus = 5
 	custom_materials = list(/datum/material/iron=6000)
-	resistance_flags = FIRE_PROOF
-	attack_speed = CLICK_CD_MELEE * 0.85 //6.8
+	w_class = WEIGHT_CLASS_SMALL
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	var/bayonet = FALSE	//Can this be attached to a gun?
 
 /obj/item/melee/onehanded/knife/Initialize()
 	. = ..()
@@ -179,8 +175,7 @@
 	icon_state = "knife_hunting"
 	desc = "Dependable hunting knife."
 	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
-	force = 23
-	throwforce = 25
+	throwforce = THROWING_EFFECTIVE
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cut")
 
 /obj/item/melee/onehanded/knife/survival
@@ -188,14 +183,12 @@
 	icon_state = "knife_survival"
 	desc = "Multi-purpose knife with blackened steel."
 	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
-	force = 23
-	throwforce = 25
+	throwforce = THROWING_EFFECTIVE
 
 /obj/item/melee/onehanded/knife/bayonet
 	name = "bayonet knife"
 	icon_state = "knife_bayonet"
 	desc = "This weapon is made for stabbing, not much use for other things."
-	force = 23
 	bayonet = TRUE
 
 /obj/item/melee/onehanded/knife/bowie
@@ -203,8 +196,8 @@
 	icon_state = "knife_bowie"
 	item_state = "knife_bowie"
 	desc = "A large clip point fighting knife."
-	force = 28
-	throwforce = 25
+	force = WEAPON_FORCE_BIG_KNIFE
+	throwforce = THROWING_EFFECTIVE
 	attack_verb = list("slashed", "stabbed", "sliced", "shanked", "ripped", "lacerated")
 
 /obj/item/melee/onehanded/knife/trench
@@ -212,7 +205,8 @@
 	icon_state = "knife_trench"
 	item_state = "knife_trench"
 	desc = "This blade is designed for brutal close quarters combat."
-	force = 30
+	force = (WEAPON_FORCE_BIG_KNIFE+1)
+	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=8000)
 	attack_verb = list("slashed", "stabbed", "sliced", "shanked", "ripped", "lacerated")
 
@@ -224,8 +218,6 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	desc = "A sharpened bone. The bare minimum in survival."
 	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
-	force = 23
-	throwforce = 20
 	custom_materials = null
 
 /obj/item/melee/onehanded/knife/ritualdagger
@@ -233,7 +225,6 @@
 	desc = "An ancient blade used to carry out the spiritual rituals of the Wayfarer people."
 	icon_state = "knife_ritual"
 	item_state = "knife_ritual"
-	force = 25
 	armour_penetration = 0.1
 	custom_materials = null
 
@@ -242,12 +233,12 @@ obj/item/melee/onehanded/knife/switchblade
 	desc = "A sharp, concealable, spring-loaded knife."
 	icon_state = "knife_switch"
 	force = 3
-	throwforce = 5
+	throwforce = THROWING_PATHETIC
 	hitsound = 'sound/weapons/genhit.ogg'
 	attack_verb = list("stubbed", "poked")
 	var/extended = 0
-	var/extended_force = 21
-	var/extended_throwforce = 23
+	var/extended_force = WEAPON_FORCE_KNIFE
+	var/extended_throwforce = THROWING_DECENT
 	var/extended_icon_state = "knife_switch_ext"
 	var/retracted_icon_state = "knife_switch"
 
@@ -284,9 +275,9 @@ obj/item/melee/onehanded/knife/switchblade
 	desc = "A high-quality kitchen knife made from Saturnite alloy, this one is covered in oxidation. Perhaps Abraxo might clean it up?"
 	icon_state = "knife_cosmic_dirty"
 	item_state = "knife"
-	force = 15
-	throwforce = 10
-	armour_penetration = 0.2
+	force = WEAPON_FORCE_KNIFE
+	throwforce = THROWING_POOR
+	armour_penetration = PIERCING_MINOR
 
 // Abraxo my beloved. Can now be used directly to clean the blade.
 /obj/item/melee/onehanded/knife/cosmicdirty/attackby(obj/item/C, mob/user, params)
@@ -308,9 +299,9 @@ obj/item/melee/onehanded/knife/switchblade
 	desc = "A high-quality kitchen knife made from Saturnite alloy, can be heated with a welder for easier cutting of frozen butter."
 	icon_state = "knife_cosmic"
 	item_state = "knife"
-	force = 25
-	throwforce = 15
-	armour_penetration = 0.2
+	force = WEAPON_FORCE_BIG_KNIFE
+	throwforce = THROWING_DECENT
+	armour_penetration = PIERCING_MODERATE
 
 // Heat it with a welder
 /obj/item/melee/onehanded/knife/cosmic/welder_act(mob/living/user, obj/item/I)
@@ -329,21 +320,21 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "knife_cosmic_heated"
 	item_state = "knife"
 	damtype = BURN
-	force = 35
-	throwforce = 20
-	armour_penetration = 0.4
+	force = WEAPON_FORCE_BIG_KNIFE
+	armour_penetration = PIERCING_MAJOR
+	throwforce = THROWING_EFFECTIVE
 	w_class = WEIGHT_CLASS_NORMAL // Its super hot, not comfy to put back in your pocket.
 
 /obj/item/melee/onehanded/knife/throwing
 	name = "throwing knife"
 	desc = "a finely balanced knife made from a lightweight alloy, designed for being thrown. You can easily embed these in someone, and you look darn cool while doing so."
 	icon_state = "knife_throw"
-	force = 20
-	throwforce = 30
-	armour_penetration = 0.25
-	bare_wound_bonus = 15 //keep your arteries covered
+	force = WEAPON_FORCE_KNIFE
+	armour_penetration = PIERCING_MODERATE
+	throwforce = THROWING_GOOD
 	throw_speed = 5
 	throw_range = 7
+	bare_wound_bonus = 15 //keep your arteries covered
 	embedding = list("pain_mult" = 4, "embed_chance" = 70, "fall_chance" = 5)
 
 ///////////
@@ -357,8 +348,8 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "pipe"
 	item_state = "pipe"
 	attack_verb = list("mashed", "bashed", "piped", "hit", "bludgeoned", "whacked", "bonked")
-	force = 26
-	throwforce = 10
+	force = WEAPON_FORCE_CLUB
+	throwforce = THROWING_POOR
 	throw_speed = 3
 	throw_range = 3
 	sharpness = SHARP_NONE
@@ -377,8 +368,8 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "warclub"
 	item_state = "warclub"
 	attack_verb = list("mashed", "bashed", "hit", "bludgeoned", "whacked")
-	force = 30
-	throwforce = 25
+	force = (WEAPON_FORCE_CLUB+1)
+	throwforce = THROWING_EFFECTIVE
 	block_chance = 5
 
 /obj/item/melee/onehanded/club/warclub/attack(mob/living/M, mob/living/user)
@@ -393,7 +384,7 @@ obj/item/melee/onehanded/knife/switchblade
 	desc = "A rusty old tire iron, normally used for loosening nuts from car tires.<br>Though it has a short reach, it has decent damage and a fast swing."
 	icon_state = "tire"
 	item_state = "tire"
-	force = 30
+	force = WEAPON_FORCE_CLUB
 	custom_materials = list(/datum/material/iron = 4000)
 
 // NCR Flag			Keywords: NCR, Damage 26, Stamina damage, Block
@@ -404,7 +395,7 @@ obj/item/melee/onehanded/knife/switchblade
 	item_state = "flag-ncr"
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = null
-	force = 26
+	force = WEAPON_FORCE_CLUB
 	block_chance = 30
 	attack_verb = list("smacked", "thwacked", "democratized", "freedomed")
 
@@ -657,13 +648,13 @@ obj/item/melee/onehanded/knife/switchblade
 	icon = 'icons/fallout/objects/melee/melee.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/melee1h_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
-	attack_speed = CLICK_CD_MELEE * 0.9
+	attack_speed = MELEE_SPEED_FAST
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
 	w_class = WEIGHT_CLASS_SMALL
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_NONE
 	armour_penetration = 0.05
-	throwforce = 10
+	throwforce = THROWING_PATHETIC
 	throw_range = 5
 	attack_verb = list("punched", "jabbed", "whacked")
 	var/can_adjust_unarmed = TRUE
@@ -910,25 +901,3 @@ CODE FOR BLEEDING STACK
 	else
 		B.add_stacks(bleed_stacks_per_hit)
 */
-
-
-// BETA // Obsolete
-
-/obj/item/melee/onehanded/machete/knifetesting
-	name = "testing knife"
-	icon_state = "knife_bowie"
-	item_state = "knife_bowie"
-	force = 18
-	throwforce = 15
-
-/obj/item/melee/onehanded/machete/clubtesting
-	name = "1hgeneric"
-	icon_state = "tire"
-	item_state = "tire"
-	force = 20
-
-/obj/item/melee/onehanded/machete/swordtesting
-	name = "topmelee"
-	icon_state = "machete_imp"
-	item_state = "salvagedmachete"
-	force = 30

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -10,16 +10,17 @@
 	item_state = "powerfist"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	flags_1 = CONDUCT_1
-	attack_verb = list("whacked", "fisted", "power-punched")
+	attack_speed = MELEE_SPEED_NORMAL
 	force = 22
 	throwforce = 10
 	throw_range = 3
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
+	flags_1 = CONDUCT_1
+	attack_verb = list("whacked", "fisted", "power-punched")
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
 	var/throw_distance = 1
-	attack_speed = CLICK_CD_MELEE
+
 
 /obj/item/melee/powerfist/f13/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wrench))
@@ -94,9 +95,8 @@
 	item_state = "mole_miner_g"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	flags_1 = CONDUCT_1
 	force = 15
-	throwforce = 10
+	throwforce = THROWING_POOR
 	throw_range = 7
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -104,9 +104,7 @@
 	var/digrange = 0
 	toolspeed = 0.4
 	sharpness = SHARP_EDGED
-	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
-	armor = ARMOR_VALUE_GENERIC_ITEM
 
 
 /////////////////////
@@ -121,15 +119,15 @@
 	icon_state = "ripper"
 	lefthand_file = 'icons/fallout/onmob/weapons/melee1h_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
-	w_class = WEIGHT_CLASS_NORMAL
-	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
-	slot_flags = ITEM_SLOT_SUITSTORE | ITEM_SLOT_BELT
 	force = 10
-	wound_bonus = 25
+	wound_bonus = WOUNDING_BONUS_BIG
 	block_chance = 15
 	throw_speed = 3
 	throw_range = 4
-	throwforce = 10
+	throwforce = THROWING_POOR
+	w_class = WEIGHT_CLASS_NORMAL
+	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
+	slot_flags = ITEM_SLOT_SUITSTORE | ITEM_SLOT_BELT
 	tool_behaviour = TOOL_SAW
 	sharpness = SHARP_EDGED
 	toolspeed = 1.5

--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -5,7 +5,7 @@
 	lefthand_file = 'icons/fallout/onmob/weapons/melee2h_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/melee2h_righthand.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/backslot_weapon.dmi'
-	attack_speed = CLICK_CD_MELEE * 1.15 //9.2
+	attack_speed = MELEE_SPEED_SLOW
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	max_integrity = 200
@@ -40,9 +40,8 @@
 	icon_state = "legionaxe"
 	icon_prefix = "legionaxe"
 	force = 30
-	throwforce = 15
-	wound_bonus = 10
-	bare_wound_bonus = 10
+	throwforce = THROWING_POOR
+	wound_bonus = WOUNDING_BONUS_TINY
 	sharpness = SHARP_EDGED
 	resistance_flags = FIRE_PROOF
 	attack_verb = list("axed", "chopped", "cleaved", "torn", "hacked")
@@ -50,6 +49,7 @@
 	wielded_icon = "legionaxe2"
 	force_unwielded = 30
 	force_wielded = 60
+	attack_speed = MELEE_SPEED_SLOWER
 
 /obj/item/twohanded/legionaxe/ComponentInitialize()
 	. = ..()
@@ -82,18 +82,17 @@
 	desc = "Heavy fireman axe from the old world, with its distinctive red colour and excellent quality steel. Excellent for smashing doors."
 	icon_state = "fireaxe"
 	icon_prefix = "fireaxe"
+	wielded_icon = "fireaxe2"
+	attack_speed = MELEE_SPEED_SLOWER
 	force = 28
-	throwforce = 15
-	wound_bonus = 10
-	bare_wound_bonus = 10
+	force_unwielded = 28
+	force_wielded = 55
+	wound_bonus = WOUNDING_BONUS_TINY
+	throwforce = THROWING_POOR
 	sharpness = SHARP_EDGED
 	resistance_flags = FIRE_PROOF
 	attack_verb = list("axed", "chopped", "cleaved", "torn", "hacked")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	wielded_icon = "fireaxe2"
-	force_unwielded = 28
-	force_wielded = 55
-	attack_speed = CLICK_CD_MELEE * 1.25 //10
 
 /obj/item/twohanded/fireaxe/ComponentInitialize()
 	. = ..()
@@ -127,11 +126,12 @@
 	desc = "A large, vicious axe crafted out of several sharpened bone plates and crudely tied together. Made of monsters, by killing monsters, for killing monsters. Swings faster than other axes due to its light weight."
 	icon_state = "boneaxe"
 	icon_prefix = "boneaxe"
-	resistance_flags = null
 	wielded_icon = "boneaxe2"
+	attack_speed = MELEE_SPEED_SLOW
 	force_unwielded = 25
 	force_wielded = 40
-	attack_speed = CLICK_CD_MELEE * 1.1 //8.8
+	bare_wound_bonus = WOUNDING_BONUS_BIG
+	resistance_flags = null
 
 /obj/item/twohanded/fireaxe/boneaxe/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -156,10 +156,10 @@
 	desc = "It was too big to be called a sword. Massive, thick, heavy, and far too rough. Indeed, it was more like a heap of raw iron."
 	icon_prefix = "bumper"
 	icon_state = "bumper"
-	wound_bonus = null
-	sharpness = SHARP_NONE
-	resistance_flags = null
 	wielded_icon = "bumper2"
+	wound_bonus = WOUNDING_BONUS_MODEST
+	sharpness = SHARP_NONE
+	resistance_flags = FIRE_PROOF
 
 /obj/item/twohanded/fireaxe/bmprsword/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -186,21 +186,19 @@
 	desc = "A simple spear with a metal head and wooden shaft."
 	icon_state = "spear-metal"
 	icon_prefix = "spear-metal"
-	force = 13
-	throwforce = 30
+	wielded_icon = "spear-metal2"
+	force = WEAPON_FORCE_SPEAR
+	force_unwielded = WEAPON_FORCE_SPEAR
+	force_wielded = WEAPON_FORCE_SPEAR_WIELDED
+	throwforce = THROWING_GOOD
 	throw_speed = 4
 	embedding = list("embed_chance" = 0)
 	max_reach = 2
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "impaled", "jabbed", "torn", "gored")
 	sharpness = SHARP_POINTY
-	max_integrity = 200
-	armor = ARMOR_VALUE_GENERIC_ITEM
 	wound_bonus = -15
 	bare_wound_bonus = 15
-	wielded_icon = "spear-metal2"
-	force_unwielded = 13
-	force_wielded = 32
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb = list("attacked", "impaled", "jabbed", "torn", "gored")
 	var/obj/item/grenade/explosive = null
 	var/war_cry = "AAAAARGH!!!"
 
@@ -287,9 +285,9 @@
 	icon_state = "spear-lance"
 	icon_prefix = "spear-lance"
 	wielded_icon = "spear-lance2"
-	force = 25
-	force_unwielded = 25
-	force_wielded = 40
+	force = (WEAPON_FORCE_SPEAR+1)
+	force_unwielded = (WEAPON_FORCE_SPEAR+1)
+	force_wielded = (WEAPON_FORCE_SPEAR_WIELDED+4)
 
 // Scrap spear		Keywords: Damage 17/28, Reach, Throw bonus
 /obj/item/twohanded/spear/scrapspear
@@ -297,12 +295,13 @@
 	desc = "Made from two rods, a glass shard and some duct tape. For the modern tribal or the truly desperate. Surprisingly effective when thrown."
 	icon_state = "spear-scrap"
 	icon_prefix = "spear-scrap"
-	throwforce = 28
+	force = (WEAPON_FORCE_SPEAR-2)
+	force_unwielded = (WEAPON_FORCE_SPEAR-2)
+	force_wielded = (WEAPON_FORCE_SPEAR_WIELDED-3)
+	throwforce = THROWING_EFFECTIVE
 	embedding = list("pain_mult" = 2, "embed_chance" = 35, "fall_chance" = 20)
 	wielded_icon = "spear-scrap2"
-	force = 17
-	force_unwielded = 17
-	force_wielded = 28
+
 
 // Bone Spear		Keywords: TRIBAL, Damage 21/36, Armor-piercing +0.1, Reach
 /obj/item/twohanded/spear/bonespear
@@ -358,7 +357,6 @@
 	force = 20
 	force_unwielded = 25
 	force_wielded = 30
-	attack_speed = CLICK_CD_MELEE * 0.85 // 6.8
 	
 
 /////////////////
@@ -371,30 +369,29 @@
 	desc = "There ain't a skull in the league that can withstand a swatter."
 	icon_state = "baseball"
 	icon_prefix = "baseball"
-	force = 25
-	throwforce = 12
+	wielded_icon = "baseball2"
+	force = WEAPON_FORCE_CLUB
+	force_unwielded = WEAPON_FORCE_CLUB
+	force_wielded = WEAPON_FORCE_CLUB_WIELDED
+	throwforce = THROWING_POOR
+	attack_speed = MELEE_SPEED_NORMAL //8. swing as fast as one-handed weapons, and do more damage, but with the inconvenience of worse storage.
 	attack_verb = list("beat", "smacked", "clubbed", "clobbered")
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_NONE
-	wielded_icon = "baseball2"
-	force_unwielded = 25
-	force_wielded = 38
-	attack_speed = CLICK_CD_MELEE //8. swing as fast as one-handed weapons, and do more damage, but with the inconvenience of worse storage.
 	
 
-// Spiked Baseball Bat		Keywords: Damage 26/40, Damage bonus Stamina, Sharp
+// Spiked Baseball Bat		Keywords: Damage 25/38, Damage bonus Stamina, Sharp
 /obj/item/twohanded/baseball/spiked
 	name = "spiked baseball bat"
 	desc = "There ain't a skull in the league that can withstand a swatter, especially with large nails drilled through the top of it."
 	icon_state = "baseballspike"
 	icon_prefix = "baseballspike"
-	force = 26
-	throwforce = 15
+	wielded_icon = "baseballspike2"
+	force = WEAPON_FORCE_CLUB
+	force_unwielded = WEAPON_FORCE_CLUB
+	force_wielded = WEAPON_FORCE_CLUB_WIELDED
 	wound_bonus = 5
 	sharpness = SHARP_POINTY
-	wielded_icon = "baseballspike2"
-	force_unwielded = 26
-	force_wielded = 40
 
 /obj/item/twohanded/baseball/spiked/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -402,7 +399,7 @@
 		return
 	M.apply_damage(15, STAMINA, "chest", M.run_armor_check("chest", "melee"))
 
-// Louisville Slugger		Keywords: Damage 25/32, Damage bonus Stamina
+// Louisville Slugger		Keywords: Damage 25/38, Damage bonus Stamina
 /obj/item/twohanded/baseball/louisville
 	name = "Louisville slugger"
 	desc = "Purification in progress."
@@ -410,9 +407,9 @@
 	icon_prefix = "louisville"
 	attack_verb = list("thwacked", "bashed", "louisville slugged", "hit", "bludgeoned", "whacked", "bonked")
 	wielded_icon = "louisville2"
-	force = 25
-	force_unwielded = 25
-	force_wielded = 34
+	force = WEAPON_FORCE_CLUB
+	force_unwielded = WEAPON_FORCE_CLUB
+	force_wielded = WEAPON_FORCE_CLUB_WIELDED
 
 /obj/item/twohanded/baseball/louisville/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -428,9 +425,9 @@
 	icon_prefix = "golfclub"
 	attack_verb = list("smashed", "bashed", "fored", "hit", "bludgeoned", "whacked")
 	wielded_icon = "golfclub2"
-	force = 22
-	force_unwielded = 22
-	force_wielded = 32
+	force = WEAPON_FORCE_CLUB
+	force_unwielded = WEAPON_FORCE_CLUB
+	force_wielded = WEAPON_FORCE_CLUB_WIELDED
 
 /obj/item/twohanded/baseball/golfclub/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -448,12 +445,12 @@
 /obj/item/twohanded/sledgehammer
 	name = "sledgehammer"
 	desc = "A heavy sledgehammer that lost most of its use besides caving in heads and barricades. Swings incredibly slowly, but with deadly power."
-	attack_speed = CLICK_CD_MELEE * 1.8 //14.4
-	force = 25
-	throwforce = 20 // Huge hammers aren't that great for throwing
+	attack_speed = MELEE_SPEED_SLOWEST
+	force = WEAPON_FORCE_CLUB
+	force_unwielded = WEAPON_FORCE_CLUB
+	throwforce = THROWING_POOR // Huge hammers aren't that great for throwing
 	sharpness = SHARP_NONE
 	attack_verb = list("bashed", "pounded", "bludgeoned", "pummeled", "thrashed")
-	force_unwielded = 25
 
 
 // Sledgehammer			Keywords: Damage 25/55, Blacksmithing
@@ -487,10 +484,11 @@
 	righthand_file = 'icons/fallout/onmob/weapons/64x64_righthand.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
+	attack_speed = MELEE_SPEED_SLOWEST
 	damtype = "fire"
 	force = 5
-	armour_penetration = 0.3
-	throwforce = 5
+	armour_penetration = PIERCING_MAJOR
+	throwforce = THROWING_PATHETIC
 	throw_speed = 2
 	throw_range = 3
 	attack_verb = list("burned", "welded", "cauterized", "melted", "charred")
@@ -551,6 +549,7 @@
 	desc = "A heavy sledgehammer manufacted from ultra-dense materials, developed by the Brotherhood of Steel. It looks like it could crush someone's skull with ease."
 	icon_state = "hammer-super"
 	icon_prefix = "hammer-super"
+	attack_speed = MELEE_SPEED_SLOWER
 	force = 25
 	wielded_icon = "hammer-super2"
 	force_unwielded = 20
@@ -577,7 +576,10 @@ obj/item/twohanded/sledgehammer/supersledge/afterattack(atom/A, mob/living/user,
 	and deliver a tremendously powerful impact, easily crushing concrete."
 	icon_state = "hammer-rocket"
 	icon_prefix = "hammer-rocket"
-	force = 20
+	wielded_icon = "hammer-rocket2"
+	force = WEAPON_FORCE_CLUB
+	force_unwielded = WEAPON_FORCE_CLUB
+	force_wielded = 56
 	tool_behaviour = TOOL_MINING
 	toolspeed = 0.5
 	hitsound = "sound/f13effects/explosion_distant_2.ogg"
@@ -585,9 +587,6 @@ obj/item/twohanded/sledgehammer/supersledge/afterattack(atom/A, mob/living/user,
 	var/digrange = 1
 	var/attacksound = "sound/f13effects/explosion_distant_2.ogg"
 	var/sound = "sound/f13effects/explosion_distant_2.ogg"
-	wielded_icon = "hammer-rocket2"
-	force_unwielded = 20
-	force_wielded = 56
 
 /obj/item/twohanded/sledgehammer/rockethammer/ComponentInitialize()
 	. = ..()
@@ -635,9 +634,9 @@ obj/item/twohanded/sledgehammer/supersledge/afterattack(atom/A, mob/living/user,
 	desc = "A heavy hammer with a head that consists of leaking fusion cores. Might be unhealthy."
 	icon_state = "hammer-atom"
 	icon_prefix = "hammer-atom"
-	force = 25
 	wielded_icon = "hammer-atom2"
-	force_unwielded = 25
+	force = WEAPON_FORCE_CLUB
+	force_unwielded = WEAPON_FORCE_CLUB
 	force_wielded = 55
 
 /obj/item/twohanded/sledgehammer/atomsjudgement/attack(mob/living/M, mob/living/user)
@@ -660,7 +659,7 @@ obj/item/twohanded/sledgehammer/supersledge/afterattack(atom/A, mob/living/user,
 	wielded_icon = "hammer-war2"
 	force_unwielded = 34
 	force_wielded = 55
-	attack_speed = CLICK_CD_MELEE
+	attack_speed = MELEE_SPEED_NORMAL
 
 
 // Shaman staff				Keywords: Damage 15/30, Big stamina damage buff
@@ -721,6 +720,7 @@ obj/item/twohanded/sledgehammer/supersledge/afterattack(atom/A, mob/living/user,
 	desc = "A versatile power tool. Useful for limbing trees and delimbing humans."
 	icon_state = "chainsaw"
 	icon_prefix = "chainsaw"
+	attack_speed = MELEE_SPEED_NORMAL
 	force = 8
 	wound_bonus = 15
 	bare_wound_bonus = 15
@@ -848,7 +848,7 @@ obj/item/twohanded/sledgehammer/supersledge/afterattack(atom/A, mob/living/user,
 	item_state = "autoaxe"
 	icon_prefix = "autoaxe"
 	force_on = 33
-	attack_speed = CLICK_CD_MELEE * 1.5
+	attack_speed = MELEE_SPEED_SLOWEST
 	armour_penetration = 0.3
 	on_icon_state = "autoaxe_on"
 	off_icon_state = "autoaxe"
@@ -865,7 +865,7 @@ obj/item/twohanded/sledgehammer/supersledge/afterattack(atom/A, mob/living/user,
 		item_state = on_item_state
 		w_class = weight_class_on
 		force = force_on
-		attack_speed = CLICK_CD_MELEE * 0.5
+		attack_speed = MELEE_SPEED_FASTEST
 		attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 		playsound(loc, on_sound, 50, TRUE)
 	else

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1089,7 +1089,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		/obj/item/weldingtool = 1,
 		/obj/item/book/granter/trait/explosives = 1,
 		/obj/item/book/granter/trait/explosives_advanced = 1,
-		/obj/item/clothing/gloves/legion/forgemaster = 1
+		/obj/item/clothing/gloves/blacksmith_mittens = 1
 		)
 
 /datum/outfit/loadout/headmedicus
@@ -1249,7 +1249,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 /datum/outfit/loadout/slaveopifex
 	name = "Artisan"
 	neck = /obj/item/clothing/neck/apron/labor/forge
-	gloves = /obj/item/clothing/gloves/legion/forgemaster
+	gloves = /obj/item/clothing/gloves/blacksmith_mittens
 	belt = /obj/item/storage/belt/fannypack
 	glasses = /obj/item/clothing/glasses/welding
 	shoes = /obj/item/clothing/shoes/f13/military/plated

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -376,19 +376,19 @@ GLOBAL_LIST_INIT(anvil_recipes, list(
 	anchored = TRUE
 
 // Decent makeshift anvil, can break, mobile. Gets the exclusive scrap version of the machete and 2h chopper, as well as the universal tool instead of a crowbar
-/obj/structure/anvil/obtainable/table
+/obj/structure/blacksmith/anvil/obtainable/table
 	name = "table anvil"
 	desc = "A reinforced table. Usable as an anvil, favored by mad wastelanders and the dregs of the wasteland. Can be loosened from its bolts and moved."
 	icon_state = "tablevil"
 	anvilquality = -2 //WE SHOULD NOT HAVE CHANGED THIS.
 	itemqualitymax = 4
 
-/obj/structure/anvil/obtainable/table/wrench_act(mob/living/user, obj/item/I)
+/obj/structure/blacksmith/anvil/obtainable/table/wrench_act(mob/living/user, obj/item/I)
 	..()
 	default_unfasten_wrench(user, I, 5)
 	return TRUE
 
-/obj/structure/anvil/obtainable/table/do_shaping(mob/user, qualitychange)
+/obj/structure/blacksmith/anvil/obtainable/table/do_shaping(mob/user, qualitychange)
 	if(prob(2))
 		to_chat(user, "The [src] breaks under the strain!")
 		take_damage(max_integrity)

--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -64,7 +64,7 @@
 /obj/item/ingot/silver
 	custom_materials = list(/datum/material/silver=12000)
 
-/obj/item/ingot/titanium
+/obj/item/blacksmith/ingot/titanium
 	custom_materials = list(/datum/material/titanium=12000)
 
 // Adapted to suit FO so it can be used.

--- a/modular_atom/blacksmith/additions.dm
+++ b/modular_atom/blacksmith/additions.dm
@@ -9,8 +9,7 @@
 #define CHAIN /obj/item/blacksmith/chain
 
 #define QUALITY_MODIFIER quality
-#define FAST_ATTACK 7
-#define SLOW_ATTACK 9
+
 
 //////////////////////////////////////
 //									//
@@ -217,10 +216,6 @@
 
 
 // TEMPORARY CACHE OF SINFUL SHAME
-
-/obj/item/clothing/gloves/f13/blacksmith
-/obj/item/clothing/gloves/legion/forgemaster
-
 /obj/item/ingot/silver
 /obj/item/ingot/gold
 /obj/item/ingot/titanium

--- a/modular_atom/blacksmith/additions.dm
+++ b/modular_atom/blacksmith/additions.dm
@@ -10,6 +10,10 @@
 
 #define QUALITY_MODIFIER quality
 
+#define FORCE_SMITH_REACH 18
+#define FORCE_SMITH_LOW 21
+#define FORCE_SMITH_HIGH 28
+
 
 //////////////////////////////////////
 //									//
@@ -212,16 +216,3 @@
 				</body>
 				</html>
 				"}
-
-
-
-// TEMPORARY CACHE OF SINFUL SHAME
-/obj/item/ingot/silver
-/obj/item/ingot/gold
-/obj/item/ingot/titanium
-
-/obj/structure/furnace
-
-/obj/structure/anvil/obtainable
-/obj/structure/anvil/obtainable/sandstone
-/obj/structure/anvil/obtainable/table

--- a/modular_atom/blacksmith/finished_items.dm
+++ b/modular_atom/blacksmith/finished_items.dm
@@ -13,13 +13,15 @@
 	lefthand_file = 'modular_atom/blacksmith/icons/onmob/lefthand.dmi'
 	righthand_file = 'modular_atom/blacksmith/icons/onmob/righthand.dmi'
 	mob_overlay_icon = 'modular_atom/blacksmith/icons/onmob/slot.dmi'
+	force = 6
+	throwforce = THROWING_DECENT
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 6
 	obj_flags = UNIQUE_RENAME
 	wielded_mult = 1
+	wound_bonus = WOUNDING_BONUS_MODEST
 	var/quality
 	var/overlay_state = "woodenrod"
 	var/mutable_appearance/overlay
@@ -41,9 +43,10 @@
 	lefthand_file = 'modular_atom/blacksmith/icons/onmob/lefthand.dmi'
 	righthand_file = 'modular_atom/blacksmith/icons/onmob/righthand.dmi'
 	mob_overlay_icon = 'modular_atom/blacksmith/icons/onmob/slot.dmi'
+	force = 10
+	throwforce = THROWING_POOR
 	sharpness = SHARP_EDGED
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	force = 10
 	wielded_mult = 1.8
 	w_class = WEIGHT_CLASS_BULKY
 	wielded = FALSE
@@ -82,6 +85,7 @@
 	mob_overlay_icon = 'modular_atom/blacksmith/icons/onmob/slot.dmi'
 	item_state = "hammer"
 	overlay_state = "hammerhandle"
+	force = WEAPON_FORCE_CLUB
 	slot_flags = ITEM_SLOT_BELT
 	var/qualitymod = 0
 
@@ -296,11 +300,11 @@
 	overlay_state = "hilt_dagger"
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = SHARP_EDGED
-	force = 21
-	throwforce = 23
+	force = (WEAPON_FORCE_BIG_KNIFE-6)
+	throwforce = THROWING_EFFECTIVE
 	hitsound = 'modular_atom/blacksmith/sound/hit_knife.ogg'
 	armour_penetration = 0.05
-	attack_speed = FAST_ATTACK
+	attack_speed = MELEE_SPEED_FAST //7
 
 // go for the eyes Boo
 /obj/item/melee/smith/dagger/attack(mob/living/carbon/M, mob/living/carbon/user)
@@ -322,7 +326,7 @@
 	name = "bowie knife"
 	icon_state = "bowie_smith"
 	overlay_state = "hilt_bowie"
-	force = 23
+	force = (WEAPON_FORCE_BIG_KNIFE-4)
 
 
 //////////////////////////////////
@@ -336,12 +340,11 @@
 	name = "machete"
 	icon_state = "machete_smith"
 	overlay_state = "hilt_machete"
-	force = 29
-	throwforce = 15
+	force = (WEAPON_FORCE_SWORD-4)
 	sharpness = SHARP_EDGED
-	wound_bonus = 10
+	wound_bonus = WOUNDING_BONUS_BIG
 	block_chance = 20
-	armour_penetration = 0.1
+	armour_penetration = PIERCING_MINOR
 
 /obj/item/melee/smith/machete/ComponentInitialize()
 	. = ..()
@@ -373,14 +376,11 @@
 	icon_state = "waki_smith"
 	overlay_state = "hilt_waki"
 	sharpness = SHARP_EDGED
-	force = 25
-	throwforce = 12
+	force = (WEAPON_FORCE_SWORD-10)
 	item_flags = ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/waki
 	hitsound = 'modular_atom/blacksmith/sound/hit_sword.ogg'
 	block_chance = 5
-	wound_bonus = 5
-	bare_wound_bonus = 20
 
 /datum/block_parry_data/waki
 	parry_stamina_cost = 8
@@ -408,18 +408,18 @@
 	hitsound = 'sound/effects/butcher.ogg'
 	tool_behaviour = TOOL_SAW
 	toolspeed = 1
-	wound_bonus = -5
-	bare_wound_bonus = 35
+	wound_bonus = WOUNDING_MALUS_SHALLOW
+	bare_wound_bonus = WOUNDING_BONUS_BIG
 
 // ------------ MACE ------------ // [32 AP 0.4]
 /obj/item/melee/smith/mace
 	name = "mace"
 	icon_state = "mace_smith"
 	overlay_state = "shaft_mace"
-	force = 22
-	throwforce = 12
-	armour_penetration = 0.3
-	wound_bonus = 10
+	force = (WEAPON_FORCE_CLUB-6)
+	throwforce = THROWING_POOR
+	armour_penetration = PIERCING_MAJOR
+	wound_bonus = WOUNDING_BONUS_HUGE
 	hitsound = 'modular_atom/blacksmith/sound/hit_mace.ogg'
 
 /obj/item/melee/smith/mace/afterattack(mob/living/M, mob/living/user)
@@ -441,16 +441,15 @@
 	icon_state = "sword_smith"
 	item_state = "sword_smith"
 	overlay_state = "hilt_sword"
-	armour_penetration = 0.1
-	force = 27
-	throwforce = 10
+	force = (WEAPON_FORCE_SWORD-7) //28
+	armour_penetration = PIERCING_MINOR
 	sharpness = SHARP_EDGED
 	item_flags = ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/sword
 	w_class = WEIGHT_CLASS_BULKY
-	wound_bonus = 5
+	wound_bonus = WOUNDING_BONUS_BIG
 	block_chance = 10
-	armour_penetration = 0.1
+
 
 /datum/block_parry_data/sword
 	parry_stamina_cost = 12
@@ -475,7 +474,7 @@
 	icon_state = "spatha_smith"
 	item_state = "spatha_smith"
 	overlay_state = "hilt_spatha"
-	block_chance = 15
+	block_chance = 14
 
 // ------------ SABRE ------------ // [35 AP 0.25 Parry]
 /obj/item/melee/smith/sword/sabre
@@ -483,11 +482,9 @@
 	icon_state = "sabre_smith"
 	item_state = "sabre_smith"
 	overlay_state = "hilt_sabre"
-	armour_penetration = 0.25
-	force = 25
-	block_chance = 20
+	force = (WEAPON_FORCE_SWORD-8)
+	block_chance = 18
 	block_parry_data = /datum/block_parry_data/smithsaber
-	armour_penetration = 0.15
 
 /datum/block_parry_data/smithsaber
 	parry_stamina_cost = 10
@@ -517,17 +514,16 @@
 	icon_state = "katana_smith"
 	icon_prefix = "katana_smith"
 	overlay_state = "hilt_katana"
-	force = 25
-	throwforce = 8
+	force = (WEAPON_FORCE_SWORD-8)
+	armour_penetration = PIERCING_MODERATE
+	throwforce = THROWING_POOR
 	wielded_mult = 1.5
 	item_flags = ITEM_CAN_PARRY | NEEDS_PERMIT
-	block_parry_data = /datum/block_parry_data/smithkatana
-	hitsound = 'modular_atom/blacksmith/sound/hit_sword.ogg'
 	slot_flags = ITEM_SLOT_BELT
 	block_chance = 15
-	wound_bonus = 5
-	bare_wound_bonus = 30
-	armour_penetration = 0.2
+	wound_bonus = WOUNDING_BONUS_BIG
+	block_parry_data = /datum/block_parry_data/smithkatana
+	hitsound = 'modular_atom/blacksmith/sound/hit_sword.ogg'
 
 /datum/block_parry_data/smithkatana
 	parry_stamina_cost = 10
@@ -556,21 +552,17 @@
 	icon_prefix = "longsword_smith"
 	overlay_state = "hilt_longsword"
 
-// ------------ SCRAP BLADE ------------ // [33/46.2 AP 0.1 Wounding]
+// ------------ SCRAP BLADE ------------ // [33/46.2 Wounding]
 /obj/item/melee/smith/twohand/katana/scrapblade
 	name = "scrap blade"
 	icon_state = "scrap_smith"
 	icon_prefix = "scrap_smith"
 	overlay_state = "hilt_scrap"
-	force = 23
-	throwforce = 30
+	force = (WEAPON_FORCE_SWORD-9)
 	wielded_mult = 1.4
-	armour_penetration = 0.1
-	wound_bonus = 20
-	attack_speed = SLOW_ATTACK
-	slot_flags = ITEM_SLOT_BELT
+	attack_speed = MELEE_SPEED_SLOW //9
 
-/obj/item/melee/smith/twohand/axe/scrapblade/ComponentInitialize()
+/obj/item/melee/smith/twohand/katana/scrapblade/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 110, 75) //decent in a pinch, but pretty bad.
 
@@ -581,7 +573,7 @@
 //								//
 //////////////////////////////////
 
-// ------------ HEAVY AXE ------------ // [28/56 AP 0.05 Doorbusting]
+// ------------ HEAVY AXE ------------ // [28/56 AP 0.1 Doorbusting]
 /obj/item/melee/smith/twohand/axe
 	name = "heavy axe"
 	icon_state = "axe_smith"
@@ -592,9 +584,8 @@
 	throwforce = 15
 	wielded_mult = 2
 	slot_flags = ITEM_SLOT_BACK
-	wound_bonus = 10
-	bare_wound_bonus = 10
-	armour_penetration = 0.05
+	wound_bonus = WOUNDING_BONUS_BIG
+	armour_penetration = PIERCING_MINOR
 
 /obj/item/melee/smith/twohand/axe/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -613,7 +604,7 @@
 	icon_state = "waraxe_smith"
 	icon_prefix = "waraxe_smith"
 	overlay_state = "shaft_waraxe"
-	throwforce = 30
+	throwforce = THROWING_GOOD
 
 /obj/item/melee/smith/twohand/axe/waraxe/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -633,15 +624,14 @@
 	icon_prefix = "crusher_smith"
 	overlay_state = "shaft_crusher"
 	sharpness = SHARP_NONE
-	force = 22
-	throwforce = 5
-	wound_bonus = 20
-	bare_wound_bonus = 30
-	wielded_mult = 1.5
+	force = (WEAPON_FORCE_CLUB-6)
+	throwforce = THROWING_PATHETIC
+	wound_bonus = WOUNDING_BONUS_HUGE
+	wielded_mult = WEAPON_BLUNT_TWOHAND_MULT
 	hitsound = 'modular_atom/blacksmith/sound/hit_mace.ogg'
 	slot_flags = null
-	armour_penetration = 0.1
-	attack_speed = SLOW_ATTACK
+	armour_penetration =PIERCING_MODERATE
+	attack_speed = MELEE_SPEED_SLOW
 
 /obj/item/melee/smith/twohand/crusher/Initialize()
 	. = ..()
@@ -679,11 +669,11 @@
 	icon_state = "spear_smith"
 	icon_prefix = "spear_smith"
 	overlay_state = "shaft_spear"
+	force = (WEAPON_FORCE_SPEAR_WIELDED-21)
+	armour_penetration = PIERCING_MINOR
+	throwforce = THROWING_GOOD
 	max_reach = 2
-	force = 11
-	throwforce = 20
 	sharpness = SHARP_POINTY
-	armour_penetration = 0.1
 
 // ------------ TRIDENT ------------ // [21/37.8 Reach Embed]
 /obj/item/melee/smith/twohand/spear/trident
@@ -691,13 +681,12 @@
 	icon_state = "trident_smith"
 	icon_prefix = "trident_smith"
 	overlay_state = "shaft_trident"
-	force = 10
-	attack_speed = SLOW_ATTACK
-	throwforce = 30
+	force = (WEAPON_FORCE_SPEAR_WIELDED-20)
+	attack_speed = MELEE_SPEED_SLOW
 	embedding = list("pain_mult" = 2, "embed_chance" = 40, "fall_chance" = 30, "ignore_throwspeed_threshold" = TRUE)
 	armour_penetration = 0
 
-/obj/item/melee/smith/twohand/crusher/Initialize()
+/obj/item/melee/smith/twohand/spear/trident/Initialize()
 	. = ..()
 	desc = "Made for spearing small lizard and fish, able to pin down the prey if thrown."
 
@@ -707,7 +696,6 @@
 	icon_state = "lance_smith"
 	icon_prefix = "lance_smith"
 	overlay_state = "shaft_lance"
-	throwforce = 30
 
 
 //////////////////////////////////////////////////
@@ -724,8 +712,8 @@
 	item_state = "javelin_smith"
 	sharpness = SHARP_POINTY
 	embedding = list("pain_mult" = 2, "embed_chance" = 62, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
-	force = 16
-	armour_penetration = 0.2
+	force = (WEAPON_FORCE_SPEAR-8)
+	armour_penetration = PIERCING_MODERATE
 
 // ------------ THROWING KNIFE ------------ // [25 (33.6) AP 0.1 Embed]
 /obj/item/melee/smith/throwingknife
@@ -734,9 +722,9 @@
 	overlay_state = "handle_throwing"
 	item_state = "dagger_smith"
 	embedding = list("pain_mult" = 2, "embed_chance" = 65, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
-	force = 15
+	force = (WEAPON_FORCE_SPEAR-9)
+	armour_penetration = PIERCING_MINOR
 	w_class = WEIGHT_CLASS_SMALL
-	armour_penetration = 0.1
 
 // ------------ METAL BOLA ------------ //
 /obj/item/restraints/legcuffs/bola/smithed

--- a/modular_atom/blacksmith/finished_items.dm
+++ b/modular_atom/blacksmith/finished_items.dm
@@ -13,15 +13,15 @@
 	lefthand_file = 'modular_atom/blacksmith/icons/onmob/lefthand.dmi'
 	righthand_file = 'modular_atom/blacksmith/icons/onmob/righthand.dmi'
 	mob_overlay_icon = 'modular_atom/blacksmith/icons/onmob/slot.dmi'
-	force = 6
+	force = FORCE_SMITH_LOW
 	throwforce = THROWING_DECENT
+	wound_bonus = WOUNDING_BONUS_MODEST
+	wielded_mult = 1
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
 	obj_flags = UNIQUE_RENAME
-	wielded_mult = 1
-	wound_bonus = WOUNDING_BONUS_MODEST
 	var/quality
 	var/overlay_state = "woodenrod"
 	var/mutable_appearance/overlay
@@ -43,13 +43,15 @@
 	lefthand_file = 'modular_atom/blacksmith/icons/onmob/lefthand.dmi'
 	righthand_file = 'modular_atom/blacksmith/icons/onmob/righthand.dmi'
 	mob_overlay_icon = 'modular_atom/blacksmith/icons/onmob/slot.dmi'
-	force = 10
+	attack_speed = MELEE_SPEED_SLOW
+	force = FORCE_SMITH_LOW
 	throwforce = THROWING_POOR
 	sharpness = SHARP_EDGED
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	wielded_mult = 1.8
+	wielded_mult = 1.4
 	w_class = WEIGHT_CLASS_BULKY
 	wielded = FALSE
+	total_mass = (TOTAL_MASS_MEDIEVAL_WEAPON * 1.5)
 	var/icon_prefix = null
 	var/x_offset = null
 	var/y_offset = null
@@ -85,6 +87,7 @@
 	mob_overlay_icon = 'modular_atom/blacksmith/icons/onmob/slot.dmi'
 	item_state = "hammer"
 	overlay_state = "hammerhandle"
+	attack_speed = MELEE_SPEED_SLOWEST
 	force = WEAPON_FORCE_CLUB
 	slot_flags = ITEM_SLOT_BELT
 	var/qualitymod = 0
@@ -220,7 +223,7 @@
 	obj_flags = UNIQUE_RENAME
 	sharpness = SHARP_POINTY
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	force = 30
+	force = WEAPON_FORCE_CLUB 
 
 /obj/item/crowbar/smithedunitool/Initialize()
 	..()
@@ -244,7 +247,7 @@
 	item_state = "knife_smith"
 	obj_flags = UNIQUE_RENAME
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	force = 23
+	force = WEAPON_FORCE_KNIFE
 
 /obj/item/kitchen/knife/smithed/Initialize()
 	. = ..()
@@ -293,18 +296,19 @@
 //								//
 //////////////////////////////////
 
-// ------------ DAGGER ------------ // [31 AP 0.35 Eyestab]
+// ------------ DAGGER ------------ // [33 AP Eyestab]
 /obj/item/melee/smith/dagger
 	name = "dagger"
 	icon_state = "dagger_smith"
 	overlay_state = "hilt_dagger"
+	attack_speed = MELEE_SPEED_FAST
+	force = FORCE_SMITH_LOW
+	armour_penetration = 0.05
+	throwforce = THROWING_EFFECTIVE
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = SHARP_EDGED
-	force = (WEAPON_FORCE_BIG_KNIFE-6)
-	throwforce = THROWING_EFFECTIVE
 	hitsound = 'modular_atom/blacksmith/sound/hit_knife.ogg'
-	armour_penetration = 0.05
-	attack_speed = MELEE_SPEED_FAST //7
+
 
 // go for the eyes Boo
 /obj/item/melee/smith/dagger/attack(mob/living/carbon/M, mob/living/carbon/user)
@@ -321,12 +325,12 @@
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 100, 10)
 
-// ------------ BOWIE KNIFE ------------ // [33 AP 0.3 Eyestab]
+// ------------ BOWIE KNIFE ------------ // [35 AP  Eyestab]
 /obj/item/melee/smith/dagger/bowie 
 	name = "bowie knife"
 	icon_state = "bowie_smith"
 	overlay_state = "hilt_bowie"
-	force = (WEAPON_FORCE_BIG_KNIFE-4)
+	force = (FORCE_SMITH_LOW+2)
 
 
 //////////////////////////////////
@@ -335,16 +339,16 @@
 //								//
 //////////////////////////////////
 
-// ------------ MACHETE ------------ // [39 AP 0.1]
+// ------------ MACHETE ------------ // [40 AP 0.1]
 /obj/item/melee/smith/machete
 	name = "machete"
 	icon_state = "machete_smith"
 	overlay_state = "hilt_machete"
-	force = (WEAPON_FORCE_SWORD-4)
-	sharpness = SHARP_EDGED
+	force = FORCE_SMITH_HIGH
+	armour_penetration = PIERCING_MINOR
 	wound_bonus = WOUNDING_BONUS_BIG
 	block_chance = 20
-	armour_penetration = PIERCING_MINOR
+	sharpness = SHARP_EDGED
 
 /obj/item/melee/smith/machete/ComponentInitialize()
 	. = ..()
@@ -375,12 +379,13 @@
 	name = "wakizashi"
 	icon_state = "waki_smith"
 	overlay_state = "hilt_waki"
-	sharpness = SHARP_EDGED
-	force = (WEAPON_FORCE_SWORD-10)
-	item_flags = ITEM_CAN_PARRY
-	block_parry_data = /datum/block_parry_data/waki
-	hitsound = 'modular_atom/blacksmith/sound/hit_sword.ogg'
+	force = (FORCE_SMITH_HIGH-2)
 	block_chance = 5
+	block_parry_data = /datum/block_parry_data/waki
+	sharpness = SHARP_EDGED
+	item_flags = ITEM_CAN_PARRY
+	hitsound = 'modular_atom/blacksmith/sound/hit_sword.ogg'
+
 
 /datum/block_parry_data/waki
 	parry_stamina_cost = 8
@@ -400,26 +405,30 @@
 	. = ..()
 	AddComponent(/datum/component/butchering, 110, 70) //decent in a pinch, but pretty bad.
 
+
 // ------------ SCRAP SAW ------------ // [35 AP 0 Parry]
 /obj/item/melee/smith/wakizashi/scrapsaw
 	name = "scrap saw"
 	icon_state = "saw_smith"
 	overlay_state = "handle_saw"
-	hitsound = 'sound/effects/butcher.ogg'
-	tool_behaviour = TOOL_SAW
-	toolspeed = 1
 	wound_bonus = WOUNDING_MALUS_SHALLOW
 	bare_wound_bonus = WOUNDING_BONUS_BIG
+	tool_behaviour = TOOL_SAW
+	toolspeed = 1
+	hitsound = 'sound/effects/butcher.ogg'
+
 
 // ------------ MACE ------------ // [32 AP 0.4]
 /obj/item/melee/smith/mace
 	name = "mace"
 	icon_state = "mace_smith"
 	overlay_state = "shaft_mace"
-	force = (WEAPON_FORCE_CLUB-6)
-	throwforce = THROWING_POOR
+	attack_speed = MELEE_SPEED_SLOW
+	force = (FORCE_SMITH_LOW+1)
 	armour_penetration = PIERCING_MAJOR
+	throwforce = THROWING_POOR
 	wound_bonus = WOUNDING_BONUS_HUGE
+	total_mass = (TOTAL_MASS_MEDIEVAL_WEAPON*1.2)
 	hitsound = 'modular_atom/blacksmith/sound/hit_mace.ogg'
 
 /obj/item/melee/smith/mace/afterattack(mob/living/M, mob/living/user)
@@ -441,15 +450,14 @@
 	icon_state = "sword_smith"
 	item_state = "sword_smith"
 	overlay_state = "hilt_sword"
-	force = (WEAPON_FORCE_SWORD-7) //28
+	force = FORCE_SMITH_HIGH
 	armour_penetration = PIERCING_MINOR
-	sharpness = SHARP_EDGED
+	wound_bonus = WOUNDING_BONUS_BIG
 	item_flags = ITEM_CAN_PARRY
+	block_chance = 10
 	block_parry_data = /datum/block_parry_data/sword
 	w_class = WEIGHT_CLASS_BULKY
-	wound_bonus = WOUNDING_BONUS_BIG
-	block_chance = 10
-
+	sharpness = SHARP_EDGED
 
 /datum/block_parry_data/sword
 	parry_stamina_cost = 12
@@ -468,6 +476,7 @@
 	AddComponent(/datum/component/butchering, 120, 70) //decent in a pinch, but pretty bad.
 	AddElement(/datum/element/sword_point)
 
+
 // ------------ SPATHA ------------ // [37 AP 0.2 Parry]
 /obj/item/melee/smith/sword/spatha
 	name = "spatha"
@@ -476,13 +485,14 @@
 	overlay_state = "hilt_spatha"
 	block_chance = 14
 
+
 // ------------ SABRE ------------ // [35 AP 0.25 Parry]
 /obj/item/melee/smith/sword/sabre
 	name = "sabre"
 	icon_state = "sabre_smith"
 	item_state = "sabre_smith"
 	overlay_state = "hilt_sabre"
-	force = (WEAPON_FORCE_SWORD-8)
+	force = (FORCE_SMITH_HIGH-1)
 	block_chance = 18
 	block_parry_data = /datum/block_parry_data/smithsaber
 
@@ -514,15 +524,15 @@
 	icon_state = "katana_smith"
 	icon_prefix = "katana_smith"
 	overlay_state = "hilt_katana"
-	force = (WEAPON_FORCE_SWORD-8)
+	force = (FORCE_SMITH_HIGH-1)
 	armour_penetration = PIERCING_MODERATE
 	throwforce = THROWING_POOR
-	wielded_mult = 1.5
-	item_flags = ITEM_CAN_PARRY | NEEDS_PERMIT
-	slot_flags = ITEM_SLOT_BELT
-	block_chance = 15
 	wound_bonus = WOUNDING_BONUS_BIG
+	wielded_mult = 1.2
+	item_flags = ITEM_CAN_PARRY
+	block_chance = 15
 	block_parry_data = /datum/block_parry_data/smithkatana
+	slot_flags = ITEM_SLOT_BELT
 	hitsound = 'modular_atom/blacksmith/sound/hit_sword.ogg'
 
 /datum/block_parry_data/smithkatana
@@ -545,6 +555,7 @@
 	AddComponent(/datum/component/butchering, 130, 60) //pretty bad.
 	AddElement(/datum/element/sword_point)
 
+
 // ------------ LONGSWORD ------------ // [35/49 AP 0.2 Parry]
 /obj/item/melee/smith/twohand/katana/longsword
 	name = "longsword"
@@ -552,15 +563,15 @@
 	icon_prefix = "longsword_smith"
 	overlay_state = "hilt_longsword"
 
+
 // ------------ SCRAP BLADE ------------ // [33/46.2 Wounding]
 /obj/item/melee/smith/twohand/katana/scrapblade
 	name = "scrap blade"
 	icon_state = "scrap_smith"
 	icon_prefix = "scrap_smith"
 	overlay_state = "hilt_scrap"
-	force = (WEAPON_FORCE_SWORD-9)
-	wielded_mult = 1.4
-	attack_speed = MELEE_SPEED_SLOW //9
+	attack_speed = MELEE_SPEED_SLOW
+	force = FORCE_SMITH_HIGH
 
 /obj/item/melee/smith/twohand/katana/scrapblade/ComponentInitialize()
 	. = ..()
@@ -579,13 +590,12 @@
 	icon_state = "axe_smith"
 	icon_prefix = "axe_smith"
 	overlay_state = "shaft_axe"
-	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2
-	force = 18
-	throwforce = 15
-	wielded_mult = 2
-	slot_flags = ITEM_SLOT_BACK
-	wound_bonus = WOUNDING_BONUS_BIG
+	force = FORCE_SMITH_LOW
 	armour_penetration = PIERCING_MINOR
+	throwforce = THROWING_POOR
+	wound_bonus = WOUNDING_BONUS_BIG
+	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2
+	slot_flags = ITEM_SLOT_BACK
 
 /obj/item/melee/smith/twohand/axe/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -597,6 +607,7 @@
 	else if(istype(A, /obj/structure/simple_door))
 		var/obj/structure/simple_door/M = A
 		M.take_damage(20, BRUTE, "melee", 0)
+
 
 // ------------ LEGION WAR AXE ------------ // [28/56 AP 0.05 Doorbusting]
 /obj/item/melee/smith/twohand/axe/waraxe
@@ -617,21 +628,22 @@
 		var/obj/structure/simple_door/M = A
 		M.take_damage(20, BRUTE, "melee", 0)
 
+
 // ------------ GHOUL CRUSHER ------------ // [32/48 AP 0.1 Ghoul bonus] - for those dry twig like limbs, snap snap..
 /obj/item/melee/smith/twohand/crusher
 	name = "crusher"
 	icon_state = "crusher_smith"
 	icon_prefix = "crusher_smith"
 	overlay_state = "shaft_crusher"
-	sharpness = SHARP_NONE
-	force = (WEAPON_FORCE_CLUB-6)
+	attack_speed = MELEE_SPEED_SLOWER
+	force = FORCE_SMITH_LOW
+	armour_penetration = PIERCING_MODERATE
 	throwforce = THROWING_PATHETIC
 	wound_bonus = WOUNDING_BONUS_HUGE
-	wielded_mult = WEAPON_BLUNT_TWOHAND_MULT
-	hitsound = 'modular_atom/blacksmith/sound/hit_mace.ogg'
+	sharpness = SHARP_NONE
 	slot_flags = null
-	armour_penetration =PIERCING_MODERATE
-	attack_speed = MELEE_SPEED_SLOW
+	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2
+	hitsound = 'modular_atom/blacksmith/sound/hit_mace.ogg'
 
 /obj/item/melee/smith/twohand/crusher/Initialize()
 	. = ..()
@@ -669,9 +681,10 @@
 	icon_state = "spear_smith"
 	icon_prefix = "spear_smith"
 	overlay_state = "shaft_spear"
-	force = (WEAPON_FORCE_SPEAR_WIELDED-21)
+	force = FORCE_SMITH_REACH
 	armour_penetration = PIERCING_MINOR
 	throwforce = THROWING_GOOD
+	wielded_mult = 1.3
 	max_reach = 2
 	sharpness = SHARP_POINTY
 
@@ -681,8 +694,8 @@
 	icon_state = "trident_smith"
 	icon_prefix = "trident_smith"
 	overlay_state = "shaft_trident"
-	force = (WEAPON_FORCE_SPEAR_WIELDED-20)
 	attack_speed = MELEE_SPEED_SLOW
+	force = (FORCE_SMITH_REACH+1)	
 	embedding = list("pain_mult" = 2, "embed_chance" = 40, "fall_chance" = 30, "ignore_throwspeed_threshold" = TRUE)
 	armour_penetration = 0
 
@@ -710,10 +723,10 @@
 	icon_state = "javelin_smith"
 	overlay_state = "shaft_javelin"
 	item_state = "javelin_smith"
+	force = FORCE_SMITH_REACH
+	armour_penetration = PIERCING_MODERATE
 	sharpness = SHARP_POINTY
 	embedding = list("pain_mult" = 2, "embed_chance" = 62, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
-	force = (WEAPON_FORCE_SPEAR-8)
-	armour_penetration = PIERCING_MODERATE
 
 // ------------ THROWING KNIFE ------------ // [25 (33.6) AP 0.1 Embed]
 /obj/item/melee/smith/throwingknife
@@ -721,9 +734,9 @@
 	icon_state = "throwing_smith"
 	overlay_state = "handle_throwing"
 	item_state = "dagger_smith"
-	embedding = list("pain_mult" = 2, "embed_chance" = 65, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
-	force = (WEAPON_FORCE_SPEAR-9)
+	force = FORCE_SMITH_REACH
 	armour_penetration = PIERCING_MINOR
+	embedding = list("pain_mult" = 2, "embed_chance" = 65, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
 	w_class = WEIGHT_CLASS_SMALL
 
 // ------------ METAL BOLA ------------ //

--- a/modular_atom/blacksmith/smithed_items.dm
+++ b/modular_atom/blacksmith/smithed_items.dm
@@ -106,13 +106,13 @@
 			qualname =  "poor"
 		if(-1 to 1)
 			qualname = "normal"
-		if(11 to INFINITY)
+		if(12 to INFINITY)
 			qualname = "legendary"
-		if(8 to 11)
+		if(10 to 12)
 			qualname = "masterwork"
-		if(7 to 8)
+		if(8 to 9)
 			qualname = "excellent"
-		if(5 to 7)
+		if(5 to 8)
 			qualname = "good"
 		if(0 to 5)
 			qualname = "above-average"
@@ -279,7 +279,7 @@
 
 /obj/item/smithing/hammerhead/startfinish()
 	var/obj/item/melee/smith/hammer/finalforreal = new /obj/item/melee/smith/hammer(src)
-	finalforreal.force += quality/2
+	finalforreal.force += quality/4
 	finalforreal.qualitymod = quality/2.5
 	finalitem = finalforreal
 	..()
@@ -469,7 +469,7 @@
 /obj/item/smithing/daggerblade/startfinish()
 	finalitem = new /obj/item/melee/smith/dagger(src)
 	finalitem.force += QUALITY_MODIFIER
-	finalitem.armour_penetration += QUALITY_MODIFIER*0.03
+	finalitem.armour_penetration += QUALITY_MODIFIER*0.01
 	..()
 
 // ------------ BOWIE KNIFE ------------ //
@@ -718,7 +718,7 @@
 	finalforreal.force += QUALITY_MODIFIER
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]2")
-	finalforreal.throwforce = finalforreal.force/10
+	finalforreal.throwforce = finalforreal.force
 	finalitem = finalforreal
 	..()
 
@@ -733,7 +733,7 @@
 	finalforreal.force += QUALITY_MODIFIER
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]2")
-	finalforreal.throwforce = finalforreal.force/10
+	finalforreal.throwforce = finalforreal.force
 	finalitem = finalforreal
 	..()
 
@@ -748,7 +748,7 @@
 	finalforreal.force += QUALITY_MODIFIER
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]2")
-	finalforreal.throwforce = finalforreal.force/10
+	finalforreal.throwforce = finalforreal.force
 	finalitem = finalforreal
 	..()
 

--- a/modular_atom/blacksmith/smithed_items.dm
+++ b/modular_atom/blacksmith/smithed_items.dm
@@ -809,8 +809,6 @@
 #undef GLOW_BRIGHT
 #undef GLOW_MODERATE
 #undef GLOW_WEAK
-#undef FAST_ATTACK
-#undef SLOW_ATTACK
 
 
 // ------------------------------- TG Remnants ------------------------------


### PR DESCRIPTION
## About The Pull Request
- Bunch of defines added/implemented in melee. Point is to make this mess a little less cryptic and arbitrary. Mostly little or no noticeable end user effect, Cosmic knife suffers a bit since it was comically overpowered over the other knives and swords. It's still the best knife by a mile. Adjust the defines as needed, avoid arbitrary crap and keep more items actually useful, easy. Also links the smithed stuff to the regular via defines so any changes will automatically carry over and be consistent. 
- Mittens cleanup
- Metalworking bench now correct tool label

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Defines melee added
/:cl:

EDIT: Since I literally only have a day or two more to finish this project, having it sit is not kosher. I'll happily unmerge all improvements and fixing outside of the blacksmith module so the checkmark is green and leave cleanup for someone else(no one ever will), if the CI is the issue. It really doesn't matter to me. I'll update it later and remove the defines and mapfixes tonight if theres no response.