### PR TITLE
Renames NCR Rep Roles

### DIFF
--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -292,8 +292,8 @@
 //////////////
 
 /obj/item/clothing/accessory/lawyers_badge
-	name = "attorney's badge"
-	desc = "Fills you with the conviction of JUSTICE. Lawyers tend to want to show it to everyone they meet."
+	name = "NCR agent's badge"
+	desc = "A polished badge representative of courage, honor, and morally dubious undercover missions."
 	icon_state = "lawyerbadge"
 
 /obj/item/clothing/accessory/lawyers_badge/attack_self(mob/user)

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -425,6 +425,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/loadout/repagent
 	name = "Government Agent"
+	glasses = /obj/item/clothing/glasses/sunglasses
 	suit = /obj/item/clothing/under/rank/security/detective/grey
 	shoes = /obj/item/clothing/shoes/laceup
 	backpack_contents = list(

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -432,7 +432,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/storage/box/ration/menu_two = 1,
 		/obj/item/clothing/accessory/waistcoat = 1,
 		/obj/item/clothing/suit/toggle/lawyer/black = 1,
-		/obj/item/storage/briefcase = 1
+		/obj/item/storage/briefcase = 1,
+		/obj/item/clothing/accessory/lawyers_badge = 1
 		)
 
 /datum/outfit/loadout/repambassador

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -386,9 +386,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	exp_requirements = 750
 
 	loadout_options = list(
-		/datum/outfit/loadout/repbrahminbaron,
-		/datum/outfit/loadout/repambassador,
-		/datum/outfit/loadout/repexecutive
+		/datum/outfit/loadout/repsenator,
+		/datum/outfit/loadout/repagent,
+		/datum/outfit/loadout/repambassador
 		)
 
 	matchmaking_allowed = list(
@@ -413,8 +413,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/storage/bag/money/small/ncr = 2
 		)
 
-/datum/outfit/loadout/repbrahminbaron
-	name = "Brahmin Baron"
+/datum/outfit/loadout/repsenator
+	name = "Senator"
 	suit = /obj/item/clothing/under/suit/burgundy
 	shoes = /obj/item/clothing/shoes/f13/cowboy
 	head = /obj/item/clothing/head/helmet/f13/brahmincowboyhat
@@ -423,8 +423,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/storage/box/ration/menu_two = 1
 		)
 
-/datum/outfit/loadout/repambassador
-	name = "Ambassador"
+/datum/outfit/loadout/repagent
+	name = "Government Agent"
 	suit = /obj/item/clothing/under/rank/security/detective/grey
 	shoes = /obj/item/clothing/shoes/laceup
 	backpack_contents = list(
@@ -435,8 +435,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/storage/briefcase = 1
 		)
 
-/datum/outfit/loadout/repexecutive
-	name = "Executive"
+/datum/outfit/loadout/repambassador
+	name = "Ambassador"
 	suit = /obj/item/clothing/under/suit_jacket/tan
 	shoes = /obj/item/clothing/shoes/laceup
 	head = /obj/item/clothing/head/helmet/f13/rustedcowboyhat


### PR DESCRIPTION
We're with the government, and we're here to help.

## About The Pull Request
Renames the NCR Rep roles to be actual government jobs instead of random rich people.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Renamed NCR Rep roles to Agent, Ambassador, and Senator
add: NCR agent badge to Government Agent
/:cl:
