### PR TITLE
fixes armor calcs

### DIFF
--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -529,9 +529,9 @@
 
 /// Should the modifier MULTiply or ADD the value?
 GLOBAL_LIST_INIT(armor_token_operation_legend, list(
-		"melee" = "MULT",
-		"bullet" = "MULT",
-		"laser" = "MULT",
+		"melee" = "ADD",
+		"bullet" = "ADD",
+		"laser" = "ADD",
 		"linemelee" = "ADD",
 		"linebullet" = "ADD",
 		"linelaser" = "ADD",


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
we have been getting reports that armor thickness has been performing over 10x as good as it actually should be
we have decided that use of expensive alien polymers in armor is not a sustainable cost especially not for wastelanders

NCR tradesmen are now strictly prohibited from selling these hyper-performing armor pieces to anyone in the area
your body may be filled with holes but our balance books are solid
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

fix: MULT -> ADD in armor define

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
