### PR TITLE
Spraycan't (spraycannable armours fix*)

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -165,7 +165,7 @@
 			is_capped = !is_capped
 			to_chat(user, span_notice("The cap on [src] is now [is_capped ? "on" : "off"]."))
 			update_icon()
-			if(is_capped)
+			if(is_capped) // makes the item massive so it can spraypaint items with containers (bags, armour) at the cost of the inability to store the item when the cap is off. Blatently stolen from pen code.
 				w_class = WEIGHT_CLASS_TINY
 			else
 				w_class = WEIGHT_CLASS_GIGANTIC
@@ -248,7 +248,7 @@
 			if(has_cap)
 				is_capped = !is_capped
 				. = TRUE
-				if(is_capped)
+				if(is_capped) // Same as above, removing the cap makes it massive so it paints bags and armor with pockets instead of going inside. Stolen from pen code.
 					w_class = WEIGHT_CLASS_TINY
 				else
 					w_class = WEIGHT_CLASS_GIGANTIC

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -165,6 +165,10 @@
 			is_capped = !is_capped
 			to_chat(user, span_notice("The cap on [src] is now [is_capped ? "on" : "off"]."))
 			update_icon()
+			if(is_capped)
+				w_class = WEIGHT_CLASS_TINY
+			else
+				w_class = WEIGHT_CLASS_GIGANTIC
 
 /obj/item/toy/crayon/CtrlClick(mob/user)
 	if(can_change_colour && !isturf(loc) && user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
@@ -244,6 +248,10 @@
 			if(has_cap)
 				is_capped = !is_capped
 				. = TRUE
+				if(is_capped)
+					w_class = WEIGHT_CLASS_TINY
+				else
+					w_class = WEIGHT_CLASS_GIGANTIC
 		if("select_stencil")
 			var/stencil = params["item"]
 			if(stencil in all_drawables + randoms)


### PR DESCRIPTION
## About The Pull Request
Fixes spraycans unable to color containers and armor with pockets*

*Ports the (janky) measure pens use to bypass being put in the object you're trying to rename by making them gigantic when the cap is off.

It's stupid, It works, what can I say?

Video proof of function. Both the "toggle cap" UI button and alt-clicking work as intended.
[![Spraycan't](https://cdn.discordapp.com/attachments/1014004595950895106/1035277438218932295/unknown.png)](https://cdn.discordapp.com/attachments/596783387088388208/1035240233517711490/2022-10-27_13-04-55.mp4 "Spraycan't")

Pros: Can spraypaint funny t51b piss armor legion colors, amazing legion buff
Cons: Can't stick a spraycan in a bag when the cap is off as it sprays the bag itself. (Put the cap back on, dummy)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
add: Copied 2 lines of code
/:cl:
