### PR TITLE
YK-42b Pulse Rifle firerate fix

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -12,6 +12,10 @@
 	flight_x_offset = 17
 	flight_y_offset = 9
 
+	init_firemodes = list(
+		SEMI_AUTO_PISTOL
+	)
+
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	return
 


### PR DESCRIPTION
## About The Pull Request
a one line change i made in a webedit. testing changes is for nerds. it's synced with the base firerate for all energy weapons now, supposedly.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: The YK-42b Pulse Rifle will no longer fire once every six seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
