### PR TITLE
Healing Powder Fixes

### DIFF
--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
@@ -12037,7 +12037,7 @@
 /turf/open/floor/plating,
 /area/f13/tunnel)
 "fct" = (
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt"
@@ -12091,7 +12091,7 @@
 /area/f13/wasteland)
 "fdf" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "fdm" = (
@@ -12205,7 +12205,7 @@
 /area/f13/wasteland)
 "feR" = (
 /obj/structure/closet/cabinet,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ffa" = (
@@ -14105,7 +14105,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -16854,7 +16854,7 @@
 /area/f13/building)
 "hbw" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hbH" = (
@@ -23680,7 +23680,7 @@
 /area/f13/building)
 "jRy" = (
 /obj/structure/table/wood/poker,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jRJ" = (
@@ -24204,8 +24204,8 @@
 /area/f13/wasteland)
 "kbQ" = (
 /obj/structure/closet/crate/large,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -35575,8 +35575,8 @@
 /area/f13/wasteland)
 "pbf" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/effect/spawner/lootdrop/clothing_low,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -43187,8 +43187,8 @@
 /area/f13/village)
 "suQ" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/clothing/under/f13/legskirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -51523,7 +51523,7 @@
 "wlJ" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/flask,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wmp" = (

--- a/_maps/map_files/Temp Map Storage/Dungeons -outdated.dmm
+++ b/_maps/map_files/Temp Map Storage/Dungeons -outdated.dmm
@@ -5397,9 +5397,9 @@
 /area/f13/bunker)
 "fAj" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
 "fAl" = (
@@ -12797,9 +12797,9 @@
 /area/f13/tunnel)
 "mWt" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},

--- a/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
+++ b/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
@@ -12260,7 +12260,7 @@
 	},
 /area/f13/wasteland)
 "fct" = (
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt"
@@ -12314,7 +12314,7 @@
 /area/f13/wasteland)
 "fdf" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "fdm" = (
@@ -12426,7 +12426,7 @@
 /area/f13/wasteland)
 "feR" = (
 /obj/structure/closet/cabinet,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ffa" = (
@@ -14407,7 +14407,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -17198,7 +17198,7 @@
 /area/f13/building)
 "hbw" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hbH" = (
@@ -24184,7 +24184,7 @@
 /area/f13/building)
 "jRy" = (
 /obj/structure/table/wood/poker,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jRI" = (
@@ -24744,8 +24744,8 @@
 /area/f13/wasteland)
 "kbQ" = (
 /obj/structure/closet/crate/large,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -36231,8 +36231,8 @@
 /area/f13/wasteland)
 "pbf" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/effect/spawner/lootdrop/clothing_low,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -43985,8 +43985,8 @@
 /area/f13/village)
 "suQ" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/pill/healingpowder,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/clothing/under/f13/legskirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -52467,7 +52467,7 @@
 "wlJ" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/flask,
