### PR TITLE
Mine Salve is removed from chemistry and makeable

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -75,7 +75,6 @@
 	)
 
 	var/list/upgrade_reagents3 = list(
-		/datum/reagent/medicine/mine_salve,
 		/datum/reagent/toxin
 	)
 

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -62,6 +62,7 @@ datum/chemical_reaction/rezadone
 	required_reagents = list(/datum/reagent/medicine/salglu_solution = 2, /datum/reagent/consumable/baked_banana_peel = 1)
 	mob_react = FALSE
 
+/*
 /datum/chemical_reaction/mine_salve
 	name = "Miner's Salve"
 	id = /datum/reagent/medicine/mine_salve
@@ -73,6 +74,7 @@ datum/chemical_reaction/rezadone
 	id = "mine_salve_2"
 	results = list(/datum/reagent/medicine/mine_salve = 15)
 	required_reagents = list(/datum/reagent/toxin/plasma = 5, /datum/reagent/iron = 5, /datum/reagent/consumable/sugar = 1) // A sheet of plasma, a twinkie and a sheet of metal makes four of these
+*/
 
 /datum/chemical_reaction/synthflesh
 	name = "Synthflesh"


### PR DESCRIPTION
## About The Pull Request
Miner salve removal from chemistry + recipes. Only wy to get it from farming bascially

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
removal: miner salve chemistry and makeable on your own.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
