### PR TITLE
Fixes the borked recipes

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -19434,13 +19434,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"bWj" = (
-/obj/machinery/vending/boozeomat{
-	density = 0;
-	pixel_x = -32
-	},
-/turf/closed/wall/f13/wood/interior,
-/area/f13/building)
 "bWl" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -84168,7 +84161,7 @@ dHQ
 xrr
 xrr
 aYc
-bWj
+aqQ
 xrr
 bfE
 whb

--- a/atombomb.dme
+++ b/atombomb.dme
@@ -3288,6 +3288,7 @@
 #include "code\modules\reagents\chemistry\reagents\other_reagents.dm"
 #include "code\modules\reagents\chemistry\reagents\pyrotechnic_reagents.dm"
 #include "code\modules\reagents\chemistry\reagents\toxin_reagents.dm"
+#include "code\modules\reagents\chemistry\recipes\chemrecipes-fallout.dm"
 #include "code\modules\reagents\chemistry\recipes\drugs.dm"
 #include "code\modules\reagents\chemistry\recipes\medicine.dm"
 #include "code\modules\reagents\chemistry\recipes\others.dm"

--- a/code/modules/food_and_drinks/recipes/drinks/drinks_fallout.dm
+++ b/code/modules/food_and_drinks/recipes/drinks/drinks_fallout.dm
@@ -353,7 +353,7 @@
 	name = "Battle Brew"
 	id = "bbrew"
 	results = list(/datum/reagent/consumable/ethanol/bbrew = 2)
-	required_reagents = list(/datum/reagent/medicine/medx = 1, /datum/reagent/consumable/ethanol/vodka = 1)
+	required_reagents = list(/datum/reagent/medicine/charcoal = 1, /datum/reagent/consumable/ethanol/vodka = 1) // Charcoal for right now, as we do have mutant cave fungus but not in game yet, just code.
 
 /datum/chemical_reaction/bbrew2
 	name = "Blackwater Brew"

--- a/code/modules/reagents/chemistry/recipes/chemrecipes-fallout.dm
+++ b/code/modules/reagents/chemistry/recipes/chemrecipes-fallout.dm
@@ -97,7 +97,7 @@
 	name = "Med-X"
 	id = /datum/reagent/medicine/medx
 	results = list(/datum/reagent/medicine/medx = 4)
-	required_reagents = list(/datum/reagent/drug/aranesp = 1, /datum/reagent/phenol = 1, /datum/reagent/drug/heroin = 1, /datum/reagent/medicine/stimpakimitation = 1)
+	required_reagents = list(/datum/reagent/drug/aranesp = 1, /datum/reagent/phenol = 1, /datum/reagent/drug/heroin = 1, /datum/reagent/medicine/stimpak = 1)
 	OptimalTempMin 		= 780
 	OptimalTempMax		= 821
 	ExplodeTemp			= 824


### PR DESCRIPTION
## About The Pull Request
This fixes fallout recipes, and adds charcoal instead of medx for battle brew currnetly until we have something else in place for it.


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: accidentally didnt enable the dmi for drugs and adds new thing for battlebrew.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