-/obj/item/reagent_containers/pill/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wmp" = (

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -514,7 +514,7 @@ GLOBAL_LIST_INIT(ammobelt_allowed, typecacheof(list(
 	/obj/item/ammo_casing,
 	/obj/item/grenade,
 	/obj/item/reagent_containers/hypospray/medipen/stimpak,
-	/obj/item/reagent_containers/pill/healingpowder,
+	/obj/item/reagent_containers/pill/patch/healingpowder,
 	/obj/item/reagent_containers/pill/patch/healpoultice,
 	/obj/item/reagent_containers/pill/bitterdrink,
 	/obj/item/restraints/handcuffs,

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -424,7 +424,7 @@ GLOBAL_LIST_INIT(loot_medical_tool, list(
 ))
 
 GLOBAL_LIST_INIT(loot_medical_medicine, list(
-	/obj/item/reagent_containers/pill/healingpowder,
+	/obj/item/reagent_containers/pill/patch/healingpowder,
 	/obj/item/storage/pill_bottle/chem_tin/radx,
 	/obj/item/reagent_containers/blood/radaway,
 	/obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -436,7 +436,7 @@ GLOBAL_LIST_INIT(loot_medical_medicine, list(
 GLOBAL_LIST_INIT(loot_medical_drug, list(
 	/obj/item/reagent_containers/pill/patch/jet,
 	/obj/item/reagent_containers/pill/patch/turbo,
-	/obj/item/reagent_containers/pill/healingpowder,
+	/obj/item/reagent_containers/pill/patch/healingpowder,
 	/obj/item/reagent_containers/pill/stimulant,
 	/obj/item/reagent_containers/hypospray/medipen/medx,
 	/obj/item/reagent_containers/hypospray/medipen/steady

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -33,7 +33,7 @@
 
 /datum/crafting_recipe/healpowder  //keep the number of plants needed low so picking wild plants is viable. balance botany instead.
 	name = "Healing powder"
-	result = /obj/item/reagent_containers/pill/healingpowder
+	result = /obj/item/reagent_containers/pill/patch/healingpowder
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 1,
 				/obj/item/reagent_containers/food/snacks/grown/xander = 1)
 	time = 5

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -539,7 +539,7 @@
 	name = "wasteland meds spawner"
 	lootcount = 1
 
-	loot = list(/obj/item/reagent_containers/pill/healingpowder,
+	loot = list(/obj/item/reagent_containers/pill/patch/healingpowder,
 				/obj/item/storage/pill_bottle/chem_tin/radx,
 				/obj/item/reagent_containers/blood/radaway,
 				/obj/item/storage/pill_bottle/chem_tin/mentats,
@@ -556,7 +556,7 @@
 	loot = list(
 				/obj/item/reagent_containers/pill/patch/jet,
 				/obj/item/reagent_containers/pill/patch/turbo,
-				/obj/item/reagent_containers/pill/healingpowder,
+				/obj/item/reagent_containers/pill/patch/healingpowder,
 				/obj/item/reagent_containers/pill/stimulant,
 				/obj/item/reagent_containers/hypospray/medipen/medx,
 				/obj/item/storage/pill_bottle/chem_tin/buffout,

--- a/code/game/objects/items/storage/f13storage.dm
+++ b/code/game/objects/items/storage/f13storage.dm
@@ -347,7 +347,7 @@
 
 /obj/item/storage/box/medicine/powder5/PopulateContents()
 	for(var/i in 1 to 5)
-		new /obj/item/reagent_containers/pill/healingpowder(src)
+		new /obj/item/reagent_containers/pill/patch/healingpowder(src)
 
 // -----------------------------------
 // POULTICE BOX

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -244,7 +244,7 @@
 	STR.allow_quick_gather = TRUE
 	STR.click_gather = TRUE
 	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill, /obj/item/dice))
-	STR.cant_hold = typecacheof(list(/obj/item/reagent_containers/pill/patch/jet, /obj/item/reagent_containers/pill/patch/turbo, /obj/item/reagent_containers/pill/healingpowder, /obj/item/reagent_containers/pill/patch/healpoultice))
+	STR.cant_hold = typecacheof(list(/obj/item/reagent_containers/pill/patch/jet, /obj/item/reagent_containers/pill/patch/turbo, /obj/item/reagent_containers/pill/patch/healingpowder, /obj/item/reagent_containers/pill/patch/healpoultice))
 
 /obj/item/storage/pill_bottle/AltClick(mob/living/carbon/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))

--- a/code/game/objects/items/storage/survivalkit.dm
+++ b/code/game/objects/items/storage/survivalkit.dm
@@ -22,8 +22,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/survivalkit/tribal/PopulateContents()
-	new /obj/item/reagent_containers/pill/healingpowder(src)
-	new /obj/item/reagent_containers/pill/healingpowder(src)
+	new /obj/item/reagent_containers/pill/patch/healingpowder(src)
+	new /obj/item/reagent_containers/pill/patch/healingpowder(src)
 	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/reagent_containers/food/drinks/flask/survival(src)
 
@@ -74,8 +74,8 @@
 	color = "#d1ffb3"
 
 /obj/item/storage/survivalkit/medical/tribal/PopulateContents()
-	new /obj/item/reagent_containers/pill/healingpowder(src)
-	new /obj/item/reagent_containers/pill/healingpowder(src)
+	new /obj/item/reagent_containers/pill/patch/healingpowder(src)
+	new /obj/item/reagent_containers/pill/patch/healingpowder(src)
 	new /obj/item/stack/medical/gauze/improvised(src)
 	new /obj/item/stack/medical/mesh/aloe(src)
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -866,7 +866,7 @@
 	outfit = /datum/outfit/job/tribal/f13hunter
 	suit_store = /obj/item/twohanded/spear/bonespear/deathclaw
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/healingpowder = 1,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
 		/obj/item/melee/onehanded/knife/bone = 1,
 		/obj/item/binoculars = 1,
 		/obj/item/restraints/legcuffs/bola/tactical = 1
@@ -884,7 +884,7 @@
 		/obj/item/melee/onehanded/knife/bone = 1,
 		/obj/item/restraints/legcuffs/bola = 2,
 		/obj/item/binoculars = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 1
+		/obj/item/reagent_containers/pill/patch/healingpowder = 1
 	)
 
 /obj/effect/mob_spawn/human/fallout13/tribal/special(mob/living/new_spawn)

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -29,7 +29,7 @@
 								/obj/item/reagent_containers/food/snacks/grown/fungus = 2.5,
 								/obj/item/reagent_containers/food/snacks/grown/agave = 2.5,
 								/obj/item/reagent_containers/pill/patch/jet = 10,
-								/obj/item/reagent_containers/pill/healingpowder = 5,
+								/obj/item/reagent_containers/pill/patch/healingpowder = 5,
 								/obj/item/reagent_containers/hypospray/medipen/psycho = 10,
 								/obj/item/reagent_containers/hypospray/medipen/medx = 15,
 								/obj/item/reagent_containers/pill/patch/healpoultice = 20,

--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -10,11 +10,11 @@
 	/obj/item/reagent_containers/blood/radaway,
 	/obj/item/reagent_containers/hypospray/medipen/steady,
 	/obj/item/storage/pill_bottle/chem_tin/mentats,
-	/obj/item/reagent_containers/pill/healingpowder,
+	/obj/item/reagent_containers/pill/patch/healingpowder,
 	/obj/item/storage/pill_bottle/chem_tin/buffout,
 	/obj/item/reagent_containers/pill/stimulant,
 	/obj/item/storage/pill_bottle/chem_tin/radx,
-	/obj/item/reagent_containers/pill/healingpowder
+	/obj/item/reagent_containers/pill/patch/healingpowder
 	)
 
 /datum/export/item/chemshigh

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -728,7 +728,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/revolver45 = 1,
 		/obj/item/ammo_box/loader/acp45 = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 1,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
 		/obj/item/storage/bag/money/small/legenlisted = 1,
 		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/restraints/handcuffs = 1,
@@ -988,7 +988,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	r_pocket = /obj/item/flashlight/lantern
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/legenlisted = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 1,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
 		/obj/item/melee/onehanded/machete = 1,
 		)
 
@@ -1041,7 +1041,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit_store = /obj/item/melee/onehanded/machete/forgedmachete
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/legenlisted = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 2
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2
 		)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13immune/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -1196,7 +1196,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	gloves = /obj/item/clothing/gloves/f13/crudemedical
 	r_pocket = /obj/item/flashlight/lantern
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/reagent_containers/pill/patch/healpoultice = 2,
 		/obj/item/smelling_salts = 1,
 		/obj/item/book/granter/trait/lowsurgery = 1,

--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -118,7 +118,7 @@ Tribal Chief
 	suit_store =	/obj/item/twohanded/spear/bonespear/deathclaw
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/warpaint_bowl=1,
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/flashlight/lantern = 1,
@@ -254,7 +254,7 @@ Tribal Head Hunter
 	belt = /obj/item/twohanded/spearaxe
 	id = /obj/item/card/id/tribetattoo
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/healingpowder=2,
+		/obj/item/reagent_containers/pill/patch/healingpowder=2,
 		/obj/item/warpaint_bowl=1,
 		/obj/item/stack/medical/gauze=1,
 		/obj/item/restraints/legcuffs/bola/tactical=2,
@@ -410,7 +410,7 @@ Villager
 	shoes = /obj/item/clothing/shoes/sandal
 	id = /obj/item/card/id/tribetattoo
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/healingpowder=1,
+		/obj/item/reagent_containers/pill/patch/healingpowder=1,
 		/obj/item/warpaint_bowl=1,
 		/obj/item/stack/medical/gauze=1,
 		/obj/item/flashlight/flare/torch=1
@@ -520,7 +520,7 @@ Hunter
 	shoes = /obj/item/clothing/shoes/sandal
 	id = /obj/item/card/id/tribetattoo
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/healingpowder=2,
+		/obj/item/reagent_containers/pill/patch/healingpowder=2,
 		/obj/item/warpaint_bowl=1,
 		/obj/item/stack/medical/gauze=1,
 		/obj/item/flashlight/flare/torch=1
@@ -590,7 +590,7 @@ Spirit-Pledged
 	backpack_contents = list(
 		/obj/item/twohanded/spear/bonespear=1,
 		/obj/item/melee/onehanded/knife/bone=1,
-		/obj/item/reagent_containers/pill/healingpowder=1
+		/obj/item/reagent_containers/pill/patch/healingpowder=1
 	)
 
 /datum/outfit/loadout/gardener
@@ -641,7 +641,7 @@ Guardian
 	suit_store = /obj/item/twohanded/spear/bonespear/deathclaw
 	id = /obj/item/card/id/tribetattoo
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/healingpowder=2,
+		/obj/item/reagent_containers/pill/patch/healingpowder=2,
 		/obj/item/warpaint_bowl=1,
 		/obj/item/stack/medical/gauze=1,
 		/obj/item/flashlight/flare/torch=1,

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -803,7 +803,7 @@ Raider
 	box = /obj/item/storage/survivalkit/tribal
 	box_two = /obj/item/storage/survivalkit/medical/tribal
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/flashlight/lantern = 1,
 		)
 
@@ -844,7 +844,7 @@ Raider
 		/obj/item/twohanded/sledgehammer/warmace = 1,
 		/obj/item/melee/onehanded/knife/ritualdagger = 1,
 		/obj/item/stack/medical/gauze/improvised = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/book/granter/crafting_recipe/tribal = 1,
 		/obj/item/book/granter/trait/tribaltraditions =1,
 	)
@@ -860,7 +860,7 @@ Raider
 		/obj/item/reagent_containers/glass/bucket/wood = 1,
 		/obj/item/storage/bag/plants = 1,
 		/obj/item/crowbar/smithedunitool = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 3,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 3,
 		/obj/item/book/granter/trait/tribaltraditions =1,
 	)
 
@@ -873,7 +873,7 @@ Raider
 		/obj/item/gun/ballistic/bow/sturdy = 1,
 		/obj/item/storage/bag/tribe_quiver/archer = 1,
 		/obj/item/binoculars = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/book/granter/trait/tribaltraditions =1,
 		)
 
@@ -908,7 +908,7 @@ Raider
 		/obj/item/clothing/under/f13/female/deadhorses = 1,
 		/obj/item/melee/onehanded/club/warclub = 1,
 		/obj/item/storage/backpack/spearquiver = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 2
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2
 	)
 
 /datum/outfit/loadout/deadhorsesranged
@@ -930,7 +930,7 @@ Raider
 		/obj/item/storage/bag/plants=1,
 		/obj/item/cultivator=1,
 		/obj/item/reagent_containers/glass/bucket/wood=1,
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/book/granter/crafting_recipe/tribal/deadhorses = 1
 	)
 
@@ -957,7 +957,7 @@ Raider
 		/obj/item/storage/bag/plants = 1,
 		/obj/item/cultivator = 1,
 		/obj/item/reagent_containers/glass/bucket/wood = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/melee/unarmed/yaoguaigauntlet = 1,
 		/obj/item/warpaint_bowl = 1,
 		/obj/item/toy/crayon/spraycan = 2,
@@ -974,7 +974,7 @@ Raider
 		/obj/item/clothing/under/f13/female/eighties = 1,
 		/obj/item/gun/ballistic/shotgun/trench = 1,
 		/obj/item/ammo_box/shotgun/buck = 2,
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/reagent_containers/pill/patch/turbo = 2,
 		/obj/item/reagent_containers/pill/patch/jet = 2
 	)
