### PR TITLE
small upgrade to townsmen

### DIFF
--- a/code/modules/jobs/job_types/eastwood.dm
+++ b/code/modules/jobs/job_types/eastwood.dm
@@ -330,7 +330,9 @@ here's a tip, go search DEFINES/access.dm
 		/obj/item/toy/crayon/white=1,
 		/obj/item/detective_scanner=1,
 		/obj/item/storage/box/gloves=1,
-		/obj/item/storage/box/evidence=1)
+		/obj/item/storage/box/evidence=1
+		/obj/item/ammo_box/loader/m44=1
+		)
 
 /*--------------------------------------------------------------*/
 //Researcher
@@ -926,10 +928,14 @@ here's a tip, go search DEFINES/access.dm
 	name = "Vaultie"
 	uniform = /obj/item/clothing/under/f13/eastwood/vault
 	gloves = /obj/item/pda
+	belt = /obj/item/storage/belt
 	shoes = /obj/item/clothing/shoes/jackboots
 	gloves = /obj/item/clothing/gloves/f13/leather
 	backpack_contents = list(
 	/obj/item/gun/ballistic/automatic/pistol/n99 = 1,
+	/obj/item/ammo_box/magazine/pistol10mm = 2,
+	/obj/item/melee/onehanded/knife/survival = 1,
+	/obj/item/flashlight/flare = 1,
 	)
 
 /datum/outfit/loadout/farmer
@@ -1007,6 +1013,8 @@ Roles should be limited and low since they should attempt to work within town ra
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
 		/obj/item/restraints/handcuffs=1, \
+		/obj/item/gun/ballistic/revolver/police = 1,
+		/obj/item/ammo_box/loader/a357 = 1,
 		/obj/item/storage/bag/money/small/wastelander = 1)
 
 /datum/outfit/job/wasteland/f13enforcer/pre_equip(mob/living/carbon/human/H)
@@ -1098,6 +1106,8 @@ Roles should be limited and low since they should attempt to work within town ra
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
 		/obj/item/restraints/handcuffs=1, \
 		/obj/item/ammo_box/magazine/greasegun=2, \
+		/obj/item/gun/ballistic/revolver/police = 1,
+		/obj/item/ammo_box/loader/a357 = 1,
 		/obj/item/storage/bag/money/small/raider/mobboss = 1, \
 		/obj/item/book/granter/crafting_recipe/manual/denvr = 1)
 

--- a/code/modules/jobs/job_types/eastwood.dm
+++ b/code/modules/jobs/job_types/eastwood.dm
@@ -935,7 +935,8 @@ here's a tip, go search DEFINES/access.dm
 	/obj/item/ammo_box/magazine/pistol10mm = 2,
 	/obj/item/melee/onehanded/knife/survival = 1,
 	/obj/item/flashlight/flare = 1,
-	/obj/item/pda = 1
+	/obj/item/pda = 1,
+	/obj/item/reagent_containers/food/drinks/flask = 1,
 	)
 
 /datum/outfit/loadout/farmer

--- a/code/modules/jobs/job_types/eastwood.dm
+++ b/code/modules/jobs/job_types/eastwood.dm
@@ -330,7 +330,7 @@ here's a tip, go search DEFINES/access.dm
 		/obj/item/toy/crayon/white=1,
 		/obj/item/detective_scanner=1,
 		/obj/item/storage/box/gloves=1,
-		/obj/item/storage/box/evidence=1
+		/obj/item/storage/box/evidence=1,
 		/obj/item/ammo_box/loader/m44=1
 		)
 

--- a/code/modules/jobs/job_types/eastwood.dm
+++ b/code/modules/jobs/job_types/eastwood.dm
@@ -927,7 +927,6 @@ here's a tip, go search DEFINES/access.dm
 /datum/outfit/loadout/vaultie //Think of this as old citizens
 	name = "Vaultie"
 	uniform = /obj/item/clothing/under/f13/eastwood/vault
-	gloves = /obj/item/pda
 	belt = /obj/item/storage/belt
 	shoes = /obj/item/clothing/shoes/jackboots
 	gloves = /obj/item/clothing/gloves/f13/leather
@@ -936,6 +935,7 @@ here's a tip, go search DEFINES/access.dm
 	/obj/item/ammo_box/magazine/pistol10mm = 2,
 	/obj/item/melee/onehanded/knife/survival = 1,
 	/obj/item/flashlight/flare = 1,
+	/obj/item/pda = 1
 	)
 
 /datum/outfit/loadout/farmer


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
vaultie loadout got way less than the other loadouts
given 2 spare mags for the pistol, a small knife, a generic belt,and an extra flare to put it a bit on par with the others (also an homage to the starting equipment in fallout 1)
also fixes the pipboy which doesnt spawn on him
still nowhere near the utility of the others, but at least you arent defenseless

desperados are given a police pistol and 1 spare speedloader
it was weird that they did not spawn with a sidearm of any kind, they now have a concealable pistol

detective got a .44 speedloader for his pistol
he did not start with spares at all
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: vaultie loadout for townie buffed 
tweak: desperados get side arms
tweak: detective gets spare bullets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
