### PR TITLE
power armor deflect

### DIFF
--- a/code/modules/clothing/suits/power_armor.dm
+++ b/code/modules/clothing/suits/power_armor.dm
@@ -328,8 +328,8 @@
 	name = "T-45b power armor"
 	desc = "It's a set of early-model T-45 power armor with a custom air conditioning module and restored servomotors. Bulky, but almost as good as the real thing."
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
-	armor_block_chance = 50
-	deflection_chance = 10
+	armor_block_chance = 25 //1-in-4
+	deflection_chance = 5
 
 /obj/item/clothing/suit/armor/power_armor/t45d
 	name = "T-45d power armor"
@@ -337,8 +337,8 @@
 	icon_state = "t45dpowerarmor"
 	item_state = "t45dpowerarmor"
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45d
-	armor_block_chance = 50
-	deflection_chance = 10
+	armor_block_chance = 33 //1-in-3
+	deflection_chance = 7
 
 /obj/item/clothing/suit/armor/power_armor/t45d/bos
 	name = "Brotherhood T-45d Power Armour"
@@ -353,7 +353,7 @@
 	item_state = "t51bpowerarmor"
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 25)
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t51b
-	armor_block_chance = 60
+	armor_block_chance = 40 //1-in-2.5
 	deflection_chance = 10
 
 /obj/item/clothing/suit/armor/power_armor/t51b/hardened
@@ -361,6 +361,8 @@
 	desc = "The pinnacle of pre-war technology. This suit of power armor provides substantial protection to the wearer. It's plates have been chemially treated to be stronger."
 	icon_state = "t51green"
 	item_state = "t51green"
+	armor_block_chance = 45 //very slightly better
+	deflection_chance = 12
 
 /obj/item/clothing/suit/armor/power_armor/t51b/bos
 	name = "Brotherhood T-51b Power Armour"
@@ -381,7 +383,7 @@
 	desc = "An advanced suit of armor typically used by the Enclave.<br>It is composed of lightweight metal alloys, reinforced with ceramic castings at key stress points.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for its user's comfort."
 	icon_state = "advpowerarmor1"
 	item_state = "advpowerarmor1"
-	armor_block_chance = 60
+	armor_block_chance = 50 
 	deflection_chance = 15
 
 //Peacekeeper armor adjust as needed


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
PA adjustment
restored T-45 foes down from 50-> 25
T-45d goes down from 50 -> 33
T-51b goes down from 50 -> 40
T-51b hardened goes down from 50 ->45
APA is now 50, where T-51 used to be

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

balance: drastically reduces block% of PA

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
