### PR TITLE
Removes 'Gamer' Chems

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -172,7 +172,6 @@ SUBSYSTEM_DEF(research)
 	/obj/item/slimecross/industrial/pyrite         = list(TECHWEB_POINT_TYPE_GENERIC = 3000),
 	/obj/item/slimecross/industrial/red            = list(TECHWEB_POINT_TYPE_GENERIC = 3250),
 	/obj/item/slimecross/industrial/green          = list(TECHWEB_POINT_TYPE_GENERIC = 3250),
-	/obj/item/slimecross/industrial/pink           = list(TECHWEB_POINT_TYPE_GENERIC = 3250),
 	/obj/item/slimecross/industrial/gold           = list(TECHWEB_POINT_TYPE_GENERIC = 3250),
 	/obj/item/slimecross/industrial/oil            = list(TECHWEB_POINT_TYPE_GENERIC = 3500),
 	/obj/item/slimecross/industrial/black          = list(TECHWEB_POINT_TYPE_GENERIC = 3500),

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -61,7 +61,7 @@
 										/datum/reagent/medicine/leporazine, /datum/reagent/toxin/mindbreaker, /datum/reagent/medicine/corazone
 									),
 									list(	// level 8
-										/datum/reagent/pax, /datum/reagent/drug/happiness, /datum/reagent/medicine/ephedrine
+										/datum/reagent/drug/happiness, /datum/reagent/medicine/ephedrine
 									),
 									list(	// level 9
 										/datum/reagent/toxin/lipolicide, /datum/reagent/medicine/sal_acid

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -678,7 +678,7 @@ GLOBAL_LIST_INIT(brass_recipes, list ( \
 	throw_range = 3
 	turf_type = /turf/open/floor/clockwork
 	novariants = FALSE
-	grind_results = list(/datum/reagent/iron = 5, /datum/reagent/teslium = 15, /datum/reagent/fuel/holyoil = 1)
+	grind_results = list(/datum/reagent/iron = 5, /datum/reagent/fuel/holyoil = 1)
 	merge_type = /obj/item/stack/tile/brass
 	tableVariant = /obj/structure/table/reinforced/brass
 

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -36,7 +36,6 @@
 		/datum/reagent/toxin/mindbreaker,
 		/datum/reagent/toxin/rotatium,
 		/datum/reagent/bluespace,
-		/datum/reagent/pax,
 		/datum/reagent/consumable/laughter,
 		/datum/reagent/concentrated_barbers_aid,
 		/datum/reagent/baldium,

--- a/code/modules/fallout/reagents/alcohol.dm
+++ b/code/modules/fallout/reagents/alcohol.dm
@@ -856,7 +856,6 @@
 	else
 		if(ishuman(M))
 			if(prob(80))
-				M.vomit(10)
 				M.adjustToxLoss(4*REAGENTS_EFFECT_MULTIPLIER, 0)
 			..()
 

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -162,14 +162,6 @@
 	tastes = list("brains" = 1, "meat" = 1)
 	foodtype = RAW | MEAT | TOXIC
 
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ethereal
-	icon_state = "etherealmeat"
-	desc = "So shiny you feel like ingesting it might make you shine too"
-	filling_color = "#97ee63"
-	list_reagents = list(/datum/reagent/consumable/liquidelectricity = 3)
-	tastes = list("pure electricity" = 2, "meat" = 1)
-	foodtype = RAW | MEAT | TOXIC
-
 /obj/item/reagent_containers/food/snacks/fishmeat/carp/aquatic
 	name = "fillet"
 	desc = "A fillet of one of the local water dwelling species."

--- a/code/modules/food_and_drinks/food/snacks_burgers.dm
+++ b/code/modules/food_and_drinks/food/snacks_burgers.dm
@@ -312,7 +312,7 @@
 	name = "empowered burger"
 	desc = "It's shockingly good, if you live off of electricity that is."
 	icon_state = "empoweredburger"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/consumable/liquidelectricity = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 8)
 	tastes = list("bun" = 2, "pure electricity" = 4)
 	foodtype = GRAIN | TOXIC
 

--- a/code/modules/food_and_drinks/food/snacks_soup.dm
+++ b/code/modules/food_and_drinks/food/snacks_soup.dm
@@ -247,7 +247,7 @@
 	name = "electron soup"
 	desc = "A gastronomic curiosity of ethereal origin. It is famed for the minature weather system formed over a properly prepared soup."
 	icon_state = "electronsoup"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
 	tastes = list("mushroom" = 1, "electrons" = 4, "shockingly good" = 1)
 	filling_color = "#CC2B52"
 	foodtype = VEGETABLES | TOXIC
@@ -256,8 +256,8 @@
 	name = "spiral soup"
 	desc = "The swirling of this soup is both frightening, and enticing."
 	icon_state = "spiral_soup"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity = 5, /datum/reagent/cryptobiolin = 10, /datum/reagent/toxin/rotatium = 10)
-	bonus_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/cryptobiolin = 15, /datum/reagent/toxin/rotatium = 15, /datum/reagent/consumable/liquidelectricity = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/cryptobiolin = 10, /datum/reagent/toxin/rotatium = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/cryptobiolin = 15, /datum/reagent/toxin/rotatium = 15)
 	tastes = list("the floor" = 1, "the ceiling" = 1, "regret" = 2)
 	filling_color = "#4476e2"
 	foodtype = GROSS | TOXIC | VEGETABLES

--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -97,7 +97,7 @@
 	name = "High-power energy bars"
 	icon_state = "energybar"
 	desc = "An energy bar with a lot of punch."
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity = 3)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
 	filling_color = "#97ee63"
 	tastes = list("pure electricity" = 3, "fitness" = 2)
 	foodtype = TOXIC

--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -948,7 +948,7 @@
 	name = "Catnip Tea"
 	id = /datum/reagent/consumable/catnip_tea
 	results = list(/datum/reagent/consumable/catnip_tea = 3)
-	required_reagents = list(/datum/reagent/consumable/tea = 5, /datum/reagent/pax/catnip = 2)
+	required_reagents = list(/datum/reagent/consumable/tea = 5)
 
 
 ////////////////////////////////////////// Race Base Drinks //////////////////////////////////////
@@ -987,7 +987,7 @@
 	name = "Bug Zapper"
 	id = /datum/reagent/consumable/ethanol/species_drink/bug_zapper
 	results = list(/datum/reagent/consumable/ethanol/species_drink/bug_zapper = 20) //Harder to make
-	required_reagents = list(/datum/reagent/consumable/lemonjuice = 10,  /datum/reagent/teslium = 1, /datum/reagent/copper = 10)
+	required_reagents = list(/datum/reagent/consumable/lemonjuice = 10, /datum/reagent/copper = 10)
 
 /datum/chemical_reaction/mush_crush
 	name = "Mush Crush"

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -40,7 +40,7 @@
 	plantname = "Poison-Berry Bush"
 	product = /obj/item/reagent_containers/food/snacks/grown/berries/poison
 	mutatelist = list(/obj/item/seeds/berry/death)
