### PR TITLE
New crates, brotherhood midwestern fatigues to loadout, adjustments price increase

### DIFF
--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -12,7 +12,7 @@
 /datum/supply_pack/emergency/vehicle
 	name = "Biker Gang Kit" //TUNNEL SNAKES OWN THIS TOWN
 	desc = "TUNNEL SNAKES OWN THIS TOWN. Contains an unbranded All Terrain Vehicle, two cans of spraypaint, and a complete gang outfit -- consists of black gloves, a menacing skull bandanna, and a SWEET leather overcoat!"
-	cost = 500000
+	cost = 1000000
 	contains = list(/obj/vehicle/ridden/atv,
 					/obj/item/key,
 					/obj/item/toy/crayon/spraycan,

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -157,7 +157,7 @@
 /datum/supply_pack/engineering/bsa
 	name = "Long-Tom Artillery Parts"
 	desc = "The pride of the United States Army. The legendary Long Tom Nuclear Artillery Cannon is a devastating feat of human engineering and testament to wartime determination. Highly advanced research is required for proper construction. "
-	cost = 900000
+	cost = 1000000
 	special = TRUE
 	contains = list(/obj/item/circuitboard/machine/bsa/front,
 					/obj/item/circuitboard/machine/bsa/middle,

--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -118,7 +118,7 @@
 /datum/supply_pack/misc/bicycle
 	name = "Bicycle"
 	desc = "Nanotrasen reminds all employees to never toy with powers outside their control."
-	cost = 1000000
+	cost = 10000000
 	contains = list(/obj/vehicle/ridden/bicycle)
 	crate_name = "Bicycle Crate"
 	crate_type = /obj/structure/closet/crate/large

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -21,24 +21,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// Meals ///////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
-/*
-/datum/supply_pack/organic/combomeal2
-	name = "Burger Combo #2"
-	desc = "We value our customers at the Greasy Griddle, so much so that we're willing to deliver -just for you.- This combo meal contains two burgers, a soda, fries, a toy, and some chicken nuggets."
-	cost = 3200
-	contains = list(/obj/item/reagent_containers/food/snacks/burger/bigbite,
-					/obj/item/reagent_containers/food/snacks/burger/cheese,
-					/obj/item/reagent_containers/food/snacks/fries,
-					/obj/item/reagent_containers/food/condiment/pack/ketchup,
-					/obj/item/reagent_containers/food/condiment/pack/ketchup,
-					/obj/item/reagent_containers/food/snacks/nugget,
-					/obj/item/reagent_containers/food/snacks/nugget,
-					/obj/item/reagent_containers/food/snacks/nugget,
-					/obj/item/reagent_containers/food/snacks/nugget,
-					/obj/effect/spawner/lootdrop/plush)
-	crate_name = "combo meal w/toy"
-	crate_type = /obj/structure/closet/crate/wooden
-*/
+
 /datum/supply_pack/organic/randomized/candy
 	name = "Candy Crate"
 	desc = "For people that have an insatiable sweet tooth! Has ten candies to be eaten up.."
@@ -83,26 +66,7 @@
 					/obj/item/storage/box/mre/menu3,
 					/obj/item/storage/box/mre/menu4/safe)
 	crate_name = "MRE crate (emergency rations)"
-/*
-/datum/supply_pack/organic/fiestatortilla
-	name = "Fiesta Crate"
-	desc = "Spice up the kitchen with this fiesta themed food order! Contains 8 tortilla based food items, as well as a sombrero, moustache, and cloak!"
-	cost = 2750
-	contains = list(/obj/item/clothing/head/sombrero,
-					/obj/item/clothing/suit/hooded/cloak/david,
-					/obj/item/clothing/mask/fakemoustache,
-					/obj/item/reagent_containers/food/snacks/taco,
-					/obj/item/reagent_containers/food/snacks/taco,
-					/obj/item/reagent_containers/food/snacks/taco/plain,
-					/obj/item/reagent_containers/food/snacks/taco/plain,
-					/obj/item/reagent_containers/food/snacks/enchiladas,
-					/obj/item/reagent_containers/food/snacks/enchiladas,
-					/obj/item/reagent_containers/food/snacks/carneburrito,
-					/obj/item/reagent_containers/food/snacks/cheesyburrito,
-					/obj/item/reagent_containers/glass/bottle/capsaicin,
-					/obj/item/reagent_containers/glass/bottle/capsaicin)
-	crate_name = "fiesta crate"
-*/
+
 /datum/supply_pack/organic/pizza
 	name = "Pizza Crate"
 	desc = "Best prices on this side of the wastes. All deliveries are guaranteed to be 99% rad-free!"
@@ -136,6 +100,90 @@
 	delivery. Please search all crates and manifests provided with the delivery and return the object if is located. The object resembles a standard <b>\[DATA EXPUNGED\]</b> and is to be \
 	considered <b>\[REDACTED\]</b> and returned at your leisure. Note that objects the anomaly produces are specifically attuned exactly to the individual opening the anomaly; regardless \
 	of species, the individual will find the object edible and it will taste great according to their personal definitions, which vary significantly based on person and species.")
+
+// Dots Diner reference, it is from F4 / F76. But it should work for now
+// https://fallout.fandom.com/wiki/Dot%27s_Diner 
+/datum/supply_pack/organic/randomized/burgersfries
+	name = "Dots Burgers & Fries crate"
+	desc = "For people who want quick bite and or even open up your own resturant, sponsored by Dot's Diner."
+	cost = 2500
+	num_contained = 7
+	contains = list(/obj/item/reagent_containers/food/snacks/burger/corgi,
+					/obj/item/reagent_containers/food/snacks/burger/plain,
+					/obj/item/reagent_containers/food/snacks/burger/fish,
+					/obj/item/reagent_containers/food/snacks/burger/tofu,
+					/obj/item/reagent_containers/food/snacks/burger/bearger,
+					/obj/item/reagent_containers/food/snacks/burger/brain,
+					/obj/item/reagent_containers/food/snacks/burger/bigbite,
+					/obj/item/reagent_containers/food/snacks/burger/fivealarm,
+					/obj/item/reagent_containers/food/snacks/burger/rat,
+					/obj/item/reagent_containers/food/snacks/burger/baseball,
+					/obj/item/reagent_containers/food/snacks/burger/baconburger,
+					/obj/item/reagent_containers/food/snacks/burger/soylent,
+					/obj/item/reagent_containers/food/snacks/burger/crab,
+					/obj/item/reagent_containers/food/snacks/burger/chicken,
+					/obj/item/reagent_containers/food/snacks/burger/cheese,
+					/obj/item/reagent_containers/food/snacks/fries,
+					/obj/item/reagent_containers/food/snacks/tatortot,
+					/obj/item/reagent_containers/food/snacks/cheesyfries,
+					/obj/item/reagent_containers/food/snacks/chilicheesefries)
+	crate_name = "burgers & fries crate"
+
+// Petró-Chico reference, it is referenced in F:NV. But someone could of ran with the name and had an diner or something among those lines, using it as a name.
+// https://fallout.fandom.com/wiki/Petr%C3%B3-Chico 
+/datum/supply_pack/organic/randomized/mexican
+	name = "Petró-Chicos food crate"
+	desc = "For people who want a quick bite of mexican food or to open up your own resturant, sponsored by Petró-Chico."
+	cost = 2500
+	num_contained = 7
+	contains = list(/obj/item/reagent_containers/food/snacks/burrito,
+					/obj/item/reagent_containers/food/snacks/cheesyburrito,
+					/obj/item/reagent_containers/food/snacks/carneburrito,
+					/obj/item/reagent_containers/food/snacks/fuegoburrito,
+					/obj/item/reagent_containers/food/snacks/nachos,
+					/obj/item/reagent_containers/food/snacks/cheesynachos,
+					/obj/item/reagent_containers/food/snacks/cubannachos,
+					/obj/item/reagent_containers/food/snacks/taco,
+					/obj/item/reagent_containers/food/snacks/taco/plain,
+					/obj/item/reagent_containers/food/snacks/chipsandsalsa,
+					/obj/item/reagent_containers/food/snacks/enchiladas)
+	crate_name = "Mexican food crate"
+
+// No Reference for this one.
+/datum/supply_pack/organic/randomized/seafood
+	name = "Seafood crate"
+	desc = "For people who want a quick bite of seafood or to open up your own resturant."
+	cost = 2500
+	num_contained = 10
+	contains = list(/obj/item/reagent_containers/food/snacks/fishmeat/salmon/cooked,
+					/obj/item/reagent_containers/food/snacks/fishmeat/crawdad/cooked,
+					/obj/item/reagent_containers/food/snacks/fishmeat/shrimp/cooked,
+					/obj/item/reagent_containers/food/snacks/fishing/lobster_deluxe,
+					/obj/item/reagent_containers/food/snacks/fishing/lobster_roll,
+					/obj/item/reagent_containers/food/snacks/fishfingers,
+					/obj/item/reagent_containers/food/snacks/fishandchips,
+					/obj/item/reagent_containers/food/snacks/fishfry,
+					/obj/item/reagent_containers/food/snacks/fishtaco,
+					/obj/item/reagent_containers/food/snacks/sushi_rice,
+					/obj/item/reagent_containers/food/snacks/tuna,
+					/obj/item/reagent_containers/food/snacks/sushie_basic,
+					/obj/item/reagent_containers/food/snacks/sushie_adv,
+					/obj/item/reagent_containers/food/snacks/sushie_pro,
+					/obj/item/reagent_containers/food/snacks/tobiko,
+					/obj/item/reagent_containers/food/snacks/riceball,
+					/obj/item/reagent_containers/food/snacks/sashimi,
+					/obj/item/reagent_containers/food/snacks/fishing_sushi/sake_sushi,
+					/obj/item/reagent_containers/food/snacks/fishing_sushi/sake_cookedsalmon,
+					/obj/item/reagent_containers/food/snacks/fishing_sushi/ebi_sushi,
+					/obj/item/reagent_containers/food/snacks/fishing_sushi/ikura_sushi,
+					/obj/item/reagent_containers/food/snacks/fishing_sushi/maguro_sushi,
+					/obj/item/reagent_containers/food/snacks/fishing_sushi/masago_sushi,
+					/obj/item/reagent_containers/food/snacks/vegetariansushiroll,
+					/obj/item/reagent_containers/food/snacks/vegetariansushislice,
+					/obj/item/reagent_containers/food/snacks/spicyfiletsushiroll,
+					/obj/item/reagent_containers/food/snacks/spicyfiletsushislice,
+					/obj/item/reagent_containers/food/snacks/springroll,
+					/obj/item/reagent_containers/food/snacks/customizable/sushi)
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Raw Ingredients /////////////////////////////////
@@ -350,7 +398,7 @@
 
 /datum/supply_pack/organic/exoticseeds
 	name = "Seeds Crate (Exotic)"
-	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including three replica-pod seeds and two mystery seeds!"
+	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including two mystery seeds!"
 	cost = 1500
 	contains = list(/obj/item/seeds/nettle,
 					/obj/item/seeds/plump,
@@ -376,7 +424,8 @@
 					/obj/item/seeds/mutfruit,
 					/obj/item/seeds/xander,
 					/obj/item/seeds/xander,
-					/obj/item/seeds/datura)
+					/obj/item/seeds/datura,
+					/obj/item/seeds/horsenettle)
 	crate_name = "wasteland seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
@@ -402,7 +451,7 @@
 /datum/supply_pack/organic/parrot
 	name = "Bird Crate"
 	desc = "Contains five expert telecommunication birds."
-	cost = 4000
+	cost = 500000
 	contains = list(/mob/living/simple_animal/parrot)
 	crate_name = "parrot crate"
 

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -107,7 +107,7 @@
 	name = "Dots Burgers & Fries crate"
 	desc = "For people who want quick bite and or even open up your own resturant, sponsored by Dot's Diner."
 	cost = 2500
-	num_contained = 7
+	num_contained = 10
 	contains = list(/obj/item/reagent_containers/food/snacks/burger/corgi,
 					/obj/item/reagent_containers/food/snacks/burger/plain,
 					/obj/item/reagent_containers/food/snacks/burger/fish,
@@ -135,7 +135,7 @@
 	name = "Petró-Chicos food crate"
 	desc = "For people who want a quick bite of mexican food or to open up your own resturant, sponsored by Petró-Chico."
 	cost = 2500
-	num_contained = 7
+	num_contained = 10
 	contains = list(/obj/item/reagent_containers/food/snacks/burrito,
 					/obj/item/reagent_containers/food/snacks/cheesyburrito,
 					/obj/item/reagent_containers/food/snacks/carneburrito,

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -166,7 +166,7 @@
 					/obj/item/tank/internals/air,
 					/obj/item/clothing/mask/gas)
 	crate_name = "sec hardsuit crate"
-*/
+
 /datum/supply_pack/security/securitybarriers
 	name = "Security Barrier Grenades"
 	desc = "Stem the tide with four pre-war riot grenades."
@@ -177,6 +177,7 @@
 	cost = 2000
 	crate_name = "security barriers crate"
 	can_private_buy = TRUE
+*/
 /*
 /datum/supply_pack/security/securityclothes
 	name = "Security Clothing Crate"
@@ -278,7 +279,7 @@
 /datum/supply_pack/security/traitbooks
 	name = "Technical manuals"
 	desc = "A box crammed full of manuals, for reading. SCAV issues, Guns and Ammo, how to operate chem-machines, it's all here! Come in groups of three."
-	cost = 2200
+	cost = 2500
 	contains = list(/obj/effect/spawner/lootdrop/f13/traitbooks,
 					/obj/effect/spawner/lootdrop/f13/traitbooks/low,
 					/obj/effect/spawner/lootdrop/f13/traitbooks/low)
@@ -330,14 +331,14 @@
 /datum/supply_pack/security/gunsuperhightier
 	name = "Weapons - Prewar Gun"
 	desc = "A sealed crate of a Prewar firearm, an exceptional weapon machined with lost technology."
-	cost = 6250
+	cost = 10000
 	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh)
 	crate_name = "prewar gun crate"
 
 /datum/supply_pack/security/gunhightier
 	name = "Weapons - High-Tier Guns"
 	desc = "Two high-powered ballistics, perfect for taking down the meanest of muties."
-	cost = 3500
+	cost = 6250
 	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high)
 	crate_name = "gun crate"

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -678,6 +678,28 @@
 	restricted_desc = "KHAN"
 	restricted_roles = list("Great Khan")
 
+/// Brotherhood of Steel 
+
+/datum/gear/uniform/bos
+	name = "midwestern fatigues"
+	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_FACTIONS
+	path = /obj/item/clothing/under/syndicate/brotherhood/midwestern
+	restricted_desc = "BoS"
+	restricted_roles = list(
+							"Head Paladin",
+							"Knight-Captain",
+							"Head Scribe",
+							"Senior Paladin",
+							"Senior Knight",
+							"Senior Scribe",
+							"Paladin",
+							"Knight",
+							"Scribe",
+							"Initiate",
+							"Brotherhood Off-Duty"
+	)
+
+
 //Skirts
 
 /datum/gear/uniform/skirt/white


### PR DESCRIPTION
## About The Pull Request
Adds Petro chicos food crate which is mexican food, seafood crate, and dots burger and fries crate which is all almost all references to the game. Uncodes out security barrier grenade crates. 
Balances weapons pregun by 3000 more aka 10000, and high tier guns to 6250, as you might get a bozar in them. Adds another zero to bicycle crate, makes everything to 1000000, if it increases mobility or old station goal.
This PR removes burger combo, fiesta crate but makes it own crates.
Midwestern Fatigues to loadout menu, so you can be a midwestern fatigue wearing brotherhood person.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: three new crates.
remove: the old coded out food crates but replaces them with more lore like crates.
tweaks: cost in guns and books by a tad. Increases BSA prices, Bicycle and ATV.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
