### PR TITLE
Brotherhood Armory + Medical + Kitchen + Secret Recipe around in kitchens

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -8041,11 +8041,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building/museum)
 "dyC" = (
-/obj/machinery/chem_dispenser,
 /obj/machinery/light{
 	dir = 4;
 	pixel_y = -16
 	},
+/obj/structure/table/glass,
+/obj/item/pda/chemist{
+	name = "Scribe-Chemist Pip-Boy 3000"
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/storage/box/medsprays,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/storage/bag/chemistry,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "dyM" = (
@@ -9126,7 +9133,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -22140,7 +22146,8 @@
 	},
 /area/f13/bunker)
 "owd" = (
-/obj/machinery/chem_master/advanced,
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "owp" = (
@@ -23981,14 +23988,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "pTW" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/item/storage/bag/chemistry{
-	pixel_x = -18
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "pTX" = (
@@ -24549,13 +24552,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "qnl" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/storage/box/medsprays,
-/obj/item/pda/chemist{
-	name = "Scribe-Chemist Pip-Boy 3000"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	pixel_y = 23;
@@ -24564,7 +24560,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/item/reagent_containers/dropper,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "qnL" = (
@@ -96551,7 +96547,7 @@ qEc
 qEc
 sqT
 aPE
-sGN
+pnU
 ens
 tVi
 woN

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -522,6 +522,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"apt" = (
+/obj/structure/guncase,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "apB" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -1215,6 +1224,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/vault)
+"aPE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/Knight,
+/obj/effect/landmark/start/f13/seniorknight,
+/obj/effect/landmark/start/f13/seniorpaladin,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "aPS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -1300,6 +1319,10 @@
 "aTZ" = (
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"aUc" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/medical)
 "aUl" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4345,7 +4368,6 @@
 /area/f13/tunnel)
 "bOA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
 /obj/item/clothing/under/f13/recon,
 /obj/item/clothing/under/f13/recon,
 /obj/item/clothing/under/f13/recon,
@@ -4357,6 +4379,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 6
 	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -4408,12 +4431,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bOH" = (
-/obj/structure/chair/f13foldupchair,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
 	},
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/operations)
 "bOI" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
@@ -6678,6 +6703,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "cpv" = (
@@ -7120,9 +7148,6 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "cDS" = (
-/obj/structure/closet/secure{
-	anchored = 1
-	},
 /obj/item/pda,
 /obj/item/pda,
 /obj/item/pda,
@@ -7134,6 +7159,7 @@
 /obj/item/pda,
 /obj/item/pda,
 /obj/item/book/granter/trait/pa_wear,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -8524,7 +8550,6 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "dRQ" = (
-/obj/structure/rack,
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/clothing/mask/gas/sechailer,
@@ -8634,6 +8659,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 10
 	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -9100,6 +9126,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -10056,10 +10083,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
-/obj/effect/landmark/start/f13/Knight,
-/obj/effect/landmark/start/f13/seniorknight,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/obj/effect/landmark/start/f13/initiate,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -10220,7 +10244,7 @@
 /area/f13/tunnel)
 "eYO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -10858,6 +10882,14 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"fzB" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "fAx" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway{
@@ -10934,12 +10966,12 @@
 	},
 /area/f13/vault)
 "fFh" = (
-/obj/structure/rack,
 /obj/item/clothing/suit/bomb_suit/security,
 /obj/item/clothing/head/bomb_hood/security,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -12289,7 +12321,9 @@
 /area/f13/bunker)
 "gIh" = (
 /obj/machinery/light/small,
-/obj/machinery/iv_drip,
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "gJb" = (
@@ -12441,8 +12475,8 @@
 	},
 /area/f13/enclave)
 "gPv" = (
-/obj/structure/rack,
 /obj/item/twohanded/sledgehammer/supersledge,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -13031,10 +13065,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/chair/f13foldupchair,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "hoq" = (
@@ -13264,13 +13298,13 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "hwW" = (
-/obj/structure/rack,
 /obj/item/shield/riot/bullet_proof,
 /obj/item/shield/riot/bullet_proof,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -15485,6 +15519,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"jjm" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/obj/item/paper_bin,
+/obj/item/pen/charcoal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/medical)
 "jkg" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -19188,6 +19231,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "mcp" = (
@@ -20171,7 +20216,7 @@
 	layer = 2.9
 	},
 /obj/machinery/cell_charger{
-	pixel_y = 6
+	pixel_y = 10
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
@@ -22341,8 +22386,8 @@
 /area/f13/tunnel)
 "oHS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
 /obj/machinery/light,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -24282,9 +24327,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/closet/crate/medical,
-/obj/item/storage/box/medicine/stimpaks/stimpaks5,
-/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "qhm" = (
@@ -24521,6 +24564,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "qnL" = (
@@ -24988,9 +25032,6 @@
 	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 10
 	},
 /obj/item/key/vertibird,
 /obj/item/storage/box/disks_plantgene,
@@ -25859,6 +25900,10 @@
 	dir = 9
 	},
 /area/f13/building/museum)
+"rpb" = (
+/obj/structure/closet/crate/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/medical)
 "rph" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -27583,7 +27628,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "sGN" = (
-/obj/structure/rack,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -29325,14 +29370,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "tZM" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "uap" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/darkpurple/side{
@@ -31711,6 +31759,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"vPk" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/medical)
 "vPp" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
@@ -32683,13 +32737,10 @@
 	},
 /area/f13/bunker)
 "wBu" = (
-/obj/structure/guncase,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -94463,7 +94514,7 @@ gjM
 nja
 jNn
 dRi
-tZM
+qCS
 coO
 fHe
 bTN
@@ -95998,7 +96049,7 @@ xVk
 mbX
 hcW
 lUj
-tuq
+rpb
 vAE
 bjs
 iIK
@@ -96242,15 +96293,15 @@ qqH
 qEc
 gsY
 dZK
-pom
+fzB
 eka
 jHi
-tVi
+bOH
 xGP
 iZv
 fFt
 eaj
-jRb
+jjm
 usd
 nNV
 nNV
@@ -96499,8 +96550,8 @@ sWp
 qEc
 qEc
 sqT
-pom
-pnU
+aPE
+sGN
 ens
 tVi
 woN
@@ -97013,7 +97064,7 @@ pom
 obp
 aob
 yir
-pom
+tZM
 pom
 eYO
 qEc
@@ -97269,8 +97320,8 @@ sxg
 sxg
 qEc
 qEc
-sGN
 pnU
+sGN
 pnU
 cDS
 mmH
@@ -97282,7 +97333,7 @@ lUj
 qhg
 nNV
 nNV
-rLw
+vPk
 pJr
 bOW
 hVv
@@ -97525,9 +97576,9 @@ fFt
 fFt
 gTC
 qEc
-jnc
+sGN
 pnU
-pnU
+sGN
 pnU
 sGN
 mmH
@@ -97784,7 +97835,7 @@ fFt
 qEc
 wBu
 pnU
-pnU
+sGN
 pnU
 oHS
 rQY
@@ -97793,7 +97844,7 @@ oYb
 oYb
 xYW
 iZb
-bOH
+clt
 nNV
 nNV
 nNV
@@ -98052,7 +98103,7 @@ nTq
 cpp
 bPH
 nNV
-nNV
+aUc
 rLw
 pJr
 bOW
@@ -98809,7 +98860,7 @@ jaC
 bWb
 irN
 pom
-pnU
+jnc
 iuf
 bOA
 hWl
@@ -99066,7 +99117,7 @@ jaC
 bWb
 irN
 pom
-pom
+apt
 iuf
 fFh
 pom

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -333,11 +333,13 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "axN" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/table/reinforced,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/leisure)
 "ayH" = (
 /obj/structure/chair/f13foldupchair{
 	desc = "A folding chair, missing half the seat, probably for dropping something through it.";
@@ -2609,6 +2611,7 @@
 /area/f13/building)
 "eGT" = (
 /obj/structure/table/wood,
+/obj/item/storage/bag/books,
 /turf/open/floor/carpet,
 /area/f13/brotherhood/offices1st)
 "eHj" = (
@@ -3337,6 +3340,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"gfo" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/tray,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "gfF" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -4636,6 +4646,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/city)
+"iKV" = (
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "iMF" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile/store{
@@ -5510,6 +5526,20 @@
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/vinegar,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/soysauce,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/quality_oil,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/peanut_butter,
+/obj/item/reagent_containers/food/condiment/mayonnaise,
+/obj/item/reagent_containers/food/condiment/ketchup,
+/obj/item/reagent_containers/food/condiment/honey,
+/obj/item/reagent_containers/food/condiment/cherryjelly,
+/obj/item/reagent_containers/food/condiment/bbqsauce,
+/obj/item/storage/fancy/egg_box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
 	icon_state = "tealwhrusty_chess2"
 	},
@@ -11559,6 +11589,14 @@
 	icon_state = "common-broken3"
 	},
 /area/f13/building)
+"vYa" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "vYm" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -12112,8 +12150,8 @@
 	color = "000000"
 	},
 /obj/structure/table/reinforced,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/knife,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
 	icon_state = "tealwhrusty_chess2"
 	},
@@ -12546,6 +12584,14 @@
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"xLD" = (
+/obj/machinery/light,
+/obj/structure/table/reinforced,
+/obj/item/paper/secretrecipe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "xLZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -45496,7 +45542,7 @@ qJn
 rvE
 eDW
 kvH
-rss
+gfo
 usy
 qJn
 vLb
@@ -45722,7 +45768,7 @@ laB
 "}
 (129,1,1) = {"
 laB
-axN
+dcJ
 gXj
 tOZ
 goc
@@ -46009,9 +46055,9 @@ kWA
 oAO
 wOT
 wOT
-usy
+axN
 wOT
-eiT
+usy
 qJn
 vLb
 vLb
@@ -46264,7 +46310,7 @@ kWA
 kWA
 wrx
 qJn
-wOT
+vYa
 wOT
 cde
 wOT
@@ -46523,9 +46569,9 @@ oLf
 qJn
 pVc
 wOT
-usy
+eiT
 wOT
-ndW
+xLD
 qJn
 vLb
 vLb
@@ -46782,7 +46828,7 @@ wUe
 wOT
 wOT
 wOT
-usy
+iKV
 qJn
 vLb
 vLb
@@ -47036,7 +47082,7 @@ kWA
 fKQ
 qJn
 qJn
-qJn
+rss
 qhk
 qhk
 qJn

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -16639,6 +16639,7 @@
 "bln" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
+/obj/item/paper/secretrecipe,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess/whiteredchess2,
 /area/f13/ncr)
 "blp" = (
@@ -17001,6 +17002,7 @@
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/paper/secretrecipe,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/legion)
 "bns" = (
@@ -19690,6 +19692,7 @@
 	req_one_access_txt = null
 	},
 /obj/item/book/granter/action/drink_fling,
+/obj/item/paper/secretrecipe,
 /turf/open/floor/wood_fancy/wood_fancy_dark{
 	icon_state = "fancy_dark-broken1"
 	},
@@ -32430,7 +32433,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
@@ -35685,6 +35687,7 @@
 	},
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife/butcher,
+/obj/item/paper/secretrecipe,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/khanfort)
 "iXT" = (
@@ -44564,7 +44567,7 @@
 /area/f13/building)
 "naO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/mineral/wasteland_trader/brotherhood,
+/obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nbb" = (


### PR DESCRIPTION
## About The Pull Request
Changes around the brotherhood base a tad bit.

![image](https://user-images.githubusercontent.com/29418371/201326363-2508ff74-1c27-49d9-8709-34cc785b41fb.png)
![image](https://user-images.githubusercontent.com/29418371/201327374-25861e11-3977-4173-8c59-25e29d134940.png)
Changed around the armory and medical of the brotherhood to where players have it a tad bit so less hassle on them and less totally reconstruction, and does a little organization on the brotherhood top kitchen, so its more open more or less. Secret recipes are around in everyones kitchen.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaks around armoy and medical and kitchen of BOS to be more friendly to others.
adds: secret recipes around kitchens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
