### PR TITLE
Halves the instability of corn

### DIFF
--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -8,7 +8,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/corn
 	maturation = 8
 	potency = 20
-	instability = 50 // Corn used to be wheatgrass, but through generations of selective cultivation...
+	instability = 25
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_grow = "corn-grow" // Uses one growth icons set for all the subtypes


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
This reduces corn's instability from 50 to 25, because I'm personally sick of taking advantage of pollination & fertilizer to keep it from mutating only to get Snapcorn.
## Pre-Merge Checklist
- [N] You tested this on a local server.
- [N] This code did not runtime during testing.
- [Y] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Corn's instability has been halved, making it much easier to reliably grow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
