### PR TITLE
Roof bugs + new building from wasteland + colormates for factions and store

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -605,6 +605,13 @@
 "aul" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"aun" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "auF" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
@@ -1113,6 +1120,13 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"aOj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/trophy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "aOp" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -6645,6 +6659,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"cuI" = (
+/obj/item/clothing/accessory/medal/bronze_heart{
+	name = "Purple Heart"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "cuK" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13{
@@ -12760,6 +12783,14 @@
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
+"hAO" = (
+/obj/structure/table,
+/obj/item/stack/spacecash/c20,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "hAW" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /obj/effect/decal/waste{
@@ -18655,6 +18686,13 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/museum)
+"mvB" = (
+/obj/item/lighter/gold,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "mvR" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19650,6 +19688,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"nlf" = (
+/obj/structure/table,
+/obj/item/stack/spacecash/c200,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "nlx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
@@ -19855,6 +19901,11 @@
 "nuB" = (
 /obj/structure/chair/sofa/right,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"nvo" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/simple_door/interior,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "nvA" = (
 /obj/effect/decal/cleanable/dirt{
@@ -21241,6 +21292,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/reactor)
+"oJZ" = (
+/obj/structure/table,
+/obj/item/stack/spacecash/c1,
+/obj/item/clothing/gloves/ring/silver,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "oKm" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/mineral/plastitanium,
@@ -21369,6 +21429,13 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"oPB" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/Biker,
+/obj/item/clothing/under/f13/Retro_Biker_Vest,
+/obj/item/clothing/head/fluff/Bikerhelmet,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oPJ" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -23296,6 +23363,12 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/caves)
+"qoi" = (
+/obj/structure/stairs/south{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qom" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -24012,6 +24085,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
+/area/f13/caves)
+"qQK" = (
+/obj/item/reagent_containers/food/drinks/trophy/silver_cup,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qRk" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -26550,6 +26627,10 @@
 /obj/structure/window/fulltile/wood_window,
 /turf/open/water,
 /area/f13/tunnel)
+"sYW" = (
+/obj/item/reagent_containers/food/drinks/trophy/bronze_cup,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sZg" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -28568,6 +28649,12 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"uEK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "uEV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -30113,6 +30200,13 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/water,
 /area/f13/caves)
+"vUm" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "vUS" = (
 /obj/structure/lattice{
 	layer = 3
@@ -31651,6 +31745,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"xjY" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/duffelbag,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/under/rank/civilian/util,
+/obj/item/clothing/mask/balaclava,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "xkd" = (
 /obj/item/storage/fancy/donut_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -75950,15 +76055,15 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
 aae
 aae
 aae
@@ -76207,15 +76312,15 @@ aae
 aak
 aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
+ajX
+uEK
+uEK
+aaB
+uEK
+cuI
+aaB
+uEK
+ajX
 aae
 aae
 aae
@@ -76464,15 +76569,15 @@ aak
 aak
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aak
+ajX
+xjY
+uEK
+qQK
+uEK
+uEK
+aun
+uEK
+ajX
 aae
 aaa
 aaa
@@ -76721,15 +76826,15 @@ aak
 aak
 aak
 aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
+ajX
+xjY
+vUm
+ajX
+mvB
+vUm
+ajX
+uEK
+ajX
 aae
 aaa
 dEX
@@ -76978,15 +77083,15 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+ajX
+xjY
+uEK
+uEK
+uEK
+uEK
+aaB
+uEK
+ajX
 aae
 aaa
 dEX
@@ -77235,15 +77340,15 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+ajX
+hAO
+uEK
+aOj
+uEK
+aaB
+sYW
+aaB
+ajX
 aae
 aaa
 dEX
@@ -77492,15 +77597,15 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+ajX
+nlf
+vUm
+ajX
+aaB
+jmO
+ajX
+nvo
+ajX
 aae
 aaa
 dEX
@@ -77749,15 +77854,15 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
+ajX
+oJZ
+uEK
+uEK
+aaB
+aaB
+ajX
+ehh
+ajX
 aae
 aaa
 dEX
@@ -78006,15 +78111,15 @@ aae
 aae
 aak
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+ajX
+uEK
+uEK
+uEK
+aaB
+qoi
+ajX
+oPB
+ajX
 aae
 aaa
 dEX
@@ -78263,15 +78368,15 @@ aae
 aae
 aak
 aak
-aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
 aae
 aaa
 dEX

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -431,6 +431,10 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"aoc" = (
+/obj/item/reagent_containers/food/drinks/trophy/silver_cup,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aon" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -605,13 +609,6 @@
 "aul" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"aun" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/caves)
 "auF" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
@@ -763,6 +760,15 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"aAn" = (
+/obj/structure/table,
+/obj/item/stack/spacecash/c1,
+/obj/item/clothing/gloves/ring/silver,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "aAF" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -1120,13 +1126,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"aOj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/trophy,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/caves)
 "aOp" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -6659,15 +6658,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"cuI" = (
-/obj/item/clothing/accessory/medal/bronze_heart{
-	name = "Purple Heart"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/caves)
 "cuK" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13{
@@ -7194,6 +7184,13 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"cRP" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "cSr" = (
 /obj/structure/closet,
 /obj/item/storage/box/gloves,
@@ -12588,6 +12585,13 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
+"hsH" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/Biker,
+/obj/item/clothing/under/f13/Retro_Biker_Vest,
+/obj/item/clothing/head/fluff/Bikerhelmet,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hsM" = (
 /obj/structure/wreck/trash/one_barrel,
 /turf/open/indestructible/ground/inside/subway,
@@ -12782,14 +12786,6 @@
 /obj/machinery/iv_drip,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
-"hAO" = (
-/obj/structure/table,
-/obj/item/stack/spacecash/c20,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
 /area/f13/caves)
 "hAW" = (
 /obj/structure/reagent_dispensers/barrel/old,
@@ -14535,6 +14531,12 @@
 /obj/item/clothing/under/f13/rag,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"iVx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "iVA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -18471,6 +18473,10 @@
 /obj/item/wrench/crude,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"mjy" = (
+/obj/item/clothing/accessory/medal/silver,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mjz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18686,13 +18692,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/museum)
-"mvB" = (
-/obj/item/lighter/gold,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/caves)
 "mvR" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19688,14 +19687,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"nlf" = (
-/obj/structure/table,
-/obj/item/stack/spacecash/c200,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/caves)
 "nlx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
@@ -19901,11 +19892,6 @@
 "nuB" = (
 /obj/structure/chair/sofa/right,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"nvo" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/simple_door/interior,
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "nvA" = (
 /obj/effect/decal/cleanable/dirt{
@@ -21217,6 +21203,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
+"oGZ" = (
+/obj/item/clothing/accessory/medal/bronze_heart{
+	name = "Purple Heart"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "oHI" = (
 /obj/structure/sign/departments/security,
 /obj/effect/decal/cleanable/dirt{
@@ -21292,15 +21287,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/reactor)
-"oJZ" = (
-/obj/structure/table,
-/obj/item/stack/spacecash/c1,
-/obj/item/clothing/gloves/ring/silver,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/caves)
 "oKm" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/mineral/plastitanium,
@@ -21429,13 +21415,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"oPB" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/Biker,
-/obj/item/clothing/under/f13/Retro_Biker_Vest,
-/obj/item/clothing/head/fluff/Bikerhelmet,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "oPJ" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -22033,6 +22012,15 @@
 "pqy" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
+"pqz" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/blacksmith/ingot/silver,
+/obj/item/blacksmith/ingot/silver,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "pqM" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/combat,
@@ -23363,12 +23351,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/caves)
-"qoi" = (
-/obj/structure/stairs/south{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "qom" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -24085,10 +24067,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
-"qQK" = (
-/obj/item/reagent_containers/food/drinks/trophy/silver_cup,
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qRk" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -24999,6 +24977,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"rJq" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/simple_door/interior,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rJB" = (
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
@@ -26252,6 +26235,13 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/caves)
+"sHE" = (
+/obj/item/lighter/gold,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "sHX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -26627,10 +26617,6 @@
 /obj/structure/window/fulltile/wood_window,
 /turf/open/water,
 /area/f13/tunnel)
-"sYW" = (
-/obj/item/reagent_containers/food/drinks/trophy/bronze_cup,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "sZg" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -26776,6 +26762,14 @@
 "tcm" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/bunker)
+"tcq" = (
+/obj/structure/table,
+/obj/item/stack/spacecash/c200,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "tcT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27256,6 +27250,10 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
+/area/f13/caves)
+"twd" = (
+/obj/item/reagent_containers/food/drinks/trophy/bronze_cup,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "twj" = (
 /obj/structure/nest/supermutant,
@@ -27807,6 +27805,17 @@
 /obj/structure/closet/secure_closet/brig,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"tWW" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/duffelbag,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/under/rank/civilian/util,
+/obj/item/clothing/mask/balaclava,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "tXz" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -28649,12 +28658,6 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"uEK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/caves)
 "uEV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -29521,6 +29524,12 @@
 	icon_state = "redmark"
 	},
 /area/f13/enclave)
+"vml" = (
+/obj/structure/stairs/south{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vmy" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -30199,13 +30208,6 @@
 /obj/structure/flora/rock/jungle,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/water,
-/area/f13/caves)
-"vUm" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
 /area/f13/caves)
 "vUS" = (
 /obj/structure/lattice{
@@ -31389,6 +31391,13 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"wTn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/trophy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "wTL" = (
 /obj/item/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -31745,17 +31754,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"xjY" = (
-/obj/structure/closet,
-/obj/item/storage/backpack/duffelbag,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/under/rank/civilian/util,
-/obj/item/clothing/mask/balaclava,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/caves)
 "xkd" = (
 /obj/item/storage/fancy/donut_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31857,6 +31855,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
+"xnn" = (
+/obj/structure/table,
+/obj/item/stack/spacecash/c20,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/caves)
 "xnq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -76313,13 +76319,13 @@ aak
 aak
 aae
 ajX
-uEK
-uEK
+iVx
+iVx
 aaB
-uEK
-cuI
+iVx
+oGZ
 aaB
-uEK
+iVx
 ajX
 aae
 aae
@@ -76570,13 +76576,13 @@ aak
 aae
 aae
 ajX
-xjY
-uEK
-qQK
-uEK
-uEK
-aun
-uEK
+tWW
+iVx
+aoc
+iVx
+iVx
+pqz
+iVx
 ajX
 aae
 aaa
@@ -76827,13 +76833,13 @@ aak
 aak
 aak
 ajX
-xjY
-vUm
+tWW
+cRP
 ajX
-mvB
-vUm
+sHE
+cRP
 ajX
-uEK
+iVx
 ajX
 aae
 aaa
@@ -77084,13 +77090,13 @@ aae
 aae
 aae
 ajX
-xjY
-uEK
-uEK
-uEK
-uEK
+tWW
+iVx
+iVx
+iVx
+iVx
 aaB
-uEK
+iVx
 ajX
 aae
 aaa
@@ -77341,12 +77347,12 @@ aae
 aae
 aae
 ajX
-hAO
-uEK
-aOj
-uEK
+xnn
+iVx
+wTn
+iVx
 aaB
-sYW
+twd
 aaB
 ajX
 aae
@@ -77598,13 +77604,13 @@ aae
 aae
 aae
 ajX
-nlf
-vUm
+tcq
+cRP
 ajX
-aaB
+mjy
 jmO
 ajX
-nvo
+rJq
 ajX
 aae
 aaa
@@ -77855,9 +77861,9 @@ aae
 aae
 aae
 ajX
-oJZ
-uEK
-uEK
+aAn
+iVx
+iVx
 aaB
 aaB
 ajX
@@ -78112,13 +78118,13 @@ aae
 aak
 aak
 ajX
-uEK
-uEK
-uEK
+iVx
+iVx
+iVx
 aaB
-qoi
+vml
 ajX
-oPB
+hsH
 ajX
 aae
 aaa

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -1314,6 +1314,13 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
+"cqC" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "cqK" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
@@ -4939,6 +4946,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/followers)
+"jGp" = (
+/obj/structure/table/wood/junk,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "jHg" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
@@ -10523,6 +10536,11 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"usZ" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "utH" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -10920,6 +10938,14 @@
 /obj/item/clothing/shoes/f13/military/ncr,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"vuk" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "vvS" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -11359,6 +11385,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/followers)
+"wkE" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "wmN" = (
 /obj/machinery/computer/card/legion,
 /turf/open/floor/f13/wood,
@@ -12403,6 +12435,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating/rust,
+/area/f13/wasteland)
+"yiT" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/wasteland)
 "ykR" = (
 /obj/item/chair/wood,
@@ -24850,7 +24890,7 @@ oez
 ojP
 ojP
 ojP
-ojP
+oez
 ojP
 ojP
 ojP
@@ -25106,12 +25146,12 @@ oez
 oez
 ojP
 ojP
+oez
+oez
 ojP
 ojP
 ojP
-ojP
-ojP
-ojP
+oez
 ojP
 ojP
 ojP
@@ -25361,17 +25401,17 @@ rLB
 oez
 oez
 oez
+ojP
+ojP
 oez
 oez
 oez
+ojP
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
+ojP
+ojP
 oez
 oez
 oez
@@ -25618,6 +25658,8 @@ rLB
 oez
 oez
 oez
+ojP
+ojP
 oez
 oez
 oez
@@ -25625,10 +25667,8 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
+ojP
+ojP
 oez
 oez
 oez
@@ -25875,17 +25915,17 @@ rLB
 oez
 oez
 oez
+ojP
+ojP
+ojP
+oez
+ojP
+ojP
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+ojP
+ojP
+ojP
 oez
 oez
 oez
@@ -26132,17 +26172,17 @@ rLB
 oez
 oez
 oez
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+ojP
+ojP
+ojP
+ojP
 oez
 oez
 oez
@@ -26389,17 +26429,17 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
 oez
 oez
 oez
@@ -26646,17 +26686,17 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
+ojP
 oez
 oez
 oez
@@ -55427,16 +55467,16 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+cqC
+wkE
+wkE
+jGp
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
 vqz
 vqz
 vqz
@@ -55684,16 +55724,16 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+wkE
+usZ
+usZ
+vuk
+usZ
+usZ
+usZ
+usZ
+vqz
+usZ
 vqz
 uMb
 xFD
@@ -55941,16 +55981,16 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+wkE
+yiT
+usZ
+usZ
+usZ
+usZ
+usZ
+vqz
+vqz
+usZ
 vqz
 bhm
 tnt
@@ -56198,16 +56238,16 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+wkE
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
+vqz
+usZ
+usZ
 vqz
 bhm
 wZD
@@ -56455,16 +56495,16 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+usZ
+usZ
+vqz
+vqz
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
 vqz
 bhm
 gah
@@ -56712,15 +56752,15 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+usZ
+usZ
 vqz
-vqz
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
 vqz
 vqz
 bhm
@@ -56969,15 +57009,15 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
+vqz
+vqz
+usZ
 vqz
 vqz
 bhm
@@ -57226,15 +57266,15 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+usZ
+usZ
+usZ
+usZ
+usZ
+vqz
+vqz
+usZ
+usZ
 vqz
 vqz
 bhm
@@ -57483,15 +57523,15 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
 vqz
 vqz
 bhm
@@ -57740,15 +57780,15 @@ oez
 oez
 oez
 oez
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
-gEk
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
+usZ
 vqz
 vqz
 bhm

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -562,6 +562,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
+"aYx" = (
+/obj/structure/table/wood/junk,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "aYz" = (
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -1314,13 +1320,6 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
-"cqC" = (
-/obj/structure/barricade/sandbags,
-/obj/structure/barricade/sandbags,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/wasteland)
 "cqK" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
@@ -2032,6 +2031,11 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/wood_common,
 /area/f13/building)
+"dJS" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "dLq" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -3411,6 +3415,14 @@
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"gMl" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "gMv" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -4946,12 +4958,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/followers)
-"jGp" = (
-/obj/structure/table/wood/junk,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/wasteland)
 "jHg" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
@@ -5894,6 +5900,14 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"lOV" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "lPf" = (
 /obj/structure/barricade/bars,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -9520,6 +9534,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"srz" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "ssY" = (
 /obj/structure/chair/f13chair1,
 /obj/machinery/light{
@@ -10536,11 +10557,6 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"usZ" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/wasteland)
 "utH" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -10665,6 +10681,12 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/khanfort)
+"uFV" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/wasteland)
 "uGj" = (
 /obj/structure/table,
 /obj/item/kirbyplants/random,
@@ -10938,14 +10960,6 @@
 /obj/item/clothing/shoes/f13/military/ncr,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"vuk" = (
-/obj/structure/chair/folding{
-	dir = 8
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/wasteland)
 "vvS" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -11385,12 +11399,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/followers)
-"wkE" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/wasteland)
 "wmN" = (
 /obj/machinery/computer/card/legion,
 /turf/open/floor/f13/wood,
@@ -12435,14 +12443,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating/rust,
-/area/f13/wasteland)
-"yiT" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
 /area/f13/wasteland)
 "ykR" = (
 /obj/item/chair/wood,
@@ -55467,16 +55467,16 @@ oez
 oez
 oez
 oez
-cqC
-wkE
-wkE
-jGp
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
+srz
+uFV
+uFV
+aYx
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
 vqz
 vqz
 vqz
@@ -55724,16 +55724,16 @@ oez
 oez
 oez
 oez
-wkE
-usZ
-usZ
-vuk
-usZ
-usZ
-usZ
-usZ
+uFV
+dJS
+dJS
+gMl
+dJS
+dJS
+dJS
+dJS
 vqz
-usZ
+dJS
 vqz
 uMb
 xFD
@@ -55981,16 +55981,16 @@ oez
 oez
 oez
 oez
-wkE
-yiT
-usZ
-usZ
-usZ
-usZ
-usZ
+uFV
+lOV
+dJS
+dJS
+dJS
+dJS
+dJS
 vqz
 vqz
-usZ
+dJS
 vqz
 bhm
 tnt
@@ -56238,16 +56238,16 @@ oez
 oez
 oez
 oez
-wkE
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
+uFV
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
 vqz
-usZ
-usZ
+dJS
+dJS
 vqz
 bhm
 wZD
@@ -56495,16 +56495,16 @@ oez
 oez
 oez
 oez
-usZ
-usZ
+dJS
+dJS
 vqz
 vqz
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
 vqz
 bhm
 gah
@@ -56752,15 +56752,15 @@ oez
 oez
 oez
 oez
-usZ
-usZ
+dJS
+dJS
 vqz
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
 vqz
 vqz
 bhm
@@ -57009,15 +57009,15 @@ oez
 oez
 oez
 oez
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
 vqz
 vqz
-usZ
+dJS
 vqz
 vqz
 bhm
@@ -57266,15 +57266,15 @@ oez
 oez
 oez
 oez
-usZ
-usZ
-usZ
-usZ
-usZ
+dJS
+dJS
+dJS
+dJS
+dJS
 vqz
 vqz
-usZ
-usZ
+dJS
+dJS
 vqz
 vqz
 bhm
@@ -57523,15 +57523,15 @@ oez
 oez
 oez
 oez
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
 vqz
 vqz
 bhm
@@ -57780,15 +57780,15 @@ oez
 oez
 oez
 oez
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
-usZ
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
+dJS
 vqz
 vqz
 bhm

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -1483,6 +1483,7 @@
 	dir = 1;
 	light_color = "#706891"
 	},
+/obj/item/circuitboard/machine/colormate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "agt" = (
@@ -18015,6 +18016,7 @@
 	pixel_y = -24
 	},
 /obj/structure/rack,
+/obj/item/circuitboard/machine/colormate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "bwN" = (
@@ -20048,6 +20050,7 @@
 /obj/item/clothing/mask/gas/explorer,
 /obj/item/clothing/mask/vape,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/item/circuitboard/machine/colormate,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "cjC" = (
@@ -45416,9 +45419,7 @@
 /area/f13/building)
 "nzi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/attachments{
-	icon_state = "weapon_idle"
-	},
+/obj/machinery/gear_painter,
 /turf/open/floor/f13{
 	icon_state = "yellowrustychess"
 	},
@@ -50565,7 +50566,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "pUJ" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/mineral/wasteland_vendor/attachments{
+	icon_state = "weapon_idle"
+	},
 /turf/open/floor/f13{
 	icon_state = "yellowrustychess"
 	},
@@ -61545,6 +61548,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/building)
+"vlu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/shelf_wood,
+/obj/item/circuitboard/machine/colormate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/legion)
 "vlI" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -92671,7 +92682,7 @@ mHp
 imF
 ahQ
 hEG
-ean
+ctp
 oDk
 kml
 kml
@@ -127963,7 +127974,7 @@ vLg
 dhs
 cFL
 qXa
-wfv
+vlu
 eYC
 wfv
 eYC

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -370,11 +370,10 @@
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
 "abF" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/turf/open/floor/carpet,
 /area/f13/village)
 "abG" = (
 /obj/structure/bed/mattress/pregame,
@@ -3486,6 +3485,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
+"aoa" = (
+/obj/structure/stairs/west{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain1"
+	},
+/area/f13/wasteland)
 "aob" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -6459,9 +6466,9 @@
 	},
 /area/f13/village)
 "azm" = (
-/obj/structure/window/fulltile/house,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
 	},
 /area/f13/village)
 "azn" = (
@@ -6591,6 +6598,7 @@
 	color = "#5c131b";
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -6696,14 +6704,16 @@
 	},
 /area/f13/wasteland)
 "aAc" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/snacks/f13/fancylads,
+/obj/item/reagent_containers/food/snacks/f13/dandyapples,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/village)
 "aAd" = (
+/obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -6730,6 +6740,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -6841,6 +6852,7 @@
 	pixel_x = 2;
 	pixel_y = -3
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -6946,13 +6958,10 @@
 	},
 /area/f13/village)
 "aAT" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = -32
-	},
-/obj/structure/chair/folding{
+/obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -6966,7 +6975,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "aAW" = (
-/obj/structure/simple_door/house,
+/obj/structure/simple_door/interior,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -7169,10 +7179,14 @@
 	icon_state = "television";
 	name = "pre-war advertising television"
 	},
-/turf/open/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "aBD" = (
 /obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -7466,13 +7480,10 @@
 	},
 /area/f13/village)
 "aCB" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/obj/structure/closet/cabinet,
-/obj/item/clothing/gloves/f13/baseball,
-/obj/item/twohanded/baseball,
-/turf/open/floor/carpet,
 /area/f13/village)
 "aCC" = (
 /obj/machinery/light/small/broken{
@@ -7578,7 +7589,10 @@
 "aCV" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/brown,
-/turf/open/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "aCW" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -7592,7 +7606,10 @@
 /obj/item/stack/f13Cash/random/low{
 	pixel_y = -5
 	},
-/turf/open/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "aCY" = (
 /obj/structure/car/rubbish3,
@@ -17503,17 +17520,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
-"brU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/charcoal,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood1-broken"
-	},
-/area/f13/village)
 "brV" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -21417,8 +21423,18 @@
 	},
 /area/f13/wasteland)
 "cuG" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/wasteland)
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "cuI" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -21764,14 +21780,6 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"cBw" = (
-/obj/structure/stairs/west{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain1"
-	},
-/area/f13/wasteland)
 "cBB" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -24360,6 +24368,7 @@
 /area/f13/ncr)
 "dPz" = (
 /obj/structure/simple_door/interior,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -28561,14 +28570,6 @@
 	dir = 10
 	},
 /area/f13/building)
-"fKL" = (
-/obj/structure/table,
-/obj/machinery/light/small,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
 "fKU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28633,15 +28634,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building/khanfort)
-"fNo" = (
-/obj/machinery/microwave/stove,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
 "fNp" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -31389,6 +31381,13 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/building/hospital)
+"haE" = (
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "haR" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -32059,15 +32058,6 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
-"huq" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = -32
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
 "huu" = (
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
@@ -33620,19 +33610,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"ihk" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = 32
-	},
-/obj/effect/overlay/junk/toilet{
-	dir = 4;
-	layer = 2.9
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/village)
 "ihs" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -33864,12 +33841,6 @@
 /mob/living/simple_animal/hostile/giantant,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
-"inn" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/f13/village)
 "inA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste{
@@ -33934,12 +33905,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
-"ioM" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
 "ioR" = (
 /obj/machinery/iv_drip,
 /obj/structure/decoration/clock/old/active{
@@ -34748,6 +34713,13 @@
 	color = "#e4e4e4"
 	},
 /area/f13/legion)
+"iFm" = (
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "iFp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -37804,6 +37776,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/massfusion)
+"kbX" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "kbY" = (
 /obj/machinery/light/small/broken,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -39451,6 +39431,7 @@
 	pixel_x = -26;
 	pixel_y = -4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -39780,13 +39761,6 @@
 	name = "tile"
 	},
 /area/f13/building)
-"kYD" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
 "kYR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderlefttop"
@@ -40096,6 +40070,15 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"lgb" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "lgg" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -40285,6 +40268,20 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
+"llf" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/effect/overlay/junk/toilet{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/village)
 "llo" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/wood_fancy,
@@ -42107,6 +42104,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
+	},
+/area/f13/wasteland)
+"lZT" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland)
 "lZY" = (
@@ -43971,6 +43977,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mRp" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/charcoal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/village)
 "mRq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -44187,9 +44205,11 @@
 	},
 /area/f13/wasteland)
 "mWt" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/snacks/f13/fancylads,
-/obj/item/reagent_containers/food/snacks/f13/dandyapples,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -48852,25 +48872,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"piZ" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	desc = "A RobCo Industries terminal, this one looks well worn with a few keys missing or loose.";
-	doc_content_1 = "My therapist told me to start keeping a journal, so here I am. My name's Greg, and I steal from people. Not proud of it, but I've got to make ends meet. Alimony to pay and my son to look after. Last robbery went alright, lots of antique silverware and medals to melt down. I know a guy in town.";
-	doc_content_2 = "Tom's birthday is coming up, and I'm struggling to figure out how to connect with him. He's getting in those teenage years, and all distant. I'm worried I don't make good memories now, he'll just resent me. Maybe I can take him to the range, show him how to fire his old man's battle rifle.";
-	doc_content_3 = "Me and the crew are having harder times hitting houses, with all the police and national guard around. Almost got caught last night, I'll be damned if that didn't put my balls in my throat. Might be time to get out of town, but the only problem is Sharon. She won't let go of Tom so easily.";
-	doc_content_4 = "those bastards did it, they finally did it. i'm grabbing tom and getting out of here. she won't stop me.";
-	doc_title_1 = "Journal 1";
-	doc_title_2 = "Journal 2";
-	doc_title_3 = "Journal 3";
-	doc_title_4 = "jesus christ";
-	name = "battered terminal";
-	termtag = "Greg Blunderson"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
 "pjl" = (
 /mob/living/simple_animal/hostile/cazador/young,
 /turf/open/indestructible/ground/outside/dirt{
@@ -50416,6 +50417,15 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
+"pRo" = (
+/obj/structure/table,
+/obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "pRr" = (
 /obj/structure/closet/crate/miningcar,
 /turf/open/indestructible/ground/outside/dirt{
@@ -50811,6 +50821,16 @@
 	},
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
+"qcY" = (
+/obj/machinery/microwave/stove,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "qdr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -51875,15 +51895,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/khanfort)
-"qDz" = (
-/obj/structure/chair/folding{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2right"
-	},
-/area/f13/wasteland)
 "qDT" = (
 /mob/living/simple_animal/opossum,
 /turf/open/water,
@@ -52348,6 +52359,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"qOJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/village)
 "qOU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -55362,12 +55379,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/city)
-"spd" = (
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/village)
 "spe" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -56208,7 +56219,24 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "sNu" = (
-/turf/open/floor/carpet,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	desc = "A RobCo Industries terminal, this one looks well worn with a few keys missing or loose.";
+	doc_content_1 = "My therapist told me to start keeping a journal, so here I am. My name's Greg, and I steal from people. Not proud of it, but I've got to make ends meet. Alimony to pay and my son to look after. Last robbery went alright, lots of antique silverware and medals to melt down. I know a guy in town.";
+	doc_content_2 = "Tom's birthday is coming up, and I'm struggling to figure out how to connect with him. He's getting in those teenage years, and all distant. I'm worried I don't make good memories now, he'll just resent me. Maybe I can take him to the range, show him how to fire his old man's battle rifle.";
+	doc_content_3 = "Me and the crew are having harder times hitting houses, with all the police and national guard around. Almost got caught last night, I'll be damned if that didn't put my balls in my throat. Might be time to get out of town, but the only problem is Sharon. She won't let go of Tom so easily.";
+	doc_content_4 = "those bastards did it, they finally did it. i'm grabbing tom and getting out of here. she won't stop me.";
+	doc_title_1 = "Journal 1";
+	doc_title_2 = "Journal 2";
+	doc_title_3 = "Journal 3";
+	doc_title_4 = "jesus christ";
+	name = "battered terminal";
+	termtag = "Greg Blunderson"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "sND" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58330,6 +58358,19 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/firestation)
+"tKV" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/obj/structure/chair/folding{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "tLp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -58371,16 +58412,6 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
-"tMa" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = -32
-	},
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/carpet,
-/area/f13/village)
 "tMi" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -59078,10 +59109,6 @@
 /obj/structure/flora/bush,
 /turf/open/floor/grass,
 /area/f13/wasteland)
-"uaK" = (
-/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine,
-/turf/open/floor/carpet,
-/area/f13/village)
 "uaU" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water/running{
@@ -61835,6 +61862,18 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"vsh" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/cabinet,
+/obj/item/clothing/gloves/f13/baseball,
+/obj/item/twohanded/baseball,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "vsw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61853,7 +61892,10 @@
 /area/f13/building/massfusion)
 "vtv" = (
 /obj/machinery/light/small,
-/turf/open/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "vuk" = (
 /obj/effect/decal/cleanable/dirt{
@@ -65688,6 +65730,9 @@
 	},
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"xnu" = (
+/turf/closed/wall/f13/wood/interior,
 /area/f13/wasteland)
 "xnF" = (
 /obj/structure/car/rubbish4{
@@ -110542,7 +110587,7 @@ xOD
 tpP
 aQZ
 mHp
-qDz
+lZT
 igF
 fbb
 bFI
@@ -111060,13 +111105,13 @@ tRk
 ayn
 eWr
 aaQ
-piZ
-aAT
-huq
-aAf
-tMa
-abF
 sNu
+tKV
+mWt
+aAf
+cuG
+mWt
+aCB
 aCV
 aaQ
 hmz
@@ -111317,13 +111362,13 @@ tRk
 igF
 drC
 aaQ
-brU
-aAd
-aAd
-aAf
+mRp
 aCB
-sNu
-sNu
+aCB
+aAf
+vsh
+aCB
+aCB
 vtv
 aaQ
 vGC
@@ -111573,14 +111618,14 @@ mHp
 nvn
 igF
 hEG
+haE
+aCB
+aCB
+aCB
 aAW
-aAd
-aAd
-aAd
-ioM
-sNu
-sNu
-uaK
+aCB
+aCB
+iFm
 aCX
 aaQ
 hmz
@@ -111831,13 +111876,13 @@ tRk
 ayn
 hEG
 aaQ
-mWt
-taH
-fKL
+aAc
+abF
+pRo
 aAf
 aBC
-sNu
-inn
+aCB
+lgb
 aaQ
 aaQ
 hmz
@@ -112088,15 +112133,15 @@ tRk
 ayn
 eWr
 aaQ
-fNo
-aAd
-kYD
+qcY
+aCB
+kbX
 aAf
 aAf
-ioM
-cuG
+aAW
+xnu
 hEN
-cBw
+aoa
 hmz
 ijr
 afI
@@ -112350,8 +112395,8 @@ dPz
 aAf
 aAf
 aBD
-fwV
-aAd
+qOJ
+aCB
 aaQ
 vGC
 aCD
@@ -112601,14 +112646,14 @@ mHp
 aer
 aer
 gdZ
-azm
-ihk
-aCn
+aAd
+llf
+muZ
 kRn
 aAf
 aBD
-aAd
-aAd
+aCB
+aCB
 aCN
 hmz
 aCd
@@ -112858,14 +112903,14 @@ mHp
 nvn
 wDX
 hEG
-azm
+aAd
 azN
 aAh
 aAC
 aAf
-spd
-aAc
-taH
+azm
+aAT
+abF
 aCN
 vGC
 hmz

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -370,14 +370,11 @@
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
 "abF" = (
-/obj/machinery/light/small/broken{
-	dir = 4
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/carpet,
 /area/f13/village)
 "abG" = (
 /obj/structure/bed/mattress/pregame,
@@ -6462,11 +6459,10 @@
 	},
 /area/f13/village)
 "azm" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken"
+/obj/structure/window/fulltile/house,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/obj/structure/spacevine,
-/turf/open/floor/f13/wood,
 /area/f13/village)
 "azn" = (
 /obj/structure/simple_door/interior,
@@ -6591,9 +6587,13 @@
 	},
 /area/f13/building/hospital)
 "azN" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/f13/wood,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/village)
 "azO" = (
 /obj/structure/window/fulltile/house{
@@ -6696,15 +6696,17 @@
 	},
 /area/f13/wasteland)
 "aAc" = (
-/obj/structure/chair/comfy{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "aAd" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "aAe" = (
 /obj/machinery/vending/cola/random,
@@ -6725,11 +6727,12 @@
 	},
 /area/f13/wasteland)
 "aAh" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/village)
 "aAi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6829,17 +6832,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aAC" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 12
+/obj/effect/overlay/junk/shower{
+	dir = 8
 	},
-/obj/machinery/light/small/broken{
-	dir = 4
+/obj/structure/decoration/vent/rusty{
+	desc = "It's very old and rusty.";
+	name = "rusty grate";
+	pixel_x = 2;
+	pixel_y = -3
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/village)
 "aAD" = (
 /obj/effect/decal/cleanable/dirt{
@@ -6942,10 +6946,16 @@
 	},
 /area/f13/village)
 "aAT" = (
-/obj/structure/decoration/clock{
-	pixel_y = 21
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
 	},
-/turf/open/floor/f13/wood,
+/obj/structure/chair/folding{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "aAU" = (
 /obj/structure/chair,
@@ -6956,9 +6966,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "aAW" = (
-/obj/structure/bookcase,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/house,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "aAX" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -7152,16 +7163,19 @@
 /area/f13/village)
 "aBC" = (
 /obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
+/obj/structure/junk/small/tv{
+	desc = "Advertisements would've played on this tv before the bombs dropped.";
+	icon = 'icons/fallout/objects/decorations.dmi';
+	icon_state = "television";
+	name = "pre-war advertising television"
+	},
+/turf/open/floor/carpet,
 /area/f13/village)
 "aBD" = (
-/obj/item/bedsheet,
-/obj/structure/bed/old,
-/obj/item/stack/f13Cash/random/low{
-	pixel_y = -5
+/obj/structure/bookcase,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/village)
 "aBE" = (
 /obj/item/crafting/transistor,
@@ -7452,11 +7466,13 @@
 	},
 /area/f13/village)
 "aCB" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
 /obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood,
+/obj/item/clothing/gloves/f13/baseball,
+/obj/item/twohanded/baseball,
+/turf/open/floor/carpet,
 /area/f13/village)
 "aCC" = (
 /obj/machinery/light/small/broken{
@@ -7560,13 +7576,9 @@
 	},
 /area/f13/wasteland)
 "aCV" = (
-/obj/effect/overlay/junk/toilet{
-	dir = 4;
-	layer = 2.9
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/bed/old,
+/obj/item/bedsheet/brown,
+/turf/open/floor/carpet,
 /area/f13/village)
 "aCW" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -7575,14 +7587,12 @@
 	},
 /area/f13/village)
 "aCX" = (
-/obj/effect/overlay/junk/shower{
-	dir = 8
+/obj/structure/bed/old,
+/obj/item/bedsheet/brown,
+/obj/item/stack/f13Cash/random/low{
+	pixel_y = -5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/open/floor/carpet,
 /area/f13/village)
 "aCY" = (
 /obj/structure/car/rubbish3,
@@ -17493,6 +17503,17 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
+"brU" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/charcoal,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/village)
 "brV" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -21396,11 +21417,8 @@
 	},
 /area/f13/wasteland)
 "cuG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/wasteland)
 "cuI" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -21746,6 +21764,14 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"cBw" = (
+/obj/structure/stairs/west{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain1"
+	},
+/area/f13/wasteland)
 "cBB" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -24333,10 +24359,10 @@
 	},
 /area/f13/ncr)
 "dPz" = (
-/mob/living/simple_animal/hostile/ghoul,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/village)
 "dPQ" = (
 /obj/structure/railing/handrail{
@@ -28535,6 +28561,14 @@
 	dir = 10
 	},
 /area/f13/building)
+"fKL" = (
+/obj/structure/table,
+/obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "fKU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28599,6 +28633,15 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building/khanfort)
+"fNo" = (
+/obj/machinery/microwave/stove,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "fNp" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -32016,6 +32059,15 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"huq" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "huu" = (
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
@@ -33568,6 +33620,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"ihk" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/effect/overlay/junk/toilet{
+	dir = 4;
+	layer = 2.9
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/village)
 "ihs" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -33799,6 +33864,12 @@
 /mob/living/simple_animal/hostile/giantant,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
+"inn" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/f13/village)
 "inA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste{
@@ -33863,6 +33934,12 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
+"ioM" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "ioR" = (
 /obj/machinery/iv_drip,
 /obj/structure/decoration/clock/old/active{
@@ -39366,9 +39443,17 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "kRn" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/effect/overlay/junk/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/overlay/junk/mirror{
+	pixel_x = -26;
+	pixel_y = -4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/village)
 "kRx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39695,6 +39780,13 @@
 	name = "tile"
 	},
 /area/f13/building)
+"kYD" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "kYR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderlefttop"
@@ -44095,17 +44187,11 @@
 	},
 /area/f13/wasteland)
 "mWt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/snacks/f13/fancylads,
+/obj/item/reagent_containers/food/snacks/f13/dandyapples,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "mWv" = (
@@ -48766,6 +48852,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"piZ" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	desc = "A RobCo Industries terminal, this one looks well worn with a few keys missing or loose.";
+	doc_content_1 = "My therapist told me to start keeping a journal, so here I am. My name's Greg, and I steal from people. Not proud of it, but I've got to make ends meet. Alimony to pay and my son to look after. Last robbery went alright, lots of antique silverware and medals to melt down. I know a guy in town.";
+	doc_content_2 = "Tom's birthday is coming up, and I'm struggling to figure out how to connect with him. He's getting in those teenage years, and all distant. I'm worried I don't make good memories now, he'll just resent me. Maybe I can take him to the range, show him how to fire his old man's battle rifle.";
+	doc_content_3 = "Me and the crew are having harder times hitting houses, with all the police and national guard around. Almost got caught last night, I'll be damned if that didn't put my balls in my throat. Might be time to get out of town, but the only problem is Sharon. She won't let go of Tom so easily.";
+	doc_content_4 = "those bastards did it, they finally did it. i'm grabbing tom and getting out of here. she won't stop me.";
+	doc_title_1 = "Journal 1";
+	doc_title_2 = "Journal 2";
+	doc_title_3 = "Journal 3";
+	doc_title_4 = "jesus christ";
+	name = "battered terminal";
+	termtag = "Greg Blunderson"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/village)
 "pjl" = (
 /mob/living/simple_animal/hostile/cazador/young,
 /turf/open/indestructible/ground/outside/dirt{
@@ -51770,6 +51875,15 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/khanfort)
+"qDz" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2right"
+	},
+/area/f13/wasteland)
 "qDT" = (
 /mob/living/simple_animal/opossum,
 /turf/open/water,
@@ -55248,6 +55362,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/city)
+"spd" = (
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/village)
 "spe" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -56088,15 +56208,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "sNu" = (
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/open/floor/carpet,
 /area/f13/village)
 "sND" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58259,6 +58371,16 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
+"tMa" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/carpet,
+/area/f13/village)
 "tMi" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -58956,6 +59078,10 @@
 /obj/structure/flora/bush,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"uaK" = (
+/obj/item/reagent_containers/food/drinks/bottle/brown/greenwine,
+/turf/open/floor/carpet,
+/area/f13/village)
 "uaU" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water/running{
@@ -61726,12 +61852,8 @@
 	},
 /area/f13/building/massfusion)
 "vtv" = (
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/machinery/light/small,
+/turf/open/floor/carpet,
 /area/f13/village)
 "vuk" = (
 /obj/effect/decal/cleanable/dirt{
@@ -110420,7 +110542,7 @@ xOD
 tpP
 aQZ
 mHp
-rZe
+qDz
 igF
 fbb
 bFI
@@ -110682,13 +110804,13 @@ ayn
 hEG
 aaQ
 aaQ
-aaQ
+azO
+azO
 aaQ
 azO
 azO
 aaQ
-ixn
-ixn
+aaQ
 aaQ
 hmz
 hmz
@@ -110937,14 +111059,14 @@ rFj
 tRk
 ayn
 eWr
-azm
-oJz
-oJz
-azn
-oUj
-oUj
-azn
-mWt
+aaQ
+piZ
+aAT
+huq
+aAf
+tMa
+abF
+sNu
 aCV
 aaQ
 hmz
@@ -111194,13 +111316,13 @@ ojS
 tRk
 igF
 drC
-azn
-oJz
-aAc
+aaQ
+brU
+aAd
+aAd
 aAf
-aAT
-cvU
-aAf
+aCB
+sNu
 sNu
 vtv
 aaQ
@@ -111451,14 +111573,14 @@ mHp
 nvn
 igF
 hEG
-aWg
-oJz
+aAW
 aAd
-aAf
-aAU
-aBB
-aAf
-aPl
+aAd
+aAd
+ioM
+sNu
+sNu
+uaK
 aCX
 aaQ
 hmz
@@ -111709,15 +111831,15 @@ tRk
 ayn
 hEG
 aaQ
-fqn
-oJz
+mWt
+taH
+fKL
 aAf
-aHa
 aBC
+sNu
+inn
 aaQ
-oBY
-qpv
-ixn
+aaQ
 hmz
 ijr
 mRs
@@ -111965,16 +112087,16 @@ rFj
 tRk
 ayn
 eWr
-ixn
-azn
-aAf
-aAf
-aAf
-aAf
 aaQ
-vGC
-hmz
-hmz
+fNo
+aAd
+kYD
+aAf
+aAf
+ioM
+cuG
+hEN
+cBw
 hmz
 ijr
 afI
@@ -112223,14 +112345,14 @@ tRk
 ayn
 drC
 aaQ
-oJz
+aAf
 dPz
-aHA
-oUj
+aAf
+aAf
 aBD
+fwV
+aAd
 aaQ
-aaQ
-ixn
 vGC
 aCD
 ijr
@@ -112479,15 +112601,15 @@ mHp
 aer
 aer
 gdZ
-ixn
-aBW
-cvU
+azm
+ihk
+aCn
 kRn
-cuG
-aHA
 aAf
-aCB
-ixn
+aBD
+aAd
+aAd
+aCN
 hmz
 aCd
 ijr
@@ -112736,15 +112858,15 @@ mHp
 nvn
 wDX
 hEG
-ixn
+azm
 azN
 aAh
 aAC
-aAW
-oJz
-azn
-abF
-aaQ
+aAf
+spd
+aAc
+taH
+aCN
 vGC
 hmz
 ijr
@@ -112994,14 +113116,14 @@ wDX
 ayn
 hEG
 aaQ
-azO
-azO
 aaQ
 aaQ
-ixn
-ixn
 aaQ
 aaQ
+aCN
+aCN
+aCN
+aCN
 hmz
 hmz
 ijr


### PR DESCRIPTION
## About The Pull Request

So this PR adds in the one building that was north of followers, that was near three stories. Basement, Ground then top roof.
![image](https://user-images.githubusercontent.com/29418371/198853179-7d114f43-2a3e-4543-afe7-9ae3d2ee023b.png)
![image](https://user-images.githubusercontent.com/29418371/198853182-599fc604-5210-40d0-901d-ece60e0f09e3.png)
![image](https://user-images.githubusercontent.com/29418371/198853187-5617b61f-1c02-4b89-a8cc-14618d3f84cc.png)
![image](https://user-images.githubusercontent.com/29418371/198853197-208c1924-62fc-4196-a00a-d0230bea5a2c.png)
![image](https://user-images.githubusercontent.com/29418371/198853296-0ddb22c5-f48a-4826-aada-f5139033484f.png)
Building PR that the building came from is:
https://github.com/fortune13-ss13/thewasteland/pull/689
Also adds colormate circuits to factions and a public colormate to the store.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: roofs
add: new building replacing one of the older ones
add: colormate circuits to factions and public one for store.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
