### PR TITLE
Removes can Synth from FEV and Mutation Toxins

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -691,6 +691,7 @@
 									"You feel as though you're about to change at any moment!" = MUT_MSG_ABOUT2TURN)
 	var/mutationtext
 	var/cycles_to_turn = 20 //the current_cycle threshold / iterations needed before one can transform
+	can_synth = FALSE
 	ghoulfriendly = TRUE
 
 /datum/reagent/mutationtoxin/on_mob_life(mob/living/carbon/human/H)
@@ -927,6 +928,7 @@
 	taste_description = "slime"
 	value = REAGENT_VALUE_RARE
 	ghoulfriendly = TRUE
+	can_synth = FALSE
 
 /datum/reagent/mulligan/on_mob_life(mob/living/carbon/human/H)
 	..()
@@ -944,6 +946,7 @@
 	taste_description = "slime"
 	value = REAGENT_VALUE_VERY_RARE
 	ghoulfriendly = TRUE
+	can_synth = FALSE
 
 /datum/reagent/aslimetoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
 	if(method != TOUCH)
@@ -957,6 +960,7 @@
 	taste_description = "decay"
 	value = REAGENT_VALUE_GLORIOUS
 	ghoulfriendly = TRUE
+	can_synth = FALSE
 
 /datum/reagent/gluttonytoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
 	L.ForceContractDisease(new /datum/disease/transformation/morph(), FALSE, TRUE)
@@ -969,6 +973,7 @@
 	taste_description = "bitterness"
 	pH = 10
 	ghoulfriendly = TRUE
+	can_synth = FALSE
 
 /datum/reagent/serotrotium/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M))

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -41,6 +41,7 @@
 	overdose_threshold = 18 // So, someone drinking 20 units will FOR SURE get overdosed
 	taste_description = "horrific agony"
 	taste_mult = 0.9
+	can_synth = FALSE
 	var/datum/disease/fev_disease = /datum/disease/transformation/mutant
 
 /datum/reagent/toxin/FEV_solution/overdose_process(mob/living/carbon/C)
@@ -74,6 +75,8 @@
 	name = "FEV-II solution"
 	description = "A version of FEV that has been modified by radiation. It is suggested that only radiation-free humans use it."
 	fev_disease = /datum/disease/transformation/mutant/super
+	can_synth = FALSE
+
 
 /datum/reagent/toxin/FEV_solution/two/overdose_process(mob/living/carbon/C)
 	if(C.radiation < RAD_MOB_SAFE)


### PR DESCRIPTION
## About The Pull Request
No more funny lizards or somehow pulling FEV out of plants, well should be.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: cannot synth from FEV and mutation toxins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