-	reagents_add = list(/datum/reagent/toxin/cyanide = 0.15, /datum/reagent/toxin/staminatoxin = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
+	reagents_add = list(/datum/reagent/toxin/cyanide = 0.15, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 10 // Mildly poisonous berries are common in reality
 
 /obj/item/reagent_containers/food/snacks/grown/berries/poison
@@ -66,7 +66,7 @@
 	lifespan = 30
 	potency = 50
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/toxin/coniine = 0.08, /datum/reagent/toxin/staminatoxin = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
+	reagents_add = list(/datum/reagent/toxin/coniine = 0.08, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 30
 
 /obj/item/reagent_containers/food/snacks/grown/berries/death

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -218,14 +218,13 @@
 	endurance = 8
 	yield = 4
 	growthstages = 2
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/reagent/liquidelectricity, /datum/plant_gene/trait/plant_type/carnivory)
+	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/plant_type/carnivory)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/seeds/chanterelle/jupitercup/Initialize(mapload, nogenes = FALSE)
 	. = ..()
 	if(!nogenes)
-		unset_mutability(/datum/plant_gene/reagent/liquidelectricity, PLANT_GENE_EXTRACTABLE)
 		unset_mutability(/datum/plant_gene/trait/plant_type/carnivory, PLANT_GENE_REMOVABLE)
 
 /obj/item/reagent_containers/food/snacks/grown/mushroom/jupitercup
@@ -300,7 +299,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap
 	genes = list(/datum/plant_gene/trait/glow/red, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/plant_type/fungal_metabolism)
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/teslium = 0.1, /datum/reagent/consumable/nutriment = 0.04)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04)
 	rarity = 30
 
 /obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap

--- a/code/modules/hydroponics/grown/peas.dm
+++ b/code/modules/hydroponics/grown/peas.dm
@@ -86,7 +86,7 @@
 	icon_grow = "worldpeas-grow"
 	icon_dead = "worldpeas-dead"
 	genes = list (/datum/plant_gene/trait/glow/blue)
-	reagents_add = list (/datum/reagent/pax = 0.1, /datum/reagent/drug/happiness = 0.1, /datum/reagent/consumable/nutriment = 0.15)
+	reagents_add = list (/datum/reagent/drug/happiness = 0.1, /datum/reagent/consumable/nutriment = 0.15)
 	rarity = 50 // This absolutely will make even the most hardened Syndicate Operators relax, and lay down their arms.
 
 

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -56,7 +56,7 @@
 	icon_harvest = "catnip-harvest"
 	icon_dead = "tea-dead"
 	product = /obj/item/reagent_containers/food/snacks/grown/tea/catnip
-	reagents_add = list(/datum/reagent/pax/catnip = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.06, /datum/reagent/toxin/teapowder = 0.3)
+	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.06, /datum/reagent/toxin/teapowder = 0.3)
 	rarity = 50
 
 /obj/item/reagent_containers/food/snacks/grown/tea/catnip
@@ -64,7 +64,7 @@
 	name = "Catnip buds"
 	icon_state = "catnip"
 	filling_color = "#4582B4"
-	grind_results = list(/datum/reagent/pax/catnip = 2, /datum/reagent/water = 1)
+	grind_results = list(/datum/reagent/water = 1)
 
 // Coffee
 /obj/item/seeds/coffee

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -165,12 +165,12 @@
 	name = "Polypyrylium Oligomers"
 	reagent_id = /datum/reagent/medicine/polypyr
 	rate = 0.15
-
+/*
 /datum/plant_gene/reagent/liquidelectricity
 	name = "Liquid Electricity"
 	reagent_id = /datum/reagent/consumable/liquidelectricity
 	rate = 0.1
-
+*/
 // Various traits affecting the product. Each must be somehow useful.
 /datum/plant_gene/trait
 	var/rate = 0.05

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -297,10 +297,10 @@
 
 			bleed_text += "!</B>\n"
 		msg += bleed_text.Join()
-
+/*
 	if(reagents.has_reagent(/datum/reagent/teslium))
 		msg += "[t_He] [t_is] emitting a gentle blue glow!\n"
-
+*/
 	if(islist(stun_absorption))
 		for(var/i in stun_absorption)
 			if(stun_absorption[i]["end_time"] > world.time && stun_absorption[i]["examine_message"])

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -6,10 +6,8 @@
 	attack_verb = "burn"
 	attack_sound = 'sound/weapons/etherealhit.ogg'
 	miss_sound = 'sound/weapons/etherealmiss.ogg'
-	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ethereal
 	mutantstomach = /obj/item/organ/stomach/ethereal
 	mutanttongue = /obj/item/organ/tongue/ethereal