@@ -989,7 +989,7 @@ Raider
 		/obj/item/ammo_box/shotgun/buck = 1,
 		/obj/item/gun/ballistic/automatic/smg/greasegun/worn = 1,
 		/obj/item/ammo_box/magazine/greasegun = 2,
-		/obj/item/reagent_containers/pill/healingpowder = 2
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2
 	)
 
 /datum/outfit/loadout/eightiesshaman
@@ -1000,7 +1000,7 @@ Raider
 		/obj/item/clothing/under/f13/female/eighties = 1,
 		/obj/item/gun/ballistic/revolver/single_shotgun = 1,
 		/obj/item/ammo_box/shotgun/slug = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/storage/belt/utility/full = 1,
 		/obj/item/book/granter/crafting_recipe/tribal/eighties = 1
 	)
@@ -1027,7 +1027,7 @@ Raider
 		/obj/item/warpaint_bowl=1,
 		/obj/item/melee/onehanded/knife/ritualdagger = 1,
 		/obj/item/stack/medical/gauze/improvised = 1,
-		/obj/item/reagent_containers/pill/healingpowder = 1,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
 		/obj/item/book/granter/crafting_recipe/tribal/wayfarer = 1,
 	)
 
@@ -1040,7 +1040,7 @@ Raider
 		/obj/item/clothing/under/f13/female/rustwalkers = 1,
 		/obj/item/gun/ballistic/automatic/autopipe = 1,
 		/obj/item/ammo_box/magazine/autopipe = 2,
