### PR TITLE
adds hightier egun crates

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -302,6 +302,13 @@
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh)
 	crate_name = "energy crate"
 
+/datum/supply_pack/security/laserhightier
+	name = "Weapons - Premium Energy Weapon"
+	desc = "Contains one highly-powerful energy gun for all your vaporizing needs. One spare battery included, but with this that's all you'll need."
+	cost = 15000
+	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high)
+	crate_name = "prewar energy crate"
+
 /datum/supply_pack/security/mods
 	name = "Weapons - Gun Mods"
 	desc = "Contains four random gun and energy weapon mods, fun for the whole family!"


### PR DESCRIPTION
## About The Pull Request
I added a high tier energy weapon crate because people want to roleplay as relatives of the van graffs, a high price option for said people would add to the merchant as a role at the downside of becoming an even bigger target to the brotherhood.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog
:cl:
add: Lasers, plasma, pistols, grenades - we've got it all at the Eastwood general store.
/:cl:
