### PR TITLE
ERT Janitor loadout

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -568,6 +568,13 @@
 		/obj/item/stack/cable_coil
 		))
 
+/obj/item/storage/belt/janitor/full/PopulateContents()
+	new /obj/item/lightreplacer(src)
+	new /obj/item/reagent_containers/spray/cleaner(src)
+	new /obj/item/soap/nanotrasen(src)
+	new /obj/item/holosign_creator(src)
+	new /obj/item/melee/flyswatter(src)
+
 ////////////////
 /// Belts /////
 ///////////////

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -192,6 +192,26 @@
 		/obj/item/gun/energy/pulse/pistol/loyalpin=1,\
 		/obj/item/construction/rcd/combat=1)
 
+/datum/outfit/ert/janitor
+	name = "ERT Janitor"
+
+	id = /obj/item/card/id/debug
+	suit = /obj/item/clothing/suit/space/hardsuit/ert
+	back = /obj/item/storage/backpack/satchel
+	backpack_contents = list(/obj/item/storage/box/engineer=1,\
+		/obj/item/grenade/clusterbuster/cleaner = 1,
+		/obj/item/melee/baton/loaded = 1,
+		/obj/item/mop/advanced = 1,
+		/obj/item/reagent_containers/glass/bucket = 1,
+		/obj/item/storage/box/lights/mixed = 1,
+	)
+	belt = /obj/item/storage/belt/janitor
+	glasses = /obj/item/clothing/glasses/night
+	l_pocket = /obj/item/grenade/chem_grenade/cleaner
+	r_pocket = /obj/item/grenade/chem_grenade/cleaner
+	l_hand = /obj/item/storage/bag/trash/bluespace
+	r_hand = /obj/item/mop/advanced
+
 /datum/outfit/ert/greybois
 	name = "Emergency Assistant"
 


### PR DESCRIPTION
## About The Pull Request
Select loadout and you can select ert janitor. Basically for admins to select gear into janitor instead of regular janitor

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: ERT Janitor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
