### PR TITLE
addresses issue #188, garden belt is more functional

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1016,6 +1016,23 @@ obj/item/storage/belt/medical/surgical
 	icon = 'icons/fallout/clothing/belts.dmi'
 	icon_state = "gardener"
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
+	
+/obj/item/storage/belt/utility/gardener/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 7
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.can_hold = typecacheof(list(
+		/obj/item/shovel/spade,
+		/obj/item/cultivator,
+		/obj/item/hatchet,
+		/obj/item/plant_analyzer,
+		/obj/item/seeds,
+		/obj/item/clothing/gloves,
+		/obj/item/reagent_containers/spray/plantbgone,
+		/obj/item/reagent_containers/food/drinks/flask,
+		/obj/item/reagent_containers/glass/bottle/nutrient,
+		))
 
 // Primitive medical belt, meant to be part of a ghetto surgery improvement at some point
 /obj/item/storage/belt/medical/primitive

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1032,6 +1032,7 @@ obj/item/storage/belt/medical/surgical
 		/obj/item/reagent_containers/spray/plantbgone,
 		/obj/item/reagent_containers/food/drinks/flask,
 		/obj/item/reagent_containers/glass/bottle/nutrient,
+		/obj/item/flashlight,
 		))
 
 // Primitive medical belt, meant to be part of a ghetto surgery improvement at some point


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
garden toolbelt is a child of the toolbelt, it can only hold tools
makes it so it can hold pertinent stuff inside it

closes #188 

can now hold:
spade
cultivator
hatchet
small bottles
plant b gone spray bottle
spare gloves
plant analyzer
seed packets
flasks
flashlights
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: gardener belt cant hold anything

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
