### PR TITLE
Uncringes barbed wire

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -111,7 +111,7 @@
 	INVOKE_ASYNC(H, /mob/living/carbon/human/.proc/apply_damage, damage, BRUTE, picked_def_zone, FALSE, FALSE, FALSE, CANT_WOUND)
 
 	if(!(flags & CALTROP_NOSTUN)) // Won't set off the paralysis.
-		H.Paralyze(60)
+		H.DefaultCombatKnockdown(60)
 
 	if(!soundfile)
 		return


### PR DESCRIPTION
## About The Pull Request
Makes barbed wire just knock down instead of paralyzing for 6 whooping seconds

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Barbed wire
/:cl: