### PR TITLE
Deafness trait + fixes the tribal traits you can select.

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -20,6 +20,21 @@
 	REMOVE_TRAIT(owner, TRAIT_MUTE, TRAUMA_TRAIT)
 	..()
 
+/datum/brain_trauma/severe/deaf
+	name = "Deaf"
+	desc = "Patient is completely unable to hear."
+	scan_desc = "extensive damage to the ears"
+	gain_text = span_warning("You forget how to hear!")
+	lose_text = span_notice("You suddenly remember how to hear.")
+
+/datum/brain_trauma/severe/deaf/on_gain()
+	ADD_TRAIT(owner, TRAIT_DEAF, TRAUMA_TRAIT)
+	..()
+
+/datum/brain_trauma/severe/deaf/on_lose()
+	REMOVE_TRAIT(owner, TRAIT_DEAF, TRAUMA_TRAIT)
+	..()
+
 /datum/brain_trauma/severe/aphasia
 	name = "Aphasia"
 	desc = "Patient is unable to speak or understand any language."

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -33,6 +33,51 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 	/datum/crafting_recipe/rocket_base,
 	/datum/crafting_recipe/strongrocket))
 
+GLOBAL_LIST_INIT(whitelegs_recipes, list(
+	/datum/crafting_recipe/tribalwar/whitelegs/lightarmour,
+	/datum/crafting_recipe/tribalwar/whitelegs/armour, 
+	/datum/crafting_recipe/tribalwar/whitelegs/garb, 
+	/datum/crafting_recipe/tribalwar/whitelegs/femalegarb, 
+	/datum/crafting_recipe/tribalwar/whitelegs/heavyarmour))
+
+GLOBAL_LIST_INIT(deadhorses_recipes, list(
+	/datum/crafting_recipe/tribalwar/deadhorses/lightarmour,
+	/datum/crafting_recipe/tribalwar/deadhorses/armour,
+	/datum/crafting_recipe/tribalwar/deadhorses/garb,
+	/datum/crafting_recipe/tribalwar/deadhorses/femalegarb,
+	/datum/crafting_recipe/tribalwar/deadhorses/heavyarmour))
+
+GLOBAL_LIST_INIT(sorrows_recipes, list(
+	/datum/crafting_recipe/tribalwar/sorrows/armour,
+	/datum/crafting_recipe/tribalwar/sorrows/garb,
+	/datum/crafting_recipe/tribalwar/sorrows/femalegarb,
+	/datum/crafting_recipe/tribalwar/sorrows/yaoguaigauntlet))
+
+GLOBAL_LIST_INIT(rustwalkers_recipes, list(
+	/datum/crafting_recipe/tribalwar/rustwalkers/lightarmour,
+	/datum/crafting_recipe/tribalwar/rustwalkers/armour,
+	/datum/crafting_recipe/tribalwar/rustwalkers/garb,
+	/datum/crafting_recipe/tribalwar/rustwalkers/femalegarb,
+	/datum/crafting_recipe/tribalwar/rustwalkers/heavyarmour))
+
+GLOBAL_LIST_INIT(eighties_recipes, list(
+	/datum/crafting_recipe/tribalwar/eighties/lightarmour,
+	/datum/crafting_recipe/tribalwar/eighties/armour,
+	/datum/crafting_recipe/tribalwar/eighties/garb,
+	/datum/crafting_recipe/tribalwar/eighties/femalegarb,
+	/datum/crafting_recipe/tribalwar/eighties/heavyarmour))
+
+GLOBAL_LIST_INIT(wayfarer_recipes, list(
+	/datum/crafting_recipe/tribalwar/lighttribe,
+	/datum/crafting_recipe/tribalwar/heavytribe,
+	/datum/crafting_recipe/warmace))
+
+GLOBAL_LIST_INIT(bone_dancer_recipes, list(
+	/datum/crafting_recipe/tribalwar/bone/lightarmour,
+	/datum/crafting_recipe/tribalwar/bone/armour, 
+	/datum/crafting_recipe/tribalwar/bone/heavyarmour,
+	/datum/crafting_recipe/tribalwar/bone/garb,
+	/datum/crafting_recipe/tribalwar/bone/helmet))
 
 //predominantly positive traits
 //this file is named weirdly so that positive traits are listed above negative ones
@@ -529,12 +574,17 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 /datum/quirk/whitelegstraditions/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.grant_language(/datum/language/whiteleg)
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.whitelegs_recipes
+
 
 /datum/quirk/whitelegstraditions/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		H.remove_language(/datum/language/whiteleg)
-
+	if(H)
+		H.mind.learned_recipes -= GLOB.whitelegs_recipes
 
 /datum/quirk/deadhorsestraditions
 	name = "Dead Horses traditions and language comprehension"
@@ -548,11 +598,18 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 /datum/quirk/deadhorsestraditions/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.grant_language(/datum/language/deadhorses)
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.deadhorses_recipes
+
 
 /datum/quirk/deadhorsestraditions/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		H.remove_language(/datum/language/deadhorses)
+	if(H)
+		H.mind.learned_recipes -= GLOB.deadhorses_recipes
+
 
 /datum/quirk/sorrowstraditions
 	name = "Sorrows traditions and language comprehension"
@@ -566,11 +623,16 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 /datum/quirk/sorrowstraditions/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.grant_language(/datum/language/sorrows)
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.sorrows_recipes
 
 /datum/quirk/sorrowstraditions/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		H.remove_language(/datum/language/sorrows)
+	if(H)
+		H.mind.learned_recipes -= GLOB.sorrows_recipes
 
 /datum/quirk/rustwalkerstraditions
 	name = "Rust Walkers traditions and language comprehension"
@@ -584,11 +646,17 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 /datum/quirk/rustwalkerstraditions/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.grant_language(/datum/language/german)
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.rustwalkers_recipes
+
 
 /datum/quirk/rustwalkerstraditions/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		H.remove_language(/datum/language/german)
+	if(H)
+		H.mind.learned_recipes -= GLOB.rustwalkers_recipes
 
 /datum/quirk/eightiestraditions
 	name = "Eighties traditions and language comprehension"
@@ -602,11 +670,17 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 /datum/quirk/eightiestraditions/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.grant_language(/datum/language/tribal)
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.eighties_recipes
 
 /datum/quirk/eightiestraditions/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		H.remove_language(/datum/language/tribal)
+	if(H)
+		H.mind.learned_recipes -= GLOB.eighties_recipes
+
 
 /datum/quirk/wayfarertraditions
 	name = "Wayfarer traditions and language comprehension"
@@ -620,11 +694,18 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 /datum/quirk/wayfarertraditions/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.grant_language(/datum/language/tribal)
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.wayfarer_recipes
+
 
 /datum/quirk/wayfarertraditions/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		H.remove_language(/datum/language/tribal)
+	if(H)
+		H.mind.learned_recipes -= GLOB.wayfarer_recipes
+
 
 /datum/quirk/bonedancertraditions
 	name = "Bone Dancer traditions and language comprehension"
@@ -638,8 +719,14 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 /datum/quirk/bonedancertraditions/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.grant_language(/datum/language/tribal)
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.bone_dancer_recipes
+
 
 /datum/quirk/bonedancertraditions/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		H.remove_language(/datum/language/tribal)
+	if(H)
+		H.mind.learned_recipes -= GLOB.bone_dancer_recipes

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1,3 +1,5 @@
+// Explosive / Chemistry Wiz
+
 GLOBAL_LIST_INIT(chemwhiz_recipes, list(
 	/datum/crafting_recipe/jet,
 	/datum/crafting_recipe/turbo,
@@ -32,6 +34,8 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 	/datum/crafting_recipe/explosive/shrapnelmine,
 	/datum/crafting_recipe/rocket_base,
 	/datum/crafting_recipe/strongrocket))
