### PR TITLE
Timer

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -1,4 +1,6 @@
-#define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
+#define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day / 36000 == 1 hour
+#define OFFSET_GAME_TIMER		37300	//So timer loops to 0 once round starts
+#define OFFSET_INGAME_TIMER		216000 //So ingame timer starts around 6 AM / Starts around 7-8 hours due to delay between roundstart and game
 
 ///displays the current time into the round, with a lot of extra code just there for ensuring it looks okay after an entire day passes
 #define ROUND_TIME ( "[world.time - SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round(world.time - SSticker.round_start_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]" )
@@ -35,7 +37,7 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 */
 
 #define MONDAY		"Mon"
-#define TUESDAY	"Tue"
+#define TUESDAY		"Tue"
 #define WEDNESDAY	"Wed"
 #define THURSDAY	"Thu"
 #define FRIDAY		"Fri"

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -18,7 +18,7 @@ SUBSYSTEM_DEF(statpanels)
 			"Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]",
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
 			"Round Time: [ROUND_TIME]",
-			"Station Time: [STATION_TIME_TIMESTAMP(FALSE, world.time)]",
+			"In-game Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]",
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
 		)
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -46,7 +46,7 @@ SUBSYSTEM_DEF(ticker)
 	var/start_at
 
 	/// Deciseconds to add to world.time for station time.
-	var/gametime_offset = 216000
+	var/gametime_offset = OFFSET_INGAME_TIMER
 	var/station_time_rate_multiplier = 12		//factor of station time progressal vs real time.
 
 	var/totalPlayers = 0					//used for pregame stats on statpanel

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST(topic_status_cache)
 	if(CONFIG_GET(flag/usewhitelist))
 		load_whitelist()
 
-	GLOB.timezoneOffset = text2num(time2text(0,"hh")) + OFFSET_GAME_TIMER //WHY DO YOU EXIST //36000 = 1 hour
+	GLOB.timezoneOffset = text2num(time2text(0,"hh")) + OFFSET_GAME_TIMER //37300//So timer loops to 0 once round starts
 
 	if(fexists(RESTART_COUNTER_PATH))
 		GLOB.restart_counter = text2num(trim(file2text(RESTART_COUNTER_PATH)))

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST(topic_status_cache)
 	if(CONFIG_GET(flag/usewhitelist))
 		load_whitelist()
 
-	GLOB.timezoneOffset = text2num(time2text(0,"hh")) * 36000
+	GLOB.timezoneOffset = text2num(time2text(0,"hh")) + OFFSET_GAME_TIMER //WHY DO YOU EXIST //36000 = 1 hour
 
 	if(fexists(RESTART_COUNTER_PATH))
 		GLOB.restart_counter = text2num(trim(file2text(RESTART_COUNTER_PATH)))


### PR DESCRIPTION
## About The Pull Request
Makes it so round time actually starts at 0 due to some bad math (or near it depending on tickrate)
Makes it so INGAME timer actually works again and starts at 6 AM (due to delays it might reach 7 to 8 AM before game starts proper)

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
fix: In-game time not working
fix: Timers starting at wonky times
/:cl:
