### PR TITLE
adds recharger pistols and dynamite to loot piles

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -313,7 +313,7 @@
 				)
 
 /obj/effect/spawner/bundle/f13/armor/laserproofmetal
-	name = "polsihed metal armor spawner"
+	name = "polished metal armor spawner"
 	items = list(
 				/obj/item/clothing/suit/armor/heavy/metal/polished,
 				/obj/item/clothing/head/helmet/f13/metalmask
@@ -755,9 +755,10 @@
 //Energy Weapon Spawners
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low
 	name = "low tier energy gun"
-	loot = list(/obj/effect/spawner/bundle/f13/wattz = 40,
-				/obj/effect/spawner/bundle/f13/wattzm = 25,
-				/obj/effect/spawner/bundle/f13/laserpistol = 35
+	loot = list(/obj/effect/spawner/bundle/f13/wattz = 35,
+				/obj/effect/spawner/bundle/f13/wattzm = 15,
+				/obj/effect/spawner/bundle/f13/laserpistol = 30,
+				/obj/item/gun/energy/laser/wattz/recharger = 20,
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1628,7 +1628,8 @@ obj/effect/spawner/bundle/f13/combat_rifle
 				/obj/item/grenade/f13/frag = 30,
 				/obj/item/grenade/flashbang,
 				/obj/item/grenade/f13/stinger,
-				/obj/item/grenade/empgrenade = 50
+				/obj/item/grenade/empgrenade = 50, 
+				/obj/item/grenade/f13/anarchist/dynamite,
 				)
 
 /obj/effect/spawner/lootdrop/f13/bomb/tier3
@@ -1638,6 +1639,7 @@ obj/effect/spawner/bundle/f13/combat_rifle
 				/obj/item/grenade/empgrenade,
 				/obj/item/grenade/f13/radiation,
 				/obj/item/grenade/f13/frag,
+				/obj/item/grenade/f13/anarchist/dynamite,
 				/obj/effect/spawner/bundle/f13/grenadelauncher,
 				)
 /obj/effect/spawner/lootdrop/f13/bomb/top_tier

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -276,16 +276,9 @@
 	can_charge = 0
 	selfcharge = 1
 	icon_state = "rechargerpistol"
-	w_class = WEIGHT_CLASS_SMALL
-	slot_flags = ITEM_SLOT_BELT
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/recharger/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/breeder
-	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'
-
-	slowdown = GUN_SLOWDOWN_PISTOL_LIGHT
-	force = GUN_MELEE_FORCE_PISTOL_LIGHT
-	weapon_weight = GUN_ONE_HAND_AKIMBO
-	draw_time = GUN_DRAW_NORMAL
+	draw_time = GUN_DRAW_LONG //in NV, the gun starts at 0 and then has to charge
 
 //AEP 7 Laser pistol
 /obj/item/gun/energy/laser/pistol

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -268,10 +268,10 @@
 	weapon_weight = GUN_ONE_HAND_AKIMBO
 	draw_time = GUN_DRAW_NORMAL
 
-//Breeder recharger pistol
+//recharger pistol
 /obj/item/gun/energy/laser/wattz/recharger
 	name = "Recharger Pistol"
-	desc = "A recharger pistol manufactured by the Followers of the Apocalpyse. As the name implied, it charges its capacitor banks over time using radioactive decay."
+	desc = "A locally produced copy of a recharger pistol. As the name implies, it charges its capacitor banks over time using radioactive decay."
 	can_remove = 0
 	can_charge = 0
 	selfcharge = 1

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -427,7 +427,7 @@
 /obj/item/projectile/beam/laser/lasgun/hitscan/focused 
 	name = "overcharged laser beam"
 	damage = 34
-	damage_threshold_penetration = BULLET_DT_PENETRATION_HEAVY
+	damage_threshold_penetration = BULLET_DT_PENETRATION_RIFLE
 
 /obj/item/projectile/beam/laser/tribeam/hitscan
 	name = "tribeam laser"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -391,6 +391,17 @@
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
+/obj/item/projectile/beam/laser/recharger/hitscan //hitscan recharger pistol
+	name = "recharger beam"
+	damage = 25
+	hitscan = TRUE
+	armour_penetration = BULLET_PENETRATION_LOW
+	damage_threshold_penetration = BULLET_DT_PENETRATION_PISTOL
+	tracer_type = /obj/effect/projectile/tracer/pulse
+	muzzle_type = /obj/effect/projectile/muzzle/pulse
+	impact_type = /obj/effect/projectile/impact/pulse
+	light_color = LIGHT_COLOR_BLUE
+
 /obj/item/projectile/beam/laser/pistol/hitscan //hitscan AEP7
 	name = "laser beam"
 	damage = 15
@@ -413,9 +424,10 @@
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-/obj/item/projectile/beam/laser/lasgun/hitscan/focused
+/obj/item/projectile/beam/laser/lasgun/hitscan/focused 
 	name = "overcharged laser beam"
 	damage = 34
+	damage_threshold_penetration = BULLET_DT_PENETRATION_HEAVY
 
 /obj/item/projectile/beam/laser/tribeam/hitscan
 	name = "tribeam laser"
@@ -520,16 +532,6 @@
 	tracer_type = /obj/effect/projectile/tracer/disabler
 	muzzle_type = /obj/effect/projectile/muzzle/disabler
 	impact_type = /obj/effect/projectile/impact/disabler
-
-
-/obj/item/projectile/beam/laser/recharger/hitscan //hitscan recharger pistol
-	name = "recharger beam"
-	damage = 25
-	hitscan = TRUE
-	tracer_type = /obj/effect/projectile/tracer/pulse
-	muzzle_type = /obj/effect/projectile/muzzle/pulse
-	impact_type = /obj/effect/projectile/impact/pulse
-	light_color = LIGHT_COLOR_BLUE
 
 
 /obj/item/projectile/beam/laser/ultra_pistol //unused


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
recharger pistol is genericized
recharger pistol added to low-tier energy weapon loot
recharger pistol slightly tweaked

recharger pistol rundown:
high capacity cell
charges its cell fairly quickly
25 damage per shot, no AP: good vs mobs and wastelanders, bad vs anyone with high DT
takes a long time to fire when drawn (in FNV, it always started charge at 0 after being drawn)
its a child of the wattz1000, so redundant values that were identical to the wattz were deleted

allows sticks of dynamite to spawn in explosive spawners
my name is easy pete, king of the roomba beat

future proofs the overcharged laser beam in case its ever to be used

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

balance: recharger pistol stats adjusted
add: recharger pistol now spawns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