+
+/// Tribal globals
 
 GLOBAL_LIST_INIT(whitelegs_recipes, list(
 	/datum/crafting_recipe/tribalwar/whitelegs/lightarmour,

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -402,7 +402,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/deaf
 	name = "Deaf"
 	desc = "Due to some accident, medical condition or simply by explosion. You are simply completely unable to hear."
-	value = -2 // You are deaf.
+	value = -2 // You are deaf. Not a License to grief.
 	gain_text = span_danger("You find yourself unable to ear at all!")
 	lose_text = span_notice("You somehow can hear again, even the slight sound of the wind.")
 	medical_record_text = "Functionally deaf, patient is unable to hear."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -402,7 +402,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/deaf
 	name = "Deaf"
 	desc = "Due to some accident, medical condition or simply by explosion. You are simply completely unable to hear."
-	value = -2 // You are deaf. Not a License to grief.
+	value = -2 // You are deaf.
 	gain_text = span_danger("You find yourself unable to ear at all!")
 	lose_text = span_notice("You somehow can hear again, even the slight sound of the wind.")
 	medical_record_text = "Functionally deaf, patient is unable to hear."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -402,7 +402,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/deaf
 	name = "Deaf"
 	desc = "Due to some accident, medical condition or simply by explosion. You are simply completely unable to hear."
-	value = -2 // You are deaf
+	value = -2 // You are deaf.
 	gain_text = span_danger("You find yourself unable to ear at all!")
 	lose_text = span_notice("You somehow can hear again, even the slight sound of the wind.")
 	medical_record_text = "Functionally deaf, patient is unable to hear."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -402,7 +402,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/deaf
 	name = "Deaf"
 	desc = "Due to some accident, medical condition or simply by explosion. You are simply completely unable to hear."
-	value = -2 // You are deaf
+	value = -2 /// You are deaf
 	gain_text = span_danger("You find yourself unable to ear at all!")
 	lose_text = span_notice("You somehow can hear again, even the slight sound of the wind.")
 	medical_record_text = "Functionally deaf, patient is unable to hear."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -402,7 +402,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/deaf
 	name = "Deaf"
 	desc = "Due to some accident, medical condition or simply by explosion. You are simply completely unable to hear."
-	value = -2 /// You are deaf
+	value = -2 // You are deaf
 	gain_text = span_danger("You find yourself unable to ear at all!")
 	lose_text = span_notice("You somehow can hear again, even the slight sound of the wind.")
 	medical_record_text = "Functionally deaf, patient is unable to hear."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -399,6 +399,24 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 	var/mob/living/carbon/human/H = quirk_holder
 	H?.cure_trauma_type(mute, TRAUMA_RESILIENCE_ABSOLUTE)
 
+/datum/quirk/deaf
+	name = "Deaf"
+	desc = "Due to some accident, medical condition or simply by explosion. You are simply completely unable to hear."
+	value = -2 // You are deaf
+	gain_text = span_danger("You find yourself unable to ear at all!")
+	lose_text = span_notice("You somehow can hear again, even the slight sound of the wind.")
+	medical_record_text = "Functionally deaf, patient is unable to hear."
+
+/datum/quirk/deaf/post_add()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(/datum/brain_trauma/severe/deaf, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/deaf/remove()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H?.cure_trauma_type(/datum/brain_trauma/severe/deaf, TRAUMA_RESILIENCE_ABSOLUTE)
+
 /datum/quirk/unstable
 	name = "Unstable"
 	desc = "Due to past troubles, you are unable to recover your sanity if you lose it. Be very careful managing your mood!"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -402,7 +402,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/deaf
 	name = "Deaf"
 	desc = "Due to some accident, medical condition or simply by explosion. You are simply completely unable to hear."
-	value = -2 // You are deaf.
+	value = -2 // You are deaf. Not a license to grief.
 	gain_text = span_danger("You find yourself unable to ear at all!")
 	lose_text = span_notice("You somehow can hear again, even the slight sound of the wind.")
 	medical_record_text = "Functionally deaf, patient is unable to hear."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -518,8 +518,8 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 
 /datum/quirk/masked_mook/on_process()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/clothing/mask/gas/gasmask = H.get_item_by_slot(ITEM_SLOT_MASK)
-	if(istype(gasmask))
+	var/obj/item/clothing/mask/maskmask = H.get_item_by_slot(ITEM_SLOT_MASK)
+	if(istype(maskmask) && !istype(maskmask, /obj/item/clothing/mask/cigarette))
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook_incomplete)
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook)
 	else


### PR DESCRIPTION
## About The Pull Request
I can roleplay as a deaf person now.
So this PR adds deaf as a negative trait and also adds its as brain tramua, so you can be deaf if you die and get a tramua of it. This also adds it as a negative trait for -2 points. Which is 🙏 based in my opinion. This pr also fixes the tribal traits from the trait select menu which people been asking for.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: new negative trait!
tweak: tribal traits you select them now you get recipes finally.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