-		/obj/item/reagent_containers/pill/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/circular_saw = 1
 	)
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -433,7 +433,7 @@
 		if(item_type == "bag")
 			var/obj/item/reagent_containers/pill/patch/P
 			for(var/i = 0; i < amount; i++)
-				P = new/obj/item/reagent_containers/pill/healingpowder/custom(drop_location())
+				P = new/obj/item/reagent_containers/pill/patch/healingpowder/custom(drop_location())
 				P.name = trim("[name] powder")
 				adjust_item_drop_location(P)
 				reagents.trans_to(P, vol_each)//, transfered_by = usr)

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -72,7 +72,7 @@
 // ---------------------------------
 // HEALING POWDER
 
-/obj/item/reagent_containers/pill/healingpowder // 50hp over 50 seconds.
+/obj/item/reagent_containers/pill/patch/healingpowder // 50hp over 50 seconds.
 	name = "Healing powder"
 	desc = "A powder used to heal physical wounds derived from ground broc flowers and xander roots, commonly used by tribals."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
@@ -83,7 +83,7 @@
 // ---------------------------------
 // CUSTOM POWDER
 
-/obj/item/reagent_containers/pill/healingpowder/custom
+/obj/item/reagent_containers/pill/patch/healingpowder/custom
 	name = "Homebrew powder"
 	desc = "A mysterious mix of powders."
 	list_reagents = null


### PR DESCRIPTION
## About The Pull Request
Title.

## Changelog
:cl:
fixes: Fixes healing powder by remaking it into a patch rather than pill only.
/:cl:
