### PR TITLE
Camp follower can make bitter, poultice and clothing, Mars teaching too,  loadout menu has clothing to camp follower / offduty

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1172,12 +1172,18 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	ADD_TRAIT(H, TRAIT_TRIBAL, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
+	ADD_TRAIT(H, TRAIT_MARS_TEACH, src)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legionshield)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/lever_action)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/grease_gun)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingshotgun)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tailor/legionuniform)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/xbow)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/cheaparrow)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/bitterdrink)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/bitterdrink5)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/healpoultice)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/healpoultice5)
 
 
 

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -699,6 +699,48 @@
 							"Brotherhood Off-Duty"
 	)
 
+/// Legion
+
+/datum/gear/uniform/legion
+	name = "camp follower male robe"
+	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_FACTIONS
+	path = /obj/item/clothing/under/f13/campfollowermale
+	restricted_desc = "Legion Camp Duties"
+	restricted_roles = list("Legion Off-Duty",
+							"Camp Follower"
+							)
+
+/datum/gear/uniform/legion/female
+	name = "camp follower female robe"
+	path = /obj/item/clothing/under/f13/campfollowerfemale
+	restricted_desc = "Legion Camp Duties"
+	restricted_roles = list("Legion Off-Duty",
+							"Camp Follower"
+							)
+
+/datum/gear/uniform/legion/auxilia
+	name = "male auxilia robes"
+	path = /obj/item/clothing/under/f13/legauxilia
+	restricted_desc = "Legion Camp Duties"
+	restricted_roles = list("Legion Off-Duty",
+							"Camp Follower"
+							)
+
+/datum/gear/uniform/legion/auxiliaf
+	name = "female auxilia robes"
+	path = /obj/item/clothing/under/f13/legauxiliaf
+	restricted_desc = "Legion Camp Duties"
+	restricted_roles = list("Legion Off-Duty",
+							"Camp Follower"
+							)
+
+/datum/gear/uniform/legion/roma
+	name = "roma auxilia robes"
+	path = /obj/item/clothing/under/f13/romaskirt/auxilia
+	restricted_desc = "Legion Camp Duties"
+	restricted_roles = list("Legion Off-Duty",
+							"Camp Follower"
+							)
 
 //Skirts
 


### PR DESCRIPTION
## About The Pull Request
basically makes the camp followers have bitter poultice, clothing and mars teaching and adding loadout menu with new clothing for camp followers offduties that were in the code but werent available with spawn in.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: bitters poultice and mars teaching.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