-	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
 	attack_type = BURN //burn bish

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -212,7 +212,6 @@
 	create_reagents(45, OPENCONTAINER)
 	reagents.add_reagent(/datum/reagent/toxin/chloralhydrate, 20)
 	reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 15)
-	reagents.add_reagent(/datum/reagent/toxin/staminatoxin, 10)
 
 /*
  * (Alan) Edaggers

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -877,7 +877,7 @@
 		M.adjustFireLoss(-1*REM, 0)
 		. = TRUE
 	..()
-
+/*
 /datum/reagent/consumable/liquidelectricity
 	name = "Liquid Electricity"
 	description = "The blood of Ethereals, and the stuff that keeps them going. Great for them, horrid for anyone else."
@@ -898,7 +898,7 @@
 		M.electrocute_act(rand(10,15), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
 		playsound(M, "sparks", 50, TRUE)
 	return ..()
-
+*/
 /datum/reagent/consumable/astrotame
 	name = "Astrotame"
 	description = "A space age artifical sweetener."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2338,7 +2338,7 @@
 	description = "blue sparkles that get everywhere"
 	color = "#4040FF" //A blueish color
 	glitter_type = /obj/effect/decal/cleanable/glitter/blue
-
+/*
 /datum/reagent/pax
 	name = "pax"
 	description = "A colorless liquid that suppresses violence on the subjects."
@@ -2357,7 +2357,7 @@
 /datum/reagent/pax/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_PACIFISM, type)
 	..()
-
+*/
 /datum/reagent/bz_metabolites
 	name = "BZ metabolites"
 	description = "A harmless metabolite of BZ gas"
@@ -2381,14 +2381,14 @@
 		if(changeling)
 			changeling.chem_charges = max(changeling.chem_charges-2, 0)
 	return ..()
-
+/*
 /datum/reagent/pax/peaceborg
 	name = "synth-pax"
 	description = "A colorless liquid that suppresses violence on the subjects. Cheaper to synthetize, but wears out faster than normal Pax."
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE
-
+*/
 /datum/reagent/peaceborg_confuse
 	name = "Dizzying Solution"
 	description = "Makes the target off balance and dizzy"
@@ -2471,14 +2471,14 @@
 	color = "#BCC740" //RGB: 188, 199, 64
 	taste_description = "plant dust"
 	ghoulfriendly = TRUE
-
+/*
 /datum/reagent/pax/catnip
 	name = "catnip"
 	taste_description = "grass"
 	description = "A colorless liquid that makes people more peaceful and felines more happy."
 	metabolization_rate = 1.75 * REAGENTS_METABOLISM
 	value = REAGENT_VALUE_COMMON
-
+*/
 /datum/reagent/preservahyde
 	name = "Preservahyde"
 	description = "A powerful preservation agent, utilizing the preservative effects of formaldehyde with significantly less of the histamine."

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -216,7 +216,7 @@
 		M.reagents.remove_reagent(/datum/reagent/oxygen, 0.5)
 		M.adjust_bodytemperature(15)
 	..()
-
+/*
 /datum/reagent/teslium //Teslium. Causes periodic shocks, and makes shocks against the target much more effective.
 	name = "Teslium"
 	description = "An unstable, electrically-charged metallic slurry. Periodically electrocutes its victim, and makes electrocutions against them more deadly. Excessively heating teslium results in dangerous destabilization. Do not allow to come into contact with water."
@@ -267,7 +267,7 @@
 			var/datum/species/jelly/luminescent/L = H.dna.species
 			L.extract_cooldown = max(0, L.extract_cooldown - 20)
 	..()
-
+*/
 /datum/reagent/firefighting_foam
 	name = "Firefighting Foam"
 	description = "A historical fire suppressant. Originally believed to simply displace oxygen to starve fires, it actually interferes with the combustion reaction itself. Vastly superior to the cheap water-based extinguishers found on NT vessels."

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -499,7 +499,7 @@
 /datum/reagent/toxin/mutetoxin/on_mob_life(mob/living/carbon/M)
 	M.silent = max(M.silent, 3)
 	..()
-
+/*
 /datum/reagent/toxin/staminatoxin
 	name = "Tirizene"
 	description = "A nonlethal poison that causes extreme fatigue and weakness in its victim."
@@ -513,7 +513,7 @@
 	data = max(data - 1, 5)
 	..()
 	. = 1
-
+*/
 /datum/reagent/toxin/polonium
 	name = "Polonium"
 	description = "An extremely radioactive material in liquid form. Ingestion results in fatal irradiation."

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -708,13 +708,13 @@
 	var/location = get_turf(holder.my_atom)
 	for(var/i in 1 to multiplier)
 		new /obj/item/stack/sheet/plastic(location)
-
+/*
 /datum/chemical_reaction/pax
 	name = "pax"
 	id = /datum/reagent/pax
 	results = list(/datum/reagent/pax = 3)
 	required_reagents  = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/water = 1)
-
+*/
 // TODO: Add some kind of ghoulification mutation toxin? Iunno.
 
 // Liquid Carpets

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -382,7 +382,7 @@
 /datum/chemical_reaction/pyrosium/on_reaction(datum/reagents/holder, multiplier)
 	holder.chem_temp = 20 // also cools the fuck down
 	return
-
+/*
 /datum/chemical_reaction/teslium
 	name = "Teslium"
 	id = /datum/reagent/teslium
@@ -434,7 +434,7 @@
 	id = "teslium_lightning2"
 	required_temp = 474
 	required_reagents = list(/datum/reagent/teslium = 1)
-
+*/
 /datum/chemical_reaction/reagent_explosion/nitrous_oxide
 	name = "N2O explosion"
 	id = "n2o_explosion"

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -105,7 +105,7 @@
 	name = "Rotatium"
 	id = /datum/reagent/toxin/rotatium
 	results = list(/datum/reagent/toxin/rotatium = 3)
-	required_reagents = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/teslium = 1, /datum/reagent/toxin/fentanyl = 1)
+	required_reagents = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/toxin/fentanyl = 1)
 	mix_message = span_danger("After sparks, fire, and the smell of mindbreaker, the mix is constantly spinning with no stop in sight.")
 
 /datum/chemical_reaction/skewium

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -247,14 +247,14 @@ Borg Shaker
 /obj/item/reagent_containers/borghypo/peace
 	name = "Peace Hypospray"
 
-	reagent_ids = list(/datum/reagent/peaceborg_confuse, /datum/reagent/peaceborg_tire, /datum/reagent/pax/peaceborg, /datum/reagent/medicine/insulin)
+	reagent_ids = list(/datum/reagent/peaceborg_confuse, /datum/reagent/peaceborg_tire, /datum/reagent/medicine/insulin)
 	accepts_reagent_upgrades = FALSE
 
 /obj/item/reagent_containers/borghypo/peace/hacked
 	desc = "Everything's peaceful in death!"
 	icon_state = "borghypo_s"
-	reagent_ids = list(/datum/reagent/peaceborg_confuse, /datum/reagent/peaceborg_tire, /datum/reagent/pax/peaceborg,
-					/datum/reagent/toxin/staminatoxin,/datum/reagent/toxin/sulfonal,/datum/reagent/toxin/sodium_thiopental,
+	reagent_ids = list(/datum/reagent/peaceborg_confuse, /datum/reagent/peaceborg_tire,
+					/datum/reagent/toxin/sulfonal,/datum/reagent/toxin/sodium_thiopental,
 					/datum/reagent/toxin/cyanide,/datum/reagent/toxin/fentanyl)
 	accepts_reagent_upgrades = FALSE
 

--- a/code/modules/research/xenobiology/crossbreeding/__corecross.dm
+++ b/code/modules/research/xenobiology/crossbreeding/__corecross.dm
@@ -115,13 +115,13 @@ To add a crossbreed:
 	desc = "A sphere of liquid blood, somehow managing to stay together."
 	color = "#FF0000"
 	list_reagents = list(/datum/reagent/blood = 50)
-
+/*
 /obj/item/slimecrossbeaker/pax //5u synthpax.
 	name = "peace-inducing extract"
 	desc = "A small blob of synthetic pax."
 	color = "#FFCCCC"
 	list_reagents = list(/datum/reagent/pax/peaceborg = 5)
-
+*/
 /obj/item/slimecrossbeaker/omnizine //15u omnizine.
 	name = "healing extract"
 	desc = "A gelatinous extract of pure omnizine."
@@ -169,7 +169,7 @@ To add a crossbreed:
 	desc = "A sphere of slime jelly. It seems to stick to your skin, but avoids other surfaces."
 	color = "#00FF00"
 	list_reagents = list(/datum/reagent/toxin/slimejelly = 50)
-
+/*
 /obj/item/slimecrossbeaker/autoinjector/peaceandlove
 	name = "peaceful distillation"
 	desc = "A light pink gooey sphere. Simply touching it makes you a little dizzy."
@@ -179,7 +179,7 @@ To add a crossbreed:
 /obj/item/slimecrossbeaker/autoinjector/peaceandlove/Initialize()
 	. = ..()
 	reagents.reagents_holder_flags = NONE // It won't be *that* easy to get your hands on pax.
-
+*/
 /obj/item/slimecrossbeaker/autoinjector/slimestimulant
 	name = "invigorating gel"
 	desc = "A bubbling purple mixture, designed to heal and boost movement."

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -221,7 +221,6 @@ Burning extracts:
 
 /obj/item/slimecross/burning/pink/do_effect(mob/user)
 	user.visible_message(span_notice("[src] shrinks into a small, gel-filled pellet!"))
-	new /obj/item/slimecrossbeaker/pax(get_turf(user))
 	..()
 
 /obj/item/slimecross/burning/gold
@@ -267,8 +266,6 @@ Burning extracts:
 
 /obj/item/slimecross/burning/lightpink/do_effect(mob/user)
 	user.visible_message(span_danger("[src] lets off a hypnotizing pink glow!"))
-	for(var/mob/living/carbon/C in view(7, get_turf(user)))
-		C.reagents.add_reagent(/datum/reagent/pax, 5)
 	..()
 
 /obj/item/slimecross/burning/adamantine

--- a/code/modules/research/xenobiology/crossbreeding/industrial.dm
+++ b/code/modules/research/xenobiology/crossbreeding/industrial.dm
@@ -140,11 +140,6 @@ Industrial extracts:
 	plasmarequired = 7
 	itempath = /obj/item/slimecrossbeaker/autoinjector/slimejelly
 
-/obj/item/slimecross/industrial/pink
-	colour = "pink"
-	plasmarequired = 6
-	itempath = /obj/item/slimecrossbeaker/autoinjector/peaceandlove
-
 /obj/item/slimecross/industrial/gold
 	colour = "gold"
 	plasmarequired = 10

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -348,8 +348,6 @@
 		if(SLIME_ACTIVATE_MAJOR)
 			user.visible_message(span_warning("[user]'s skin starts flashing hypnotically..."), span_notice("Your skin starts forming odd patterns, pacifying creatures around you."))
 			for(var/mob/living/carbon/C in viewers(user, null))
-				if(C != user)
-					C.reagents.add_reagent(/datum/reagent/pax,2)
 			return 600
 
 /obj/item/slime_extract/green


### PR DESCRIPTION
## About The Pull Request
Removes some of the stupid gamer-chems you can have in tomatoes. Such as Pax and the sort.

I do not want to re-live the Desert Rose 2 race for 'i want funny chem' to round end people. Admins do not wish to ban people for using intended features, others don't want a removal of intended features. Choose your side, western man.

## Changelog
:cl:
removes: Liquid electricity, teslium, tirizene, part of sludge code (vomit lock bullshit), and pax. More to come because people are uncontainable assholes.
/:cl:
