### PR TITLE
Disables BoS, replaces their base with two distinct bunkers.

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -77,23 +77,6 @@
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"abD" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
-"abE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/brotherhood/mining)
 "abF" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/barber{
@@ -101,15 +84,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"abG" = (
-/obj/item/radio/intercom{
-	desc = "Is there anyone on the other end? Who's in there?";
-	frequency = 1291;
-	name = "Mysterious Intercom";
-	pixel_y = null
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "abL" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
@@ -163,6 +137,15 @@
 /obj/item/clothing/head/bearpelt,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"aer" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "afc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -170,16 +153,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/water,
 /area/f13/caves)
-"afd" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 4;
-	name = "light fixture"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "afo" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
@@ -209,6 +182,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"afU" = (
+/obj/machinery/door/airlock/hatch{
+	name = "maintenance hatch"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "aga" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -222,13 +201,6 @@
 /obj/item/lighter,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"agn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "agq" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/crate/trashcart,
@@ -237,10 +209,6 @@
 	dir = 6
 	},
 /area/f13/caves)
-"agA" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "agO" = (
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
@@ -261,17 +229,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"aiM" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+"aij" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "hangar";
+	name = "Hangar Control"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
+/area/f13/radiation/crashsite)
+"ait" = (
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "ajB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -289,17 +260,6 @@
 "ajX" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
-"akd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"akt" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "aky" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/structure/closet,
@@ -332,15 +292,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"akZ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "alc" = (
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -389,37 +340,6 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"amK" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
-"amQ" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"amX" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/f13/brotherhood/operations)
 "ang" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -445,22 +365,10 @@
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"aob" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "aoc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"aon" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "aoG" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -522,21 +430,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"apt" = (
-/obj/structure/guncase,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "apB" = (
 /obj/structure/spacevine{
 	name = "vines"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"aqd" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "aqn" = (
 /turf/open/water,
 /area/f13/bunker)
@@ -595,6 +501,17 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"asu" = (
+/obj/effect/mob_spawn/human/corpse/chineseremnant/assault,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "bloodpaw1"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/f13/radiation/crashsite)
 "asv" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
@@ -602,16 +519,6 @@
 "asR" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/caves)
-"asV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "atk" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -739,18 +646,6 @@
 /obj/item/stack/sheet/mineral/uranium,
 /turf/open/floor/plasteel/dark,
 /area/f13/radiation)
-"axa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "axw" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
@@ -793,16 +688,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"ayM" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Power"
+"azc" = (
+/obj/structure/table/optable/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
+/area/f13/radiation/crashsite)
 "azk" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/museum)
@@ -819,12 +710,6 @@
 	color = "#e4e4e4"
 	},
 /area/f13/caves)
-"aAF" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "aBg" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/machinery/light/broken{
@@ -858,24 +743,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"aCI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	dir = 8;
-	name = "Armory Camera";
-	network = list("BoS");
-	pixel_x = -1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "aDb" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/mountain,
@@ -897,6 +764,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building)
+"aDT" = (
+/obj/item/shard/plasma/alien,
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "aEe" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -935,18 +809,6 @@
 /obj/structure/nest/raider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"aFO" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "aGd" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
@@ -960,6 +822,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"aGp" = (
+/obj/structure/bed/mattress,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "aGu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
@@ -1017,12 +886,6 @@
 /obj/structure/stairs/west,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"aJi" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
 "aJt" = (
 /obj/machinery/autolathe,
 /obj/effect/decal/cleanable/dirt,
@@ -1036,34 +899,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"aJP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "aKm" = (
 /obj/item/pickaxe/mini,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"aKr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	name = "Brig Camera";
-	network = list("BoS")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "aKD" = (
 /obj/machinery/workbench/forge{
 	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
@@ -1112,18 +951,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
+"aLb" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "aLC" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
-"aLI" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "aLS" = (
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 5
@@ -1177,32 +1018,16 @@
 	},
 /area/f13/enclave)
 "aNJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/timeddoor{
+	deletion_time = 54000
 	},
-/obj/structure/decoration/hatch{
-	dir = 8
-	},
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 6
-	},
-/area/f13/brotherhood/mining)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/radiation/crashsite)
 "aOd" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"aOp" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "aOz" = (
 /obj/machinery/button/door{
 	id = "salad";
@@ -1224,16 +1049,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/vault)
-"aPE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/Knight,
-/obj/effect/landmark/start/f13/seniorknight,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "aPS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -1319,10 +1134,6 @@
 "aTZ" = (
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"aUc" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "aUl" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -1371,11 +1182,17 @@
 "aXo" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
-"aXv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood/operations)
+"aXy" = (
+/obj/structure/chair,
+/mob/living/simple_animal/hostile/chinese,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "aYa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -1405,9 +1222,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"aZx" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
 "aZL" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
@@ -1445,10 +1259,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/caves)
-"bcz" = (
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "bcB" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/museum)
@@ -1467,18 +1277,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
-"bdZ" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/Knight,
-/obj/effect/landmark/start/f13/seniorknight,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "bef" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"bej" = (
+/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
+"bfx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/item/stack/sheet/mineral/concrete,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "bgb" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt{
@@ -1561,39 +1378,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"bih" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/t_scanner/adv_mining_scanner{
-	pixel_x = 9
-	},
-/obj/item/t_scanner/adv_mining_scanner{
-	pixel_x = -9
-	},
-/obj/item/gps/mining{
-	gpstag = "BOSMINE1";
-	pixel_x = -10;
-	pixel_y = 22
-	},
-/obj/item/gps/mining{
-	gpstag = "BOSMINE2";
-	pixel_x = 1;
-	pixel_y = 22
-	},
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/item/pickaxe/drill/diamonddrill,
-/obj/item/pickaxe/drill/diamonddrill,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "bir" = (
 /obj/machinery/light{
 	dir = 8;
@@ -1635,16 +1419,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"bjl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/Knight,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"bjs" = (
-/obj/machinery/suit_storage_unit/radsuit,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+"bjk" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "bjZ" = (
 /turf/open/water,
 /area/f13/radiation)
@@ -1688,11 +1474,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"blC" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+"bmk" = (
+/turf/open/floor/pod/light,
+/area/f13/radiation/crashsite)
+"bmo" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "bmr" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -1722,11 +1511,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"bmW" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "bnp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/crumpled,
@@ -1764,16 +1548,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/city)
-"boj" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"boM" = (
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "boR" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -1826,6 +1600,13 @@
 	dir = 9
 	},
 /area/f13/caves)
+"bqu" = (
+/obj/structure/obstacle/jammed_door,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "bqN" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -1915,6 +1696,13 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
+"buy" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "buA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder/reinforced,
@@ -1963,10 +1751,29 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
+"bwD" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "bwO" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bwW" = (
+/mob/living/simple_animal/hostile/chinese/ranged/assault{
+	health = 200;
+	rapid = 1;
+	rapid_fire_delay = 3;
+	name = "Lieutenant Diampango";
+	robust_searching = 1
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "bxg" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/turf_decal/weather/dirt,
@@ -2015,15 +1822,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bxV" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "byp" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2074,13 +1872,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"bAd" = (
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "bAg" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -2088,6 +1879,15 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bAh" = (
+/obj/structure/closet/abductor,
+/obj/item/clothing/under/abductor{
+	name = "alien jumpsuit"
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "bAr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2127,6 +1927,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bBR" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "indmine"
+	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -2178,6 +1982,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/grimy,
 /area/f13/tunnel)
+"bDr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "bDt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2190,32 +2002,19 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
-"bDx" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster82";
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/stool/f13stool,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "bDN" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 8
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"bDP" = (
-/obj/machinery/defibrillator_mount/loaded,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operating)
+"bDW" = (
+/obj/structure/barricade/concrete,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "bEf" = (
 /obj/structure/nest/protectron,
 /turf/open/floor/f13{
@@ -4366,30 +4165,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bOA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"bOB" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "bOC" = (
 /obj/item/reagent_containers/pill/patch/jet,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -4400,45 +4175,10 @@
 	name = "metal plating"
 	},
 /area/f13/city)
-"bOD" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
-"bOE" = (
-/obj/item/flag/bos,
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/railing{
-	dir = 6;
-	layer = 4.1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "bOF" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"bOH" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "bOI" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
@@ -4458,29 +4198,11 @@
 	name = "metal plating"
 	},
 /area/f13/city)
-"bOL" = (
-/obj/structure/decoration/warning,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
-"bOM" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "bON" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
 /area/f13/ncr)
-"bOO" = (
-/obj/machinery/radioterminal/bos,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "bOP" = (
 /obj/machinery/door/airlock/wood{
 	req_access_txt = "87"
@@ -4496,25 +4218,6 @@
 	name = "metal plating"
 	},
 /area/f13/city)
-"bOR" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/brotherhood/operations)
-"bOS" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "bOT" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -4529,12 +4232,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"bOW" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius";
-	name = "vault floor"
-	},
-/area/f13/brotherhood/medical)
 "bOX" = (
 /obj/structure/toilet{
 	dir = 4
@@ -4546,20 +4243,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/city)
-"bOY" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood/mining)
-"bOZ" = (
-/obj/item/flag/bos,
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "bPa" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/low_chance,
@@ -4576,30 +4259,6 @@
 /obj/structure/table,
 /turf/open/floor/carpet/orange,
 /area/f13/ncr)
-"bPe" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "bPg" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -4609,23 +4268,6 @@
 	name = "metal plating"
 	},
 /area/f13/city)
-"bPh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"bPi" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operating)
-"bPj" = (
-/obj/item/stack/sheet/mineral/uranium,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
 "bPk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4637,19 +4279,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/tunnel)
-"bPn" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "bPp" = (
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /turf/open/floor/f13{
@@ -4688,48 +4317,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"bPx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/turf/open/water,
-/area/f13/brotherhood/operations)
-"bPy" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "bPz" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/f13{
@@ -4752,12 +4339,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/city)
-"bPF" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
 "bPG" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cloth/ten,
@@ -4765,15 +4346,6 @@
 	name = "metal plating"
 	},
 /area/f13/city)
-"bPH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "bPI" = (
 /obj/structure/rack,
 /obj/item/mining_scanner,
@@ -5281,18 +4853,6 @@
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"bRW" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "bRX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/cig_packs,
@@ -5417,10 +4977,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"bTN" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
 "bUo" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -5545,16 +5101,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"bWb" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "bWd" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -5679,17 +5225,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"bYC" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "bYT" = (
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = 27
@@ -5809,17 +5344,6 @@
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"cbE" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "ccc" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5839,6 +5363,12 @@
 	icon_state = "darkredfull"
 	},
 /area/f13/vault)
+"ccD" = (
+/obj/machinery/vending/engineering,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "ccH" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -5931,15 +5461,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"cfi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "cfv" = (
 /obj/item/storage/fancy/donut_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6004,13 +5525,6 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
-"chh" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "chj" = (
 /obj/structure/bed/oldalt,
 /turf/open/floor/plating/tunnel{
@@ -6030,20 +5544,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"chY" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light,
-/turf/open/water,
-/area/f13/brotherhood/operations)
 "cid" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -6500,13 +6000,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"clt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "clD" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -6531,15 +6024,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"cmP" = (
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowtop"
-	},
-/obj/structure/grille,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "cnf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/raider/legendary,
@@ -6554,14 +6038,6 @@
 	color = "#e4e4e4"
 	},
 /area/f13/building)
-"cnH" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/medical)
 "coa" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -6642,10 +6118,22 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"coO" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
+"coJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	pixel_y = 5;
+	termtag = "Secret";
+	pixel_x = 8
+	},
+/obj/machinery/computer/terminal{
+	pixel_y = 5;
+	termtag = "Secret";
+	pixel_x = -7
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "cpb" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -6698,22 +6186,18 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"cpp" = (
-/obj/structure/simple_door/bunker,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "cpv" = (
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"cpx" = (
+/obj/machinery/computer/camera_advanced/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "cpU" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm9";
@@ -6735,24 +6219,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"cqM" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "cqO" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/water,
 /area/f13/radiation)
-"cqS" = (
-/turf/open/floor/f13{
-	color = "#f7e8e1";
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "crj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6760,14 +6230,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/tunnel)
-"crA" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
 "crR" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
@@ -6825,14 +6287,6 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
-"ctK" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "ctU" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -6858,10 +6312,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"cvn" = (
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/brotherhood/reactor)
 "cvq" = (
 /obj/machinery/button/door{
 	id = "salad";
@@ -6885,15 +6335,6 @@
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"cvx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "cvB" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -6924,14 +6365,9 @@
 	},
 /area/f13/caves)
 "cvW" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "cvX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -6946,13 +6382,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building/massfusion)
-"cwa" = (
-/obj/item/gps/computer{
-	desc = "A large, central database of currently-transmitting GPS signals.";
-	name = "GPS Ping Grabber."
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "cwj" = (
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/floor/f13{
@@ -7147,23 +6576,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
-"cDS" = (
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/book/granter/trait/pa_wear,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "cEf" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -7192,16 +6604,16 @@
 "cGl" = (
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
-"cGw" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
+"cGV" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "cHj" = (
 /obj/effect/landmark/start/f13/ncrranger,
 /turf/open/floor/f13/wood,
@@ -7226,21 +6638,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"cIX" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_x = 30;
-	start_charge = 500
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
-"cJh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "cJp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
@@ -7290,6 +6687,23 @@
 	icon_state = "darkredfull"
 	},
 /area/f13/enclave)
+"cMo" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
+"cMD" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2"
+	},
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "cML" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -7332,6 +6746,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"cOy" = (
+/obj/structure/grille,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "cOD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
@@ -7464,14 +6882,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"cUm" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+"cTF" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/area/f13/radiation/crashsite)
+"cVl" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "cVw" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -7488,6 +6918,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"cVV" = (
+/obj/machinery/door/poddoor{
+	name = "quarantine door";
+	id = "hangarlock2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/radiation/crashsite)
 "cWp" = (
 /obj/machinery/autolathe,
 /obj/effect/decal/cleanable/dirt,
@@ -7501,20 +6941,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/tunnel)
-"cWz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"cWQ" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "cWV" = (
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -7524,6 +6950,13 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"cXo" = (
+/obj/structure/chair/folding{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "cXE" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/indestructible/f13vaultrusted,
@@ -7953,14 +7386,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"dsZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "dte" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plasteel/fifty,
@@ -7992,6 +7417,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"dvu" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/good,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "dvD" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -8021,12 +7455,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"dwU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "dxt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_master,
@@ -8040,26 +7468,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building/museum)
-"dyC" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+"dyy" = (
+/obj/structure/timeddoor{
+	deletion_time = 54000
 	},
-/obj/structure/table/glass,
-/obj/item/pda/chemist{
-	name = "Scribe-Chemist Pip-Boy 3000"
+/obj/structure/timeddoor{
+	deletion_time = 54000
 	},
-/obj/item/reagent_containers/dropper,
-/obj/item/storage/box/medsprays,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/storage/bag/chemistry,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/radiation/crashsite)
 "dyM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"dyN" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "dyU" = (
 /obj/structure/rack,
 /obj/item/stack/rods/fifty,
@@ -8096,6 +7525,15 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
+"dAr" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "dAy" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -8106,14 +7544,6 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
-"dAS" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "dAT" = (
 /obj/item/stack/sheet/mineral/uranium,
 /turf/open/floor/plasteel/dark,
@@ -8126,15 +7556,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"dCq" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
-	},
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/paladin,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "dCF" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -8150,6 +7571,22 @@
 /obj/structure/barricade/bars,
 /turf/open/water,
 /area/f13/tunnel)
+"dDe" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
+"dDz" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "dDC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -8340,6 +7777,16 @@
 /obj/item/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"dIn" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/power/port_gen/pacman/super,
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "dIJ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -8349,11 +7796,22 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"dJp" = (
+/obj/effect/mob_spawn/human/corpse/chineseremnant,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/turf/open/water,
+/area/f13/radiation/crashsite)
 "dJy" = (
 /mob/living/simple_animal/hostile/radroach,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"dJE" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigars,
+/obj/item/storage/box/matches,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "dJM" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -8370,14 +7828,6 @@
 	icon_state = "reddirtysolid"
 	},
 /area/f13/bunker)
-"dKc" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "dKz" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -8393,6 +7843,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
+"dKN" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/f13/chinese/officer,
+/obj/item/clothing/head/f13/chinese/officer,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "dKT" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -8421,17 +7882,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"dLT" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/machinery/pool/drain,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "dLW" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -8447,6 +7897,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"dMQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "dNf" = (
 /obj/structure/nest/fireant{
 	max_mobs = 4;
@@ -8454,21 +7913,23 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dOk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
+"dNs" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "dOn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"dOw" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "dOG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters/old{
@@ -8517,6 +7978,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
+"dQS" = (
+/obj/structure/closet/crate/footlocker,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "dQU" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/enclave)
@@ -8532,18 +7999,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/city)
-"dRi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation{
-	anchored = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 10
-	},
-/area/f13/brotherhood/reactor)
 "dRl" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8556,121 +8011,6 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"dRQ" = (
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "dSo" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -8851,6 +8191,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"dWt" = (
+/turf/closed/indestructible/fakedoor,
+/area/f13/radiation/crashsite)
 "dWL" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -8883,9 +8226,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"dYb" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
 "dYf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -8926,43 +8266,27 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/tunnel)
-"dZK" = (
-/obj/machinery/workbench/advanced,
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "dZX" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"dZZ" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "eae" = (
 /obj/structure/sign/warning,
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"eaj" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
+"eau" = (
+/obj/structure/closet/crate/footlocker,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
@@ -9008,10 +8332,6 @@
 /obj/structure/closet/crate/wicker,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"edg" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "edw" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -9047,6 +8367,10 @@
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"edU" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "eek" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -9128,15 +8452,6 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
-"eka" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "ekf" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/clothing_high,
@@ -9160,6 +8475,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"ekR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "ekS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars{
@@ -9194,31 +8515,21 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"ens" = (
-/obj/effect/landmark/start/f13/paladin,
-/obj/effect/landmark/start/f13/seniorknight,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+"emw" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/area/f13/brotherhood/operations)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "enJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating,
 /area/f13/building/museum)
-"enO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "enP" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -9239,6 +8550,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"eop" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "eoB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9303,6 +8622,16 @@
 	dir = 8
 	},
 /area/f13/caves)
+"eqh" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/high_tools,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "eqq" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/stack/sheet/mineral/uranium,
@@ -9314,34 +8643,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"eqK" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/robot_debris/old{
-	pixel_x = 1;
-	pixel_y = 20
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
-"eqM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/fulltile/store,
-/obj/structure/grille,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosbriglock";
-	name = "brig lockdown"
-	},
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "erg" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
@@ -9362,6 +8663,22 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_four,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
+"erN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	pixel_y = 5;
+	termtag = "Secret";
+	pixel_x = -7
+	},
+/obj/machinery/computer/terminal{
+	pixel_y = 5;
+	termtag = "Secret";
+	pixel_x = 9
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "erT" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/indestructible/ground/inside/subway,
@@ -9483,13 +8800,12 @@
 /obj/item/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"evL" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
+"evS" = (
+/obj/machinery/light/small/broken{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "ewy" = (
 /mob/living/simple_animal/hostile/renegade/drifter,
 /turf/open/indestructible/ground/inside/subway,
@@ -9556,6 +8872,10 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building/massfusion)
+"exB" = (
+/obj/structure/barricade/concrete,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "exT" = (
 /obj/machinery/telecomms/server/presets/town,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -9623,18 +8943,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/tunnel)
-"eAH" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosbriglock";
-	name = "brig lockdown"
-	},
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "eBj" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -9680,11 +8988,6 @@
 /obj/effect/spawner/lootdrop/ammo/military,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"eCD" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "eCX" = (
 /obj/machinery/light/small,
 /turf/open/floor/mineral/plastitanium,
@@ -9725,16 +9028,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"eEg" = (
-/obj/machinery/workbench/advanced,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10;
-	pixel_x = 7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "eEn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -9789,6 +9082,22 @@
 /obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"eGd" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
+"eGe" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/obj/machinery/door/window/right/directional/east,
+/obj/effect/mob_spawn/human/corpse/ncr/ranger,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "eGm" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/tunnel)
@@ -9805,6 +9114,12 @@
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"eGG" = (
+/obj/machinery/door/airlock/hatch{
+	name = "maintenance hatch"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "eHi" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/glass,
@@ -9884,6 +9199,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/building/museum)
+"eJF" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "eJI" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = "factorybasement";
@@ -9907,6 +9228,19 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker)
+"eKL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "eLf" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -9930,9 +9264,6 @@
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"eLJ" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/operations)
 "eMJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -10001,17 +9332,16 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"ePu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+"ePp" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/good,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/radiation/crashsite)
 "ePy" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -10025,6 +9355,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/vault)
+"ePB" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/gibs/human,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/item/stack/sheet/mineral/concrete,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
+"ePN" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "ePW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10037,15 +9382,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"eQn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "eQQ" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/lattice{
@@ -10060,20 +9396,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"eRd" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
 "eRz" = (
 /obj/structure/table/optable,
 /obj/machinery/iv_drip{
@@ -10084,16 +9406,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/enclave)
-"eSs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "eSu" = (
 /obj/structure/bed{
 	pixel_y = 7
@@ -10129,6 +9441,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"eTi" = (
+/turf/open/water,
+/area/f13/radiation/crashsite)
 "eTB" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/f13{
@@ -10165,6 +9480,18 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"eVq" = (
+/obj/structure/obstacle/jammed_door,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "eVN" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -10176,17 +9503,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"eWb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/turf_decal/bot_white,
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "eWe" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -10248,36 +9564,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"eYO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "eYU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"eZz" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen/fourcolor,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "eZT" = (
 /obj/structure/chair{
 	dir = 4
@@ -10292,19 +9584,23 @@
 "fap" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/caves)
-"fbL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "fbR" = (
 /obj/structure/chair/left,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"fca" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "fcd" = (
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -10326,37 +9622,41 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
+"fcH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
+"fcQ" = (
+/obj/machinery/button/door{
+	id = "hangarlock1";
+	pixel_x = -28
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "fcU" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/enclave)
-"fdj" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "fdz" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 12
@@ -10409,6 +9709,16 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"ffS" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/item/retractor/alien,
+/obj/item/scalpel/alien,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "ffU" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old{
@@ -10431,14 +9741,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"fgI" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "fgM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -10447,6 +9749,17 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"fhh" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/power/port_gen/pacman/super,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "fhS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10464,6 +9777,16 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
+"fiL" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
+"fiP" = (
+/obj/machinery/door/window/right/directional/north,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "fjb" = (
 /obj/structure/chair/f13foldupchair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -10477,10 +9800,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"fjh" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "fks" = (
 /obj/effect/spawner/structure/window/plasma,
 /obj/structure/grille,
@@ -10501,14 +9820,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/caves)
-"fkN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/am_shielding_container,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/f13/brotherhood/reactor)
 "flz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10522,18 +9833,6 @@
 	},
 /turf/closed/wall/rust,
 /area/f13/tunnel)
-"fmd" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosbriglock";
-	name = "brig lockdown"
-	},
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "fmh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -10560,19 +9859,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"fnh" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"fnL" = (
-/obj/machinery/vending/robotics,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "fon" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -10610,17 +9896,6 @@
 	name = "stone floor"
 	},
 /area/f13/tunnel)
-"fqs" = (
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "fqM" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10670,6 +9945,14 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"frJ" = (
+/mob/living/simple_animal/hostile/chinese/ranged/assault{
+	robust_searching = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "fsi" = (
 /obj/structure/table,
 /obj/item/storage/belt/military,
@@ -10684,12 +9967,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"fsp" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/reactor)
 "fsu" = (
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/plasteel/f13{
@@ -10733,37 +10010,6 @@
 	name = "stone floor"
 	},
 /area/f13/tunnel)
-"fuT" = (
-/obj/structure/closet,
-/obj/item/storage/box/gloves,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/wrench/medical,
-/obj/item/toy/figure/cmo{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	layer = 2;
-	name = "Head Scribe Action Figure";
-	toysay = "Ad astra per aspera."
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "fvh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard/fifty,
@@ -10813,15 +10059,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
-"fxo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "bosbriglock";
-	name = "Brig Lockdown Button"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "fxs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -10829,13 +10066,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/bunker)
-"fxA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side,
-/area/f13/brotherhood/mining)
 "fyj" = (
 /obj/structure/lattice{
 	layer = 3
@@ -10866,21 +10096,6 @@
 	name = "stone floor"
 	},
 /area/f13/tunnel)
-"fzh" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/hemostat,
-/obj/item/retractor,
-/obj/item/scalpel,
-/obj/item/circular_saw,
-/obj/item/surgicaldrill,
-/obj/item/cautery,
-/obj/item/bonesetter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "fzj" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -10888,14 +10103,12 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"fzB" = (
+"fAi" = (
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "fAx" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway{
@@ -10956,6 +10169,13 @@
 /obj/structure/showcase/machinery/cloning_pod,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"fEF" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "fEI" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -10971,24 +10191,17 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/vault)
-"fFh" = (
-/obj/item/clothing/suit/bomb_suit/security,
-/obj/item/clothing/head/bomb_hood/security,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "fFq" = (
 /obj/structure/sign/directions/engineering,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"fFt" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+"fFA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "fFU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11001,9 +10214,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
-"fHe" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
 "fHD" = (
 /obj/item/trash/f13/c_ration_2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11017,24 +10227,22 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"fIa" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "fIf" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"fIp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/human/corpse/chineseremnant/assault,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "fIt" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
@@ -11054,14 +10262,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"fKu" = (
-/obj/machinery/computer/operating/bos{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "fKA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -11085,21 +10285,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"fLh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/am_shielding_container,
-/obj/structure/cable{
-	icon_state = "2-8"
+"fKS" = (
+/obj/machinery/abductor/gland_dispenser,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/floor/plating,
-/area/f13/brotherhood/reactor)
-"fLs" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/light_emitter,
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/radiation/crashsite)
 "fLv" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -11149,25 +10340,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"fNs" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/suit/hooded/surgical,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/surgical_drapes,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/stack/sticky_tape/surgical{
-	pixel_x = -11;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "fNu" = (
 /obj/machinery/light{
 	dir = 4
@@ -11192,31 +10364,6 @@
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"fOl" = (
-/obj/structure/guncase,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"fOx" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "fOD" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -11229,10 +10376,6 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
-"fPg" = (
-/obj/machinery/rnd/production/protolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "fPm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11240,6 +10383,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"fQi" = (
+/obj/machinery/door/airlock/medical/glass,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "fQm" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /obj/effect/decal/cleanable/dirt,
@@ -11272,16 +10420,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/building/museum)
-"fSe" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/clothing/bos,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "fSg" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -11318,11 +10456,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/tunnel)
-"fTZ" = (
-/obj/effect/spawner/structure/window/plasma,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/radiation)
 "fUS" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -11351,25 +10484,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"fWI" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/decal/cleanable/dirt,
+"fWV" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"fWS" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Secret"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
+/area/f13/radiation/crashsite)
 "fXa" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -11394,6 +10512,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"fXQ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "fXU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11459,6 +10586,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"gaJ" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "gaN" = (
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -11471,20 +10604,6 @@
 /obj/item/clothing/mask/gas/welding,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
-"gbC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike_frame{
-	anchored = 1;
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "power armor frame"
-	},
-/obj/structure/table/reinforced{
-	alpha = 0;
-	desc = "Secure bolting to support the heavy weight of power armor.";
-	name = "frame support bolts"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "gbK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11519,34 +10638,12 @@
 	name = "cave"
 	},
 /area/f13/caves)
-"gdb" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operating)
 "gdg" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"gdj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "gej" = (
 /obj/structure/table,
 /obj/item/clothing/under/f13/combat,
@@ -11568,14 +10665,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"gez" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/am_shielding_container,
-/turf/open/floor/plating,
-/area/f13/brotherhood/reactor)
 "geF" = (
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/radiation)
+"geK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "geW" = (
 /obj/item/trash/sosjerky,
 /obj/effect/decal/cleanable/dirt,
@@ -11587,18 +10685,6 @@
 /obj/structure/simple_door/bunker,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"ggc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	dir = 8;
-	name = "Firing Range Camera";
-	network = list("BoS");
-	pixel_x = -1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "ggk" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -11685,21 +10771,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"gjM" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 9
-	},
-/area/f13/brotherhood/reactor)
-"gkf" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "gkl" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
@@ -11758,12 +10829,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"gmd" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "gmh" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -11841,18 +10906,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"gpz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "gpW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -11884,6 +10937,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"gqK" = (
+/obj/machinery/vending/sovietsoda,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "gqS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11893,12 +10950,28 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"grp" = (
-/obj/machinery/light/small{
-	dir = 4
+"gqX" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
+"grE" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/item/hemostat/alien,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "grQ" = (
 /obj/machinery/vending/medical,
 /obj/effect/decal/cleanable/dirt{
@@ -11906,15 +10979,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
-"gsY" = (
-/obj/structure/decoration/smokeold,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
-"gsZ" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "gtH" = (
 /mob/living/simple_animal/hostile/raider/ranged/biker{
 	name = "Tunnel Torturers Raider"
@@ -11935,6 +10999,9 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/tunnel)
+"guh" = (
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/radiation/crashsite)
 "guu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -11970,6 +11037,14 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
+"gvf" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "gvg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -12056,6 +11131,16 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"gzo" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/gibs/human,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "gzA" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
@@ -12088,18 +11173,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gzY" = (
-/obj/structure/curtain,
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operating)
-"gAp" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "gAs" = (
 /obj/structure/closet/crate/footlocker,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
@@ -12119,6 +11192,16 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/city)
+"gAN" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4";
+	pixel_y = -2
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "gAQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -12155,12 +11238,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"gCh" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "gCo" = (
 /obj/item/stack/ore/gold,
 /turf/open/indestructible/ground/inside/subway{
@@ -12302,17 +11379,14 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
-"gHO" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
+"gHY" = (
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
+/area/f13/radiation/crashsite)
 "gHZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12325,13 +11399,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"gIh" = (
-/obj/machinery/light/small,
-/obj/structure/chair/f13foldupchair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "gJb" = (
 /obj/structure/flora/wasteplant/wild_broc,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12364,13 +11431,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gJV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "gJW" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13{
@@ -12480,13 +11540,6 @@
 	name = "metal plating"
 	},
 /area/f13/enclave)
-"gPv" = (
-/obj/item/twohanded/sledgehammer/supersledge,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "gPw" = (
 /obj/item/fishingrod,
 /turf/open/water,
@@ -12511,6 +11564,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"gRf" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "gRk" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
@@ -12599,23 +11660,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"gTC" = (
-/obj/machinery/camera/autoname{
-	dir = 10;
-	name = "Interrogation Camera";
-	network = list("BoS");
-	pixel_x = -1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"gTO" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
-"gUb" = (
-/obj/structure/bodycontainer/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "gUs" = (
 /obj/machinery/door/airlock/grunge,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -12641,18 +11685,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"gVf" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "gVF" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/reagent_dispensers/fueltank,
@@ -12669,6 +11701,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"gVW" = (
+/obj/effect/decal/waste{
+	pixel_x = 18;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "gXq" = (
 /obj/structure/decoration/rag,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -12685,21 +11724,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"gYN" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
-	},
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "gZn" = (
 /obj/structure/nest/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12775,23 +11799,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/bunker)
-"hcP" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
-"hcW" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular{
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "hdb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -12937,6 +11944,13 @@
 	name = "metal plating"
 	},
 /area/f13/enclave)
+"hiw" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/superhigh,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "hjo" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -12997,12 +12011,6 @@
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"hlK" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "hlL" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13022,6 +12030,17 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
+"hmN" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/diamond{
+	amount = 10
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "hmZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -13035,6 +12054,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/radiation)
+"hnr" = (
+/obj/machinery/abductor/experiment{
+	team_number = 100
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "hnt" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -13067,16 +12094,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"hof" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "hoq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13202,6 +12219,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
+"htr" = (
+/mob/living/simple_animal/hostile/abomination{
+	name = "escaped specimen";
+	health = 2000;
+	maxHealth = 2000;
+	loot = list("/obj/item/keycard/chinese")
+	},
+/turf/open/water,
+/area/f13/radiation/crashsite)
 "htv" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -13232,24 +12258,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"huk" = (
-/obj/effect/landmark/start/f13/scribe,
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "hul" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"huI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "huQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/reagentgrinder,
@@ -13279,14 +12292,6 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/caves)
-"hvG" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "hvT" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -13296,6 +12301,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"hvZ" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "hwR" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/turf_decal/weather/dirt{
@@ -13303,18 +12315,17 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"hwW" = (
-/obj/item/shield/riot/bullet_proof,
-/obj/item/shield/riot/bullet_proof,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+"hxh" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
 	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
+/area/f13/radiation/crashsite)
+"hxi" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "hxF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -13362,21 +12373,6 @@
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"hzj" = (
-/obj/structure/dresser,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"hzp" = (
-/obj/structure/fluff/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "hzG" = (
 /mob/living/simple_animal/hostile/raider/firefighter{
 	name = "Tunnel Torturers Raider"
@@ -13419,13 +12415,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"hCn" = (
-/obj/effect/landmark/start/f13/scribe,
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "hCA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13466,15 +12455,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"hEs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "hED" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "militarystorage2"
@@ -13518,6 +12498,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/vault)
+"hHj" = (
+/obj/structure/table,
+/obj/item/inducer/sci/combat,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "hHr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -13527,10 +12514,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/caves)
-"hHs" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
 "hHu" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
@@ -13605,6 +12588,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"hKh" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "hKR" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/blood/drip,
@@ -13631,12 +12620,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"hMO" = (
-/obj/structure/table,
-/obj/item/storage/box/handcuffs,
-/obj/item/melee/classic_baton,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "hMP" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -13655,46 +12638,33 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
-"hNA" = (
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/machinery/light/floor,
-/obj/structure/railing,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"hOo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"hOd" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/toolsgood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	name = "metal plating"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/radiation/crashsite)
+"hOt" = (
+/obj/effect/decal/waste{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/effect/decal/waste{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "hOV" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"hPt" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
 "hPv" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor2"
@@ -13752,19 +12722,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
-"hSw" = (
-/obj/structure/simple_door/blast{
-	max_integrity = 1000;
-	name = "bunker entry";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "hSR" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
@@ -13835,26 +12792,6 @@
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"hVv" = (
-/obj/structure/bed{
-	pixel_y = 7
-	},
-/obj/item/bedsheet{
-	icon_state = "sheetcmo";
-	pixel_y = 7
-	},
-/obj/machinery/iv_drip{
-	pixel_x = 13;
-	pixel_y = 2
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
 "hVw" = (
 /obj/effect/mob_spawn/human/corpse/bs,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
@@ -13872,15 +12809,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/caves)
-"hWl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "hWr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/old,
@@ -13933,6 +12861,13 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/city)
+"hYX" = (
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "hZd" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -13951,17 +12886,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
-"hZA" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "hZN" = (
 /obj/structure/lattice{
 	layer = 3
@@ -14003,23 +12927,15 @@
 	name = "metal plating"
 	},
 /area/f13/city)
-"icb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+"icj" = (
+/obj/structure/table/abductor{
+	name = "alien table"
 	},
-/obj/structure/grille,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
+/obj/item/gun/energy/laser/plasma/pistol/alien,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"icn" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/radiation/crashsite)
 "ict" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -14037,15 +12953,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"idb" = (
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "idc" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/flora/grass/wasteland{
@@ -14124,17 +13031,6 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"ifv" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	dir = 4;
-	name = "prewar lounge chair"
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/rnd)
 "ifE" = (
 /obj/item/clothing/suit/armor/medium/combat/rusted,
 /obj/item/clothing/head/helmet/f13/hoodedmask,
@@ -14177,6 +13073,10 @@
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"ijU" = (
+/obj/effect/decal/cleanable/blood/gibs/human,
+/turf/open/floor/pod/light,
+/area/f13/radiation/crashsite)
 "ijX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -14184,6 +13084,12 @@
 	},
 /turf/open/floor/plating/f13,
 /area/f13/caves)
+"ikM" = (
+/obj/machinery/power/port_gen/pacman/mrs,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "ikO" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -14191,19 +13097,16 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"ikS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "ikT" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood_common,
 /area/f13/caves)
+"ila" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "ild" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -14226,6 +13129,16 @@
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ily" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/good,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "ima" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -14265,6 +13178,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/vault)
+"imO" = (
+/obj/structure/chair,
+/mob/living/simple_animal/hostile/chinese,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "imS" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -14303,6 +13221,18 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"iok" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/item/stack/sheet/mineral/concrete,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "iol" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -14323,6 +13253,12 @@
 	name = "metal plating"
 	},
 /area/f13/enclave)
+"ipc" = (
+/obj/item/gps/computer,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "ipr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stacklifter,
@@ -14384,13 +13320,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
-"irN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
 "isn" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -14423,16 +13352,6 @@
 /obj/item/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"isB" = (
-/obj/structure/simple_door/blast{
-	max_integrity = 1000;
-	name = "bunker entry";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "isI" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -14482,15 +13401,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"iuf" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/store,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "iul" = (
 /obj/structure/spider/cocoon,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -14560,22 +13470,14 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ixD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+"ixE" = (
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
 	},
-/area/f13/brotherhood/operations)
-"ixO" = (
-/obj/effect/turf_decal/stripes/red/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/radiation/crashsite)
 "iyr" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/city)
@@ -14598,14 +13500,6 @@
 	name = "cave"
 	},
 /area/f13/caves)
-"izD" = (
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "izQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
@@ -14650,6 +13544,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"iAz" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/radiation/crashsite)
 "iAC" = (
 /obj/structure/filingcabinet,
 /obj/item/stack/f13Cash/random/med,
@@ -14680,14 +13580,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/tunnel)
-"iBj" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "iBz" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -14705,6 +13597,9 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building/massfusion)
+"iBX" = (
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "iCD" = (
 /turf/closed/mineral/ash_rock,
 /area/f13/caves)
@@ -14753,10 +13648,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"iDJ" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "iDZ" = (
 /obj/machinery/autolathe,
 /obj/effect/decal/cleanable/dirt,
@@ -14791,16 +13682,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/caves)
-"iGw" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "iGz" = (
 /obj/machinery/light{
 	dir = 1
@@ -14848,17 +13729,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"iHV" = (
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
-	dir = 8;
-	name = "Head Scribe's Archive Terminal"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "iIr" = (
 /mob/living/simple_animal/hostile/radroach,
 /obj/effect/decal/cleanable/dirt,
@@ -14873,16 +13743,19 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"iIK" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "iIN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/vault)
+"iJj" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "iJH" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -14908,6 +13781,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"iKk" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "iKs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -14923,11 +13802,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"iLm" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "iLo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -14997,21 +13871,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/tunnel)
-"iMY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/structure/kitchenspike_frame{
-	anchored = 1;
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "power armor frame"
-	},
-/obj/structure/table/reinforced{
-	alpha = 0;
-	desc = "Secure bolting to support the heavy weight of power armor.";
-	name = "frame support bolts"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "iNd" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15022,28 +13881,6 @@
 /obj/item/stack/sheet/animalhide/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"iNA" = (
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
-"iNG" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "iNR" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -15068,6 +13905,15 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
+"iQa" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "iQn" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -15088,10 +13934,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"iRj" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+"iRu" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "iRN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
@@ -15100,6 +13951,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/building/museum)
+"iSb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/sleeper,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "iSm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -15206,6 +14066,16 @@
 /obj/machinery/light/small,
 /turf/open/floor/pod,
 /area/f13/caves)
+"iVL" = (
+/obj/machinery/door/poddoor{
+	name = "quarantine door";
+	id = "hangarlock1"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/radiation/crashsite)
 "iWp" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -15244,6 +14114,12 @@
 	color = "#e4e4e4"
 	},
 /area/f13/building)
+"iXy" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "iXM" = (
 /obj/effect/turf_decal/vg_decals/numbers/nine,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -15288,9 +14164,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"iZb" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/chemistry)
 "iZm" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/cleanable/dirt{
@@ -15299,19 +14172,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/river,
 /area/f13/caves)
-"iZt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/plantgenes/seedvault,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
-"iZv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "iZw" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/indestructible/vaultdoor,
@@ -15320,12 +14180,6 @@
 /obj/effect/decal/waste,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"jaC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "jaQ" = (
 /obj/structure/chair/f13chair1{
 	dir = 8
@@ -15336,6 +14190,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
+"jaZ" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "jbk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
@@ -15383,16 +14242,6 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"jcy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "jcA" = (
 /obj/structure/bed,
 /obj/structure/spider/stickyweb,
@@ -15483,6 +14332,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"jfA" = (
+/obj/machinery/door/window/left/directional/north,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "jgb" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -15509,6 +14364,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"jhM" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/good,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "jiI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker/glass,
@@ -15525,15 +14387,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"jjm" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/obj/item/paper_bin,
-/obj/item/pen/charcoal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "jkg" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -15562,19 +14415,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"jlE" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "jmm" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -15590,39 +14430,10 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/caves)
-"jmM" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/sign/poster/prewar/poster73{
-	pixel_y = 31
-	},
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "jmO" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"jmY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"jnc" = (
-/obj/structure/guncase,
-/obj/item/gun/ballistic/shotgun/hunting,
-/obj/item/gun/ballistic/shotgun/hunting,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "jnp" = (
 /obj/effect/decal/waste{
 	pixel_x = 20;
@@ -15642,6 +14453,26 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"jnK" = (
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/chinese/ranged/assault{
+	name = "Colonel Xiaopang";
+	health = 500;
+	maxHealth = 500;
+	melee_damage_lower = 45;
+	melee_damage_upper = 45;
+	extra_projectiles = 3;
+	rapid = 3;
+	rapid_fire_delay = 3;
+	robust_searching = 1
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "jnN" = (
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -15690,6 +14521,12 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"jpV" = (
+/obj/effect/decal/cleanable/blood/gibs/human,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "jqi" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
@@ -15710,15 +14547,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"jqF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "jre" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
@@ -15754,17 +14582,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
-"jsW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
-	},
-/obj/machinery/door/poddoor/shutters/radiation{
-	id = "bosengineaccess"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "jtb" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -30
@@ -15819,6 +14636,14 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"jvz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "jvL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building/museum)
@@ -15835,15 +14660,15 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"jxk" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+"jwz" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "jxv" = (
 /obj/structure/table/wood,
 /obj/item/bodybag,
@@ -15865,18 +14690,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"jyk" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/item/flag/bos,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "jzc" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/subway,
@@ -15929,33 +14742,14 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"jAd" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+"jAp" = (
+/obj/machinery/door/airlock/engineering/abandoned{
+	name = "Reactor"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
 	},
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
-"jAi" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
+/area/f13/radiation/crashsite)
 "jBq" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/tunnel,
@@ -16077,16 +14871,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/museum)
-"jFS" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "jGk" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -16110,15 +14894,6 @@
 "jHb" = (
 /turf/open/floor/plasteel/white,
 /area/f13/wasteland)
-"jHi" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
 "jHm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/flask/vault13,
@@ -16233,29 +15008,25 @@
 /obj/item/ammo_box/a556,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"jNm" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+"jMU" = (
+/obj/structure/sign/departments/medbay{
+	name = "\improper TRIAGE"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"jNn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood/reactor)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/radiation/crashsite)
 "jNq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"jNx" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "jNJ" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -16292,18 +15063,24 @@
 /obj/item/paperplane/origami,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"jOy" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Security Checkpoint"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
+"jOR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "jPd" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"jPY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "jQb" = (
 /obj/structure/fence/cut/large{
 	dir = 4
@@ -16344,13 +15121,6 @@
 	dir = 4
 	},
 /area/f13/caves)
-"jRb" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "jRc" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
@@ -16424,22 +15194,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/caves)
-"jTV" = (
-/obj/machinery/power/am_control_unit{
-	anchored = 1;
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/radiation{
-	id = "bosengineaccess"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "jUa" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/decoration/rag{
@@ -16476,10 +15230,6 @@
 /obj/machinery/workbench/bottler,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"jUK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood/operations)
 "jUP" = (
 /obj/structure/decoration/rag,
 /obj/structure/fence{
@@ -16498,54 +15248,18 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"jUX" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp{
-	pixel_x = 3;
-	pixel_y = 12
+"jVg" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_y = -32;
-	req_one_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
-"jVd" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "jVj" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"jVt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/rnd)
 "jVZ" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -16577,19 +15291,6 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"jXQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/sign/poster/contraband/free_tonto{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 9
-	},
-/area/f13/brotherhood/mining)
 "jYj" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -16612,14 +15313,6 @@
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"jYX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 5
-	},
-/area/f13/brotherhood/mining)
 "jZe" = (
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/inside/subway,
@@ -16643,9 +15336,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"kaL" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood/operations)
 "kaU" = (
 /obj/item/mine/stun,
 /obj/effect/decal/cleanable/dirt{
@@ -16653,10 +15343,21 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"kbs" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/radiation/crashsite)
 "kbt" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"kbu" = (
+/obj/structure/sign/radiation_l,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/radiation/crashsite)
 "kbw" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -16701,6 +15402,11 @@
 /obj/structure/table,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"kew" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "keE" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/water,
@@ -16712,6 +15418,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"kfh" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "kfw" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -16799,6 +15511,16 @@
 	name = "metal plating"
 	},
 /area/f13/city)
+"kim" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/gibs/human,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "kje" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/subway,
@@ -16829,6 +15551,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"kkz" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "kkR" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
@@ -16848,6 +15576,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"klA" = (
+/obj/effect/decal/remains/human,
+/turf/open/water,
+/area/f13/radiation/crashsite)
 "klI" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -16872,23 +15604,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"kmA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
-"kmG" = (
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "kmO" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/jackboots,
@@ -16907,16 +15622,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"knq" = (
-/obj/structure/table/optable,
-/obj/machinery/iv_drip{
-	pixel_x = 15;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "kny" = (
 /obj/structure/reagent_dispensers/barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -16929,13 +15634,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"kok" = (
-/obj/structure/table,
-/obj/item/taperecorder,
-/obj/item/tape/random,
-/obj/item/tape/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+"koa" = (
+/obj/structure/table/rolling,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/radiation/crashsite)
 "kop" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/city)
@@ -17014,6 +15722,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker)
+"ksY" = (
+/obj/effect/spawner/lootdrop/trash,
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "ktc" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -17030,35 +15743,21 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"kto" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/operations)
 "ktN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"ktP" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/gibs/human,
+/obj/item/stack/sheet/mineral/concrete,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "kud" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste{
@@ -17131,10 +15830,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
-"kwq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
-/area/f13/brotherhood/mining)
+"kwf" = (
+/obj/structure/closet/abductor,
+/obj/item/clothing/under/abductor{
+	name = "alien jumpsuit"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "kwB" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -17149,18 +15856,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/tunnel)
-"kwX" = (
-/obj/docking_port/stationary{
-	area_type = /area/f13;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_0";
-	name = "Level 0: Entryway";
-	roundstart_template = /datum/map_template/shuttle/entrance_elevator;
-	width = 4
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/operations)
 "kxA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice,
@@ -17175,13 +15870,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker)
-"kxU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 6
-	},
-/area/f13/brotherhood/mining)
 "kxY" = (
 /obj/structure/sign/directions/medical,
 /turf/closed/wall/r_wall/rust,
@@ -17269,17 +15957,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"kAk" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "kAt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17366,6 +16043,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"kER" = (
+/mob/living/simple_animal/hostile/chinese{
+	name = "Culinary Officer Ramziao";
+	rapid = 1;
+	rapid_melee = 3;
+	health = 200;
+	maxHealth = 200;
+	robust_searching = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "kFa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/folding{
@@ -17459,6 +16147,10 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/radiation)
+"kIq" = (
+/obj/machinery/door/airlock/grunge/abandoned,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "kIA" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/wreck/trash/three_barrels,
@@ -17467,6 +16159,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
+"kIQ" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/type93,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
+"kIY" = (
+/obj/effect/mob_spawn/human/abductor{
+	mob_name = "Cv'zc An'zrq Fyvp'xonpx"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "kJd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17543,6 +16254,10 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"kMV" = (
+/obj/machinery/light,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "kNp" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
@@ -17550,18 +16265,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"kNs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "kNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/f13/raidertreads,
@@ -17604,15 +16307,18 @@
 	name = "metal plating"
 	},
 /area/f13/enclave)
-"kPA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "kPE" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"kQe" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4";
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "kQf" = (
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/vaultdoor,
@@ -17656,16 +16362,6 @@
 	icon_state = "aesculapius"
 	},
 /area/f13/enclave)
-"kRj" = (
-/obj/effect/decal/cleanable/robot_debris/limb,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "kRo" = (
 /obj/item/stack/sheet/mineral/sandbags,
 /turf/open/indestructible/ground/inside/subway{
@@ -17685,13 +16381,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"kSg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 8
-	},
-/area/f13/brotherhood/mining)
 "kSo" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/turf_decal/weather/dirt{
@@ -17721,6 +16410,13 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"kTS" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "kTX" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -17778,6 +16474,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"kVo" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "kVs" = (
 /obj/machinery/light{
 	dir = 1;
@@ -17853,20 +16553,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"kYJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "kYN" = (
 /obj/structure/fluff/railing,
 /obj/structure/table_frame,
@@ -17889,6 +16575,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/vault)
+"kZx" = (
+/obj/structure/table/booth,
+/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "laM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17973,15 +16664,6 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lem" = (
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/floor,
-/obj/structure/railing,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "leT" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -18028,6 +16710,15 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"lgv" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "lgL" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
@@ -18063,14 +16754,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
-"lhB" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 1
-	},
-/area/f13/brotherhood/mining)
 "lhO" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/decoration/rag,
@@ -18087,30 +16770,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"liW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "liZ" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/vault)
-"ljh" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
 "ljB" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -18152,25 +16815,6 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"llf" = (
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/machinery/light/floor,
-/obj/structure/railing,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
-"llk" = (
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "llt" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -18211,33 +16855,11 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"loN" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "loV" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"lpo" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "lpx" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -18252,6 +16874,13 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"lpP" = (
+/obj/structure/table/survival_pod,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "lqb" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -18259,15 +16888,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"lqk" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "lqn" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -18289,6 +16909,9 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"lrr" = (
+/turf/closed/mineral/strong,
+/area/f13/radiation/crashsite)
 "lrO" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
@@ -18306,6 +16929,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/radiation)
+"ltf" = (
+/obj/structure/sign/poster/contraband/communist_state{
+	desc = "All hail the Chinese Communist Party!"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/radiation/crashsite)
 "ltl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -18332,6 +16961,15 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
+"ltF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "ltL" = (
 /obj/structure/table/wood/junk,
 /turf/open/indestructible/ground/inside/subway,
@@ -18363,23 +17001,11 @@
 	icon_state = "reddirtysolid"
 	},
 /area/f13/bunker)
-"lvn" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "lvs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"lvB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
 "lvJ" = (
 /obj/structure/closet/locker,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -18429,20 +17055,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
-"lyt" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/floor,
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "lyO" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/manual/wiki/cooking_to_serve_man,
@@ -18469,11 +17081,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"lzU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/rnd/server/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "lzZ" = (
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/indestructible/ground/inside/subway,
@@ -18484,10 +17091,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/radiation)
-"lAq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+"lAi" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "lAG" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt{
@@ -18580,6 +17186,13 @@
 /obj/item/mine/stun,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"lCK" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "lDl" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -18590,10 +17203,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"lDt" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "lDK" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -18650,6 +17259,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"lFl" = (
+/obj/structure/chair,
+/mob/living/simple_animal/hostile/chinese,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "lFw" = (
 /obj/item/radio/intercom{
 	desc = "Is there anyone on the other end? Who's in there?";
@@ -18725,6 +17342,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"lHv" = (
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "lIr" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
@@ -18893,6 +17514,13 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"lOt" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "lOS" = (
 /obj/structure/car,
 /obj/effect/decal/cleanable/dirt,
@@ -18934,13 +17562,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/caves)
-"lQZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "lRm" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -18955,10 +17576,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"lRn" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
 "lRs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19023,26 +17640,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"lTT" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/computer/shuttle/bosentryelevator{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "lUi" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"lUj" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "lUl" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -19064,12 +17667,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/museum)
-"lUJ" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "lUL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
@@ -19159,6 +17756,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"lXU" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/item/clothing/under/abductor{
+	name = "alien jumpsuit"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "lYS" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -19232,15 +17843,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"mbX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
-/obj/item/storage/box/medicine/stimpaks/stimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "mcp" = (
 /obj/structure/dresser,
 /obj/machinery/light{
@@ -19272,63 +17874,10 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"mdo" = (
-/obj/item/am_containment{
-	pixel_x = 3
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced,
-/obj/item/am_containment,
-/obj/item/am_containment{
-	pixel_x = -3
-	},
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/plasma/reinforced{
-	pixel_y = 26
-	},
-/obj/machinery/door/window{
-	dir = 4;
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "mdC" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
-"mdN" = (
-/obj/structure/grille,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "mdT" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -19385,9 +17934,34 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
+"mgs" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/f13/chinese,
+/obj/item/clothing/under/f13/chinese,
+/obj/item/clothing/under/f13/chinese,
+/obj/item/clothing/head/f13/chinese,
+/obj/item/clothing/head/f13/chinese,
+/obj/item/clothing/head/f13/chinese,
+/obj/item/clothing/suit/armor/medium/vest/chinese,
+/obj/item/clothing/suit/armor/medium/vest/chinese,
+/obj/item/clothing/suit/armor/medium/vest/chinese,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "mgI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
+"mhg" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/chair,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "mip" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -19410,13 +17984,6 @@
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/caves)
-"mjo" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Interrogation";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "mjx" = (
 /obj/item/wrench/crude,
 /turf/open/indestructible/ground/inside/subway,
@@ -19458,6 +18025,18 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/water,
 /area/f13/tunnel)
+"mlu" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
+"mmj" = (
+/obj/machinery/door/airlock/grunge/abandoned{
+	name = "Canteen"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "mmk" = (
 /obj/effect/mob_spawn/human/corpse/raider/tribal,
 /obj/effect/decal/cleanable/blood/old{
@@ -19479,30 +18058,9 @@
 	icon_state = "reddirtysolid"
 	},
 /area/f13/bunker)
-"mmy" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_x = -32;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/landmark/start/f13/paladin,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "mmz" = (
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/caves)
-"mmH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "mna" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
@@ -19515,17 +18073,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker)
-"mnl" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_x = -32;
-	start_charge = 500
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "mnX" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -19571,12 +18118,13 @@
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"mpz" = (
-/obj/effect/decal/cleanable/dirt,
+"mpO" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/high_tools,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	name = "metal plating"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/radiation/crashsite)
 "mqL" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -19612,6 +18160,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"msH" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "msM" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -19673,10 +18230,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/museum)
-"mvR" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "mvW" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -19691,12 +18244,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
-"mwk" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
 "mxd" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -19716,18 +18263,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/enclave)
-"mxA" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "mxE" = (
 /obj/structure/wreck/car/bike{
 	dir = 4;
@@ -19743,6 +18278,10 @@
 /obj/item/reagent_containers/food/drinks/bottle/nukashine,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"mxT" = (
+/obj/effect/mob_spawn/human/corpse/chineseremnant,
+/turf/open/water,
+/area/f13/radiation/crashsite)
 "myr" = (
 /obj/structure/table/booth,
 /obj/machinery/light{
@@ -19758,17 +18297,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/building/museum)
-"myW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"myZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 8
-	},
-/area/f13/brotherhood/mining)
 "mzH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mopbucket,
@@ -19792,6 +18320,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
+"mzW" = (
+/obj/machinery/porta_turret/syndicate,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "mAh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19807,13 +18339,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"mAL" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "mAM" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/stack/sheet/mineral/uranium,
@@ -19856,22 +18381,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/bunker)
+"mDO" = (
+/obj/structure/simple_door/bunker{
+	name = "Bunks"
+	},
+/turf/open/floor/plasteel/asteroid,
+/area/f13/radiation/crashsite)
 "mDU" = (
 /obj/structure/closet/crate/medical/anchored,
 /obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
-"mDZ" = (
-/obj/item/flag/bos,
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "mEb" = (
 /obj/item/instrument/piano_synth,
 /obj/structure/rack,
@@ -19889,12 +18409,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"mEP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "mEQ" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -19913,36 +18427,11 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
-"mGV" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/rdconsole/core/bos{
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal"
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "mHk" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"mHX" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
-	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "mIj" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -19952,12 +18441,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"mIk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "mIw" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -20005,6 +18488,14 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"mJi" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "mJj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -20017,21 +18508,9 @@
 	},
 /turf/open/floor/plating/f13,
 /area/f13/caves)
-"mJz" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 1
-	},
-/area/f13/brotherhood/mining)
-"mJC" = (
-/turf/open/floor/f13{
-	color = "#f7e8e1";
-	dir = 1;
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
+"mJy" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "mJN" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/indestructible/ground/inside/subway,
@@ -20070,6 +18549,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"mKt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	pixel_y = 5;
+	termtag = "Secret";
+	pixel_x = 9
+	},
+/obj/machinery/computer/terminal{
+	pixel_y = 5;
+	termtag = "Secret";
+	pixel_x = -7
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "mKv" = (
 /obj/structure/closet/crate/secure,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -20147,11 +18642,17 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker)
-"mNG" = (
-/obj/machinery/light/small,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/brotherhood/reactor)
+"mNe" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "mOi" = (
 /obj/effect/spawner/structure/window/plasma,
 /obj/structure/grille/indestructable,
@@ -20201,14 +18702,12 @@
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"mPP" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
+"mQb" = (
+/obj/structure/timeddoor{
+	deletion_time = 54000
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "mQC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20217,15 +18716,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"mQQ" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "mRk" = (
 /turf/open/floor/f13{
 	icon_state = "darkredfull"
@@ -20311,20 +18801,6 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"mWk" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
 "mWn" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/indestructible/f13vaultrusted,
@@ -20383,15 +18859,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"mYi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "mYn" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20427,6 +18894,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"nak" = (
+/obj/machinery/door/airlock/abductor,
+/obj/machinery/door/airlock/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "naU" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -20447,50 +18921,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"nbE" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+"nbx" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "nbF" = (
 /obj/structure/chair/booth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
 /area/f13/enclave)
-"nbN" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "nbQ" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"ncb" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "nch" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt{
@@ -20512,6 +18958,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
+"ndv" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/item/storage/box/alienhandcuffs,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "ndM" = (
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -20562,15 +19017,6 @@
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"nfk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
 "ngc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -20587,10 +19033,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
-"ngl" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
+"ngi" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/old{
+	name = "checkpoint shutters";
+	id = "placheck"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "ngO" = (
 /obj/item/kirbyplants/dead,
 /obj/effect/decal/cleanable/dirt,
@@ -20600,18 +19051,6 @@
 /obj/structure/decoration/rads,
 /turf/closed/wall/r_wall/rust,
 /area/f13/radiation)
-"nhm" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "nhy" = (
 /obj/structure/table,
 /obj/item/healthanalyzer/advanced,
@@ -20619,18 +19058,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"nid" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "niu" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -20664,15 +19091,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"nja" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood/reactor)
 "nji" = (
 /obj/structure/fluff/rails,
 /obj/structure/handrail/g_central{
@@ -20715,20 +19133,30 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"nlx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 5
-	},
-/area/f13/brotherhood/reactor)
 "nlA" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"nlB" = (
+/mob/living/simple_animal/hostile/chinese,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "nlL" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"nmb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/barricade/concrete,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "nmE" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/machinery/light/small/broken{
@@ -20743,6 +19171,14 @@
 /obj/machinery/light/small,
 /turf/open/water,
 /area/f13/tunnel)
+"nmZ" = (
+/obj/structure/closet/crate/footlocker,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "nnP" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/decoration/rag{
@@ -20754,6 +19190,16 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"noc" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "bloodpaw1"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/f13/radiation/crashsite)
 "noI" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "rustedshutters";
@@ -20772,6 +19218,18 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
+"nph" = (
+/obj/structure/table/glass,
+/obj/structure/window/reinforced/spawner,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/radiation/crashsite)
 "npl" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -20816,14 +19274,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/vault)
-"nra" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
 "nre" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -20883,6 +19333,16 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"nrX" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "nsc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -20892,10 +19352,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
-"nsy" = (
-/obj/effect/decal/cleanable/ash/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+"nsz" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
+"nsH" = (
+/mob/living/simple_animal/hostile/chinese/ranged/assault{
+	robust_searching = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "nsW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/shotgun/improvised,
@@ -20935,6 +19410,20 @@
 /obj/structure/chair/sofa/right,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"nuH" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
+"nvi" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "nvA" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20943,12 +19432,15 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"nvP" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
+"nwr" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/old{
+	name = "checkpoint shutters";
+	id = "placheck"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "nws" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/building/massfusion)
@@ -20962,12 +19454,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/radiation)
-"nyk" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "nyl" = (
 /obj/machinery/light{
 	dir = 8;
@@ -20997,6 +19483,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"nyP" = (
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "nyY" = (
 /obj/item/trash/f13/tin{
 	dir = 4;
@@ -21075,6 +19568,13 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"nCf" = (
+/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "nCh" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -21116,6 +19616,34 @@
 "nDW" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/ncr)
+"nEi" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"nEn" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
+"nEq" = (
+/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
+"nEw" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "nEE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -21143,14 +19671,6 @@
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"nER" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#f7e8e1";
-	dir = 1;
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "nFk" = (
 /obj/structure/table/booth,
 /obj/effect/decal/waste{
@@ -21201,6 +19721,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/bunker)
+"nHE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 8
+	},
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/old{
+	name = "checkpoint shutters";
+	id = "placheck"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "nHW" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/leather/twenty,
@@ -21240,15 +19772,6 @@
 	name = "cave"
 	},
 /area/f13/caves)
-"nJF" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "nJK" = (
 /obj/item/trash/f13/c_ration_1,
 /turf/open/indestructible/ground/inside/subway,
@@ -21262,10 +19785,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"nKo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "nKt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -21347,6 +19866,9 @@
 /obj/item/stack/sheet/plasteel/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/caves)
+"nMQ" = (
+/turf/closed/wall/mineral/abductor,
+/area/f13/radiation/crashsite)
 "nMW" = (
 /obj/machinery/light{
 	dir = 4;
@@ -21359,12 +19881,6 @@
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/caves)
-"nNw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood/reactor)
 "nNA" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -21385,14 +19901,17 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"nNV" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "nOa" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"nOe" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "nOj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -21416,6 +19935,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"nOX" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/chinese,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "nPd" = (
 /obj/structure/chair/f13chair1{
 	dir = 1
@@ -21479,6 +20008,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"nRu" = (
+/obj/machinery/light,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "nRv" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/tunnel{
@@ -21536,22 +20071,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"nTq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "nTu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"nUc" = (
-/obj/structure/chalkboard,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "nUs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -21562,6 +20087,25 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"nUB" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/power/port_gen/pacman/super,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
+"nVv" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "nVH" = (
 /obj/machinery/door/airlock/grunge,
 /obj/machinery/door/airlock/grunge,
@@ -21649,6 +20193,16 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"oae" = (
+/obj/structure/closet/crate/footlocker,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "oai" = (
 /obj/machinery/light{
 	dir = 8
@@ -21697,25 +20251,6 @@
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall,
 /area/f13/vault)
-"obp" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Brig";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"obE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	desc = "An airtight door, built to withstand a nuclear blast.";
-	max_integrity = 10000;
-	name = "bunker entry";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "ocs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21743,12 +20278,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/radiation)
-"oer" = (
-/obj/effect/landmark/start/f13/Knight,
-/obj/effect/landmark/start/f13/seniorknight,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "oew" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -21800,6 +20329,20 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"ogS" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/pod/light,
+/area/f13/radiation/crashsite)
+"ohP" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/obj/machinery/door/window/right/directional/east,
+/obj/effect/mob_spawn/human/corpse/pirate,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "oib" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -21815,23 +20358,22 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"oiI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
 "oiV" = (
 /obj/machinery/door/poddoor{
 	id = "pain"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"ojc" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/item/cautery/alien,
+/obj/item/circular_saw/alien,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "ojf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/tunnel,
@@ -21952,36 +20494,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"onN" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
-	},
-/area/f13/brotherhood/operating)
-"opd" = (
-/obj/machinery/vending/cola/starkist,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"opo" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/integrated_circuit_printer,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/debugger,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "opv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"opI" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "opP" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -22015,6 +20532,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"oqX" = (
+/mob/living/simple_animal/hostile/chinese,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "orr" = (
 /obj/structure/timeddoor,
 /turf/closed/indestructible/rock,
@@ -22054,12 +20577,20 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"otv" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+"otN" = (
+/mob/living/simple_animal/hostile/chinese/ranged/assault{
+	robust_searching = 1;
+	health = 250;
+	maxHealth = 250;
+	name = "Quartermaster Huangxiong"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "otS" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/dirt,
@@ -22072,16 +20603,6 @@
 /obj/item/trash/f13/specialapples,
 /turf/open/water,
 /area/f13/caves)
-"oux" = (
-/obj/structure/chair/f13foldupchair{
-	desc = "A folding chair, missing half the seat, probably for dropping something through it.";
-	dir = 1
-	},
-/obj/effect/landmark/start/f13/scribe,
-/obj/effect/landmark/start/f13/seniorscribe,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "ouC" = (
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/subway,
@@ -22145,17 +20666,15 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"owd" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "owp" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "militarystorage2"
 	},
 /turf/open/floor/plasteel/f13/metal,
 /area/f13/tunnel)
+"owD" = (
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "owE" = (
 /obj/item/trash/f13/borscht,
 /obj/effect/decal/cleanable/dirt,
@@ -22342,6 +20861,10 @@
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"oGw" = (
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "oGV" = (
 /obj/structure/table/wood,
 /obj/structure/railing{
@@ -22357,6 +20880,12 @@
 	color = "#e4e4e4"
 	},
 /area/f13/caves)
+"oHA" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "bloodpaw1"
+	},
+/turf/open/floor/pod/light,
+/area/f13/radiation/crashsite)
 "oHI" = (
 /obj/structure/sign/departments/security,
 /obj/effect/decal/cleanable/dirt{
@@ -22391,14 +20920,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"oHS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "oIe" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -22430,14 +20951,6 @@
 /obj/structure/table,
 /turf/open/floor/plating/rust,
 /area/f13/tunnel)
-"oJL" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/shutters/radiation{
-	id = "bosengineaccess"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "oKm" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/mineral/plastitanium,
@@ -22594,9 +21107,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
-"oQH" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
+"oPU" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/high_tools,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
+"oQa" = (
+/mob/living/simple_animal/hostile/chinese,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "oRB" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -22629,6 +21155,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"oSt" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "oSM" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -22722,29 +21256,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"oVw" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "oWm" = (
 /obj/machinery/defibrillator_mount,
 /turf/closed/wall/r_wall/rust,
@@ -22796,16 +21307,6 @@
 /obj/structure/bed/pod,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/museum)
-"oYb" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "oYr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -22895,15 +21396,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"pag" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "pak" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
@@ -22930,6 +21422,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"paM" = (
+/obj/structure/closet/fridge/meat,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "paX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -22964,16 +21460,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"pcM" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
+"pcr" = (
+/obj/item/shard/plasma/alien,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
+/area/f13/radiation/crashsite)
+"pcv" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 50
+	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	name = "metal plating"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/radiation/crashsite)
 "pde" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -23064,24 +21566,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/vault)
-"pie" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"pii" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/landmark/start/f13/Knight,
-/obj/effect/landmark/start/f13/seniorknight,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "piA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -23130,6 +21614,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"pln" = (
+/obj/structure/table,
+/obj/item/storage/bag/tray,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "plp" = (
 /obj/structure/nest/supermutant,
 /obj/effect/decal/cleanable/dirt,
@@ -23145,15 +21634,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
-"plW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 6
-	},
-/area/f13/brotherhood/reactor)
 "pmD" = (
 /obj/structure/closet{
 	storage_capacity = 10
@@ -23187,21 +21667,16 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"pnF" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "pnN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
-"pnU" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"pom" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "pox" = (
 /obj/structure/showcase/horrific_experiment{
 	desc = "Some sort of pod. Seems this one's maintanance panel is open, someone was working on this.";
@@ -23211,9 +21686,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"poN" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "ppq" = (
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -23222,9 +21694,6 @@
 /obj/structure/window/shuttle/survival_pod,
 /turf/open/floor/pod/light,
 /area/f13/caves)
-"ppK" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood/operations)
 "pqq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -23300,18 +21769,6 @@
 /obj/structure/flora/wasteplant/wild_mutfruit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ptr" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "ptx" = (
 /obj/machinery/light/small,
 /obj/structure/table,
@@ -23327,6 +21784,23 @@
 	name = "cave"
 	},
 /area/f13/caves)
+"ptO" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
+"ptX" = (
+/obj/effect/decal/waste{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "pua" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/radiation)
@@ -23424,6 +21898,18 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"pya" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/machinery/abductor/console{
+	name = "alien console"
+	},
+/obj/item/shard/plasma/alien,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "pzk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/kitchenspike,
@@ -23439,12 +21925,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"pzC" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "pAe" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -23540,13 +22020,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/vault)
-"pDv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "pDI" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
@@ -23577,18 +22050,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"pEV" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Mining Storeroom";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "pFw" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
@@ -23610,19 +22071,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
-"pFY" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster70";
-	pixel_x = 31
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "pGB" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -23716,14 +22164,6 @@
 /obj/item/restraints/legcuffs/bola,
 /turf/open/floor/plating/rust,
 /area/f13/tunnel)
-"pIT" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/floor,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/reactor)
 "pJc" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -23737,17 +22177,31 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"pJr" = (
-/obj/structure/curtain{
-	color = "#845f58"
+"pJl" = (
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
 	},
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/radiation/crashsite)
 "pJv" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"pKu" = (
+/obj/machinery/button/door{
+	id = "hangarlock2";
+	pixel_x = 28
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "pLh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23780,10 +22234,6 @@
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"pMC" = (
-/obj/structure/weightmachine/stacklifter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "pMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -23808,18 +22258,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"pNx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 5;
-	name = "Brig Camera";
-	network = list("BoS")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "pNE" = (
 /obj/structure/window/fulltile/ruins,
 /obj/structure/barricade/wooden/planks,
@@ -23887,10 +22325,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"pQZ" = (
-/obj/structure/closet/crate/medical,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "pRa" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/cleanable/dirt,
@@ -23906,18 +22340,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
-"pRg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 5
-	},
-/area/f13/brotherhood/mining)
 "pRy" = (
 /obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt,
@@ -23948,15 +22370,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"pSR" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/obj/machinery/computer/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "pSZ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -23964,6 +22377,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
+"pTq" = (
+/obj/machinery/button/door{
+	id = "hangarlock2";
+	pixel_y = 28
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "pTv" = (
 /obj/structure/table,
 /obj/item/soap,
@@ -23987,52 +22409,21 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
-"pTW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
-"pTX" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/f13/brotherhood/medical)
-"pUC" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "pUS" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"pUW" = (
+/obj/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters/radiation{
+	id = "hangar"
+	},
+/obj/structure/grille,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "pVm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -24044,12 +22435,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"pVB" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "pVW" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -24086,6 +22471,12 @@
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pXU" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "pYd" = (
 /obj/item/geiger_counter,
 /turf/open/indestructible/ground/inside/subway,
@@ -24145,31 +22536,10 @@
 	icon_state = "2-i"
 	},
 /area/f13/caves)
-"qaO" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "qba" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"qbd" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
-"qbi" = (
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/floor,
-/obj/structure/railing,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "qbj" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/cups,
@@ -24204,22 +22574,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qcR" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
 "qcZ" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
 /area/f13/caves)
-"qdA" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
 "qdZ" = (
 /obj/machinery/shower{
 	pixel_y = 17
@@ -24295,13 +22655,16 @@
 "qgq" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/caves)
-"qgC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+"qgL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/brotherhood/mining)
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "qgU" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -24318,21 +22681,6 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_four,
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/caves)
-"qhg" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "qhm" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
 	icon_state = "tealwhrusty_chess2"
@@ -24389,28 +22737,6 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
-"qje" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/under/rank/medical/green,
-/obj/item/clothing/under/rank/medical/purple,
-/obj/item/clothing/under/rank/medical/blue,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "qjm" = (
 /obj/structure/rack,
 /obj/item/electropack/shockcollar{
@@ -24431,31 +22757,10 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/museum)
-"qjA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "qjR" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"qka" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/rnd)
 "qky" = (
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel{
@@ -24493,18 +22798,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"qlb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Brig";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosbriglock";
-	name = "brig lockdown"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "qlg" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/decoration/rag{
@@ -24525,12 +22818,27 @@
 	icon_state = "2-i"
 	},
 /area/f13/caves)
+"qlC" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "qlL" = (
 /obj/structure/fluff/railing{
 	dir = 5
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
+"qlP" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "chinese"
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "qmg" = (
 /obj/structure/chair/right{
 	dir = 1
@@ -24538,6 +22846,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
+"qms" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "qmt" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/turf_decal/weather/dirt,
@@ -24551,18 +22863,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"qnl" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "qnL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -24610,6 +22910,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"qoM" = (
+/obj/structure/bed/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
+"qoS" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/high_tools,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
+"qpe" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "qpl" = (
 /obj/structure/decoration/rag,
 /obj/effect/decal/cleanable/dirt,
@@ -24679,21 +23004,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/museum)
-"qqH" = (
-/obj/machinery/button/door{
-	id = "bosdoors";
-	name = "Bunker Lockdown Button"
-	},
-/obj/machinery/button/door{
-	id = "bosdoors3";
-	name = "Bunker Lockdown Button";
-	pixel_y = 8
-	},
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "qqW" = (
 /obj/machinery/light{
 	dir = 1;
@@ -24710,6 +23020,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"qrn" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/dice,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "qrx" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -24769,27 +23087,6 @@
 "qsY" = (
 /turf/open/floor/wood_common,
 /area/f13/caves)
-"qtg" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/light_emitter,
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
-"qtj" = (
-/obj/item/multitool,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "qtA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -24887,10 +23184,11 @@
 /obj/structure/noticeboard,
 /turf/closed/wall/rust,
 /area/f13/tunnel)
-"qxb" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
+"qxa" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "qxi" = (
 /obj/item/stack/ore/blackpowder/five,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24909,14 +23207,6 @@
 	name = "metal plating"
 	},
 /area/f13/enclave)
-"qyj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "qyC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -24954,10 +23244,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"qAd" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+"qzM" = (
+/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "qAw" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -25009,11 +23304,6 @@
 	},
 /turf/open/indestructible/ground/outside/river,
 /area/f13/caves)
-"qCS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
 "qDu" = (
 /obj/machinery/sleeper,
 /obj/machinery/light{
@@ -25022,17 +23312,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
-"qDG" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2
-	},
-/obj/item/key/vertibird,
-/obj/item/storage/box/disks_plantgene,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
 "qDL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
@@ -25052,9 +23331,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/sewer)
-"qEc" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "qEQ" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt{
@@ -25091,6 +23367,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qFQ" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "qFR" = (
 /turf/closed/wall/f13/wood,
 /area/f13/building)
@@ -25152,6 +23434,18 @@
 /obj/structure/falsewall/rust,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"qIv" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "qIw" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
@@ -25168,18 +23462,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
-"qIN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/box,
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "BoSLadder"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "qIQ" = (
 /obj/structure/nest/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25275,36 +23557,17 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"qOl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosarmoryacc";
-	name = "Armory";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"qOM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+"qOB" = (
+/obj/structure/table,
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "qOQ" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
 /obj/item/reagent_containers/food/snacks/meat/slab/molerat,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"qOS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "qOX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -25333,15 +23596,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/f13,
 /area/f13/caves)
-"qPU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "qPV" = (
 /obj/structure/sink{
 	dir = 4;
@@ -25355,11 +23609,6 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/radiation)
-"qQa" = (
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
 "qQF" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -25381,22 +23630,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
-"qRO" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 12
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "qSB" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -25476,6 +23709,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"qUE" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "qUM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -25484,10 +23726,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
 /area/f13/radiation)
-"qVc" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "qVR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/ammo,
@@ -25518,22 +23756,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qXn" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 12
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
-"qXt" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "qXw" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -25579,6 +23801,15 @@
 /obj/structure/weightlifter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"raj" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "rao" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -25589,23 +23820,6 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"raI" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
 "raS" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -25681,19 +23895,6 @@
 /obj/machinery/door/poddoor/shutters/radiation,
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
-"red" = (
-/obj/structure/target_stake{
-	anchored = 1
-	},
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "ref" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/inside/subway,
@@ -25850,6 +24051,22 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
+"rlq" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
+"rlG" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "rlJ" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13{
@@ -25860,6 +24077,11 @@
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"rlV" = (
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "rlY" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/r_wall/rust,
@@ -25896,10 +24118,6 @@
 	dir = 9
 	},
 /area/f13/building/museum)
-"rpb" = (
-/obj/structure/closet/crate/medical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "rph" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -25915,6 +24133,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/vault)
+"rpr" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "rpy" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -25926,13 +24150,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"rpW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
 "rqS" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
@@ -25957,40 +24174,27 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"rru" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "rry" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
+"rrE" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/item/abductor/baton{
+	name = "electro-suppressor"
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "rrL" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/vault)
-"rsu" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
 "rtc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor{
@@ -26010,6 +24214,25 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"ruv" = (
+/obj/structure/door_assembly/door_assembly_abductor{
+	anchored = 1;
+	name = "broken alien airlock"
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
+"rvj" = (
+/obj/structure/table/rolling,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/north,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/radiation/crashsite)
 "rvD" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/wasteplant/wild_mesquite,
@@ -26077,15 +24300,6 @@
 /obj/item/stock_parts/matter_bin,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"rzq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "rzv" = (
 /obj/structure/table/glass,
 /obj/item/healthanalyzer/advanced,
@@ -26104,10 +24318,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/f13/building/museum)
-"rzB" = (
-/obj/machinery/rnd/destructive_analyzer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "rzI" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -26134,21 +24344,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"rAF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "rAS" = (
 /obj/structure/rack,
 /obj/item/grenade/f13/radiation,
@@ -26230,31 +24425,6 @@
 	icon_state = "reddirtysolid"
 	},
 /area/f13/bunker)
-"rEe" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/shutters/radiation{
-	id = "bosengineaccess"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
-"rEV" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "rEX" = (
 /obj/machinery/light{
 	dir = 4;
@@ -26278,31 +24448,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"rGh" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
-"rGi" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "rGr" = (
 /obj/machinery/rnd/server/vault,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
-"rGN" = (
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+"rGA" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/area/f13/brotherhood/operations)
+/obj/machinery/light/small/broken,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "rHD" = (
 /obj/item/storage/box/ration/menu_nine,
 /obj/item/storage/box/ration/menu_nine,
@@ -26372,10 +24532,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"rKx" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "rKK" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -26391,14 +24547,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"rLd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
-"rLw" = (
-/obj/machinery/sleeper,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "rLV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -26425,11 +24573,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"rMm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "rMI" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -26500,11 +24643,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"rOY" = (
-/obj/effect/decal/cleanable/ash/large,
-/obj/effect/decal/cleanable/ash/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "rPq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
@@ -26533,10 +24671,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"rQY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/chemistry)
 "rRt" = (
 /obj/item/storage/trash_stack,
 /turf/open/water,
@@ -26549,12 +24683,6 @@
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
-"rRT" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/bedsheet/black,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "rSu" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -26572,19 +24700,6 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"rTn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "rTT" = (
 /obj/structure/closet/crate/wooden,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -26620,15 +24735,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"rUI" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/pool/drain,
-/obj/structure/toilet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "rUN" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26672,6 +24778,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"rWJ" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/good,
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "rWP" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -26697,6 +24815,15 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
+"rYA" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "rYZ" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/subway,
@@ -26709,16 +24836,6 @@
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"sab" = (
-/obj/machinery/autolathe/ammo,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/effect/turf_decal/stripes/box,
-/obj/item/book/granter/crafting_recipe/gunsmith_one,
-/obj/item/book/granter/crafting_recipe/gunsmith_two,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "sak" = (
 /obj/structure/stairs/north{
 	dir = 2
@@ -26822,22 +24939,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
-"sdN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/decoration/hatch{
-	dir = 4
-	},
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 10
-	},
-/area/f13/brotherhood/mining)
 "sdX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -26897,10 +24998,20 @@
 	},
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
+"sgU" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "shg" = (
 /mob/living/simple_animal/hostile/ghoul/legendary,
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
+"shu" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "shz" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -26912,15 +25023,6 @@
 /obj/item/trash/f13/rotten,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/radiation)
-"shW" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "sib" = (
 /obj/structure/stairs/north{
 	dir = 2
@@ -26934,13 +25036,6 @@
 	name = "metal plating"
 	},
 /area/f13/city)
-"siR" = (
-/obj/structure/chair/f13chair2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "sjg" = (
 /obj/structure/flora/wasteplant/wild_xander,
 /obj/structure/flora/rock/pile/largejungle{
@@ -27024,31 +25119,6 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"smq" = (
-/obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"smz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "smT" = (
 /obj/structure/campfire/barrel,
 /turf/open/floor/f13{
@@ -27062,36 +25132,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"snr" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
-"snv" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
+"snA" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "snS" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/blood/old{
@@ -27104,6 +25149,11 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/enclave)
+"soy" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "soz" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /obj/effect/turf_decal/bot,
@@ -27115,29 +25165,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"soS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood/reactor)
 "spC" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"spR" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	pixel_y = 3;
-	termtag = "Security"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "sqv" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /obj/effect/decal/cleanable/dirt,
@@ -27170,13 +25203,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"sqT" = (
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "srb" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -27192,6 +25218,10 @@
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
+"srD" = (
+/obj/structure/guncase/shotgun,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "ssl" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -27232,6 +25262,12 @@
 	},
 /turf/open/indestructible/ground/outside/river,
 /area/f13/caves)
+"stP" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "stX" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -27265,10 +25301,22 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"svo" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/item/shard/plasma/alien,
+/turf/closed/mineral/strong,
+/area/f13/radiation/crashsite)
 "svy" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"svF" = (
+/obj/structure/closet/fridge/cannibal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "svL" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
@@ -27277,28 +25325,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"svV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/hatch{
-	desc = "An airtight door, built to withstand a nuclear blast.";
-	max_integrity = 10000;
-	name = "bunker entry";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"swd" = (
-/obj/machinery/autolathe/constructionlathe,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "swl" = (
 /obj/item/clothing/head/crown/fancy,
 /turf/open/indestructible/ground/inside/mountain,
@@ -27311,15 +25337,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"sws" = (
-/obj/structure/simple_door/bunker{
-	name = "Firing Range";
-	req_one_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "swz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/wreck/trash/two_barrels,
@@ -27336,15 +25353,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"sxg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+"sxf" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/obj/item/kitchen/knife/butcher,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "sxA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -27386,35 +25400,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
-"syJ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/item/book/granter/crafting_recipe/blueprint/aep7,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"syO" = (
-/obj/structure/fluff/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "sza" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/light{
@@ -27485,12 +25470,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"sAE" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
 "sAJ" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -27582,12 +25561,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"sEu" = (
-/obj/machinery/light/small,
-/obj/structure/table,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "sFr" = (
 /obj/structure/junk/locker,
 /turf/open/floor/plating/tunnel{
@@ -27623,12 +25596,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"sGN" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "sHy" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd1";
@@ -27664,26 +25631,10 @@
 /obj/structure/blacksmith/quenching,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"sJK" = (
-/obj/machinery/pdapainter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "sKa" = (
 /obj/item/mine/explosive,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sKb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "sKn" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -27770,6 +25721,12 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"sNZ" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "sOm" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -27806,20 +25763,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"sOM" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/toy/figure/chemist{
-	layer = 2.8;
-	name = "Scribe action figure";
-	toysay = "Ad meliora."
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "sOQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag{
@@ -27933,6 +25876,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"sTk" = (
+/obj/structure/table,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "sTt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27941,26 +25889,17 @@
 "sUF" = (
 /turf/closed/indestructible/rock,
 /area/f13/radiation)
-"sVs" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+"sVJ" = (
+/obj/machinery/door/airlock/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/f13/brotherhood/operating)
+/area/f13/radiation/crashsite)
 "sWm" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
-"sWp" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "sWu" = (
 /obj/machinery/light{
 	dir = 4
@@ -28083,12 +26022,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building)
-"sZI" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Power"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "sZY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden/strong,
@@ -28120,31 +26053,6 @@
 	name = "cave"
 	},
 /area/f13/caves)
-"tbi" = (
-/obj/machinery/computer/terminal{
-	dir = 4;
-	pixel_y = -6;
-	termtag = "Secret"
-	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 4;
-	pixel_y = 10
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"tbl" = (
-/obj/structure/target_stake{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "tbv" = (
 /obj/structure/wreck/trash/machinepile{
 	pixel_x = -17
@@ -28178,12 +26086,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"tck" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"tci" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "tcl" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
@@ -28234,35 +26142,16 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"tea" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
-"teg" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
 "tep" = (
 /obj/structure/table,
 /obj/item/coin/uranium,
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
+"ter" = (
+/obj/structure/table,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "teF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -28283,17 +26172,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
-"tfh" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "tfm" = (
 /obj/structure/table,
 /obj/item/blacksmith/ingot/uranium,
@@ -28311,6 +26189,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"tfu" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "tfE" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/effect/decal/cleanable/dirt,
@@ -28341,18 +26223,6 @@
 "tih" = (
 /turf/closed/wall/r_wall,
 /area/f13/vault)
-"tiq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "tit" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -28398,22 +26268,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/enclave)
-"tjx" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "bosengineaccess";
-	name = "Engineering Lockdown";
-	pixel_x = 34;
-	pixel_y = -4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "tjD" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -28444,34 +26298,14 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"tkA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
+"tkF" = (
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
 	},
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/water,
-/area/f13/brotherhood/operations)
-"tkX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
+/area/f13/radiation/crashsite)
 "tkZ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -28493,17 +26327,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tmf" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
-"tmr" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "tmz" = (
 /obj/structure/fluff/rails,
 /obj/structure/handrail/g_central{
@@ -28556,10 +26379,6 @@
 /obj/item/twohanded/sledgehammer/atomsjudgement,
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
-"toj" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "toq" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/tunnel{
@@ -28578,13 +26397,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"tpp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "tpB" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/vault)
@@ -28622,21 +26434,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"tqV" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/rdconsole/core/bos{
-	dir = 4;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "tra" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13{
@@ -28675,14 +26472,19 @@
 	icon_state = "tealwhrusty_chess2"
 	},
 /area/f13/enclave)
-"tuh" = (
-/obj/item/am_shielding_container,
-/turf/open/floor/plating,
-/area/f13/brotherhood/reactor)
-"tuq" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+"tua" = (
+/obj/structure/safe/floor,
+/obj/item/clothing/under/f13/chinasuitcosmetic,
+/obj/item/clothing/head/f13/chinahelmetcosmetic,
+/obj/machinery/button/door{
+	id = "placheck";
+	pixel_x = 24
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "tuP" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light/small/broken{
@@ -28740,6 +26542,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"twz" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "twE" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -28773,12 +26583,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
 /area/f13/tunnel)
-"tyb" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "tyo" = (
 /obj/structure/chair,
 /obj/structure/cable{
@@ -28844,6 +26648,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
+"tBg" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "tBM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -28939,13 +26749,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"tED" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
 "tFp" = (
 /obj/structure/flora/tree/wasteland{
 	color = "#000000";
@@ -28959,13 +26762,6 @@
 "tFN" = (
 /turf/open/floor/plating/dirt,
 /area/f13/tunnel)
-"tFU" = (
-/obj/effect/decal/cleanable/robot_debris,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
 "tGc" = (
 /obj/structure/table,
 /turf/open/floor/plating/rust,
@@ -29109,10 +26905,19 @@
 /obj/item/reagent_containers/rag/towel,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"tNp" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+"tMT" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/chinese,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
+"tNu" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "tNM" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -29146,19 +26951,18 @@
 /obj/structure/bed/old,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/radiation)
+"tON" = (
+/obj/machinery/door/airlock/glass_large,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/timeddoor{
+	deletion_time = 54000
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "tPy" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
-"tPN" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "tQC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
@@ -29177,12 +26981,17 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"tRs" = (
-/obj/machinery/sleeper,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+"tRr" = (
+/obj/machinery/shuttle/engine/void{
+	dir = 4
 	},
-/area/f13/brotherhood/operating)
+/obj/effect/spawner/structure/window/hollow/plasma/reinforced/directional{
+	dir = 4
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "tRA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -29235,6 +27044,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"tTP" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "tUb" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
@@ -29251,6 +27066,14 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"tUC" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "tUX" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
@@ -29262,23 +27085,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
-"tVi" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "tVo" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
-"tVB" = (
-/obj/structure/rack,
-/obj/item/trash/f13/electronic/toaster/atomics,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
 "tVR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -29299,11 +27110,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"tWF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "tWW" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/duffelbag,
@@ -29315,15 +27121,13 @@
 	color = "#e4e4e4"
 	},
 /area/f13/caves)
-"tXz" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
+"tXk" = (
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 8
-	},
-/area/f13/brotherhood/mining)
+/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "tYi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/plastic/fifty,
@@ -29365,18 +27169,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"tZM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "uap" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/darkpurple/side{
@@ -29419,6 +27211,13 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"ucd" = (
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "uce" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/inside/subway,
@@ -29495,15 +27294,17 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
-"ufZ" = (
-/obj/machinery/light/small{
-	dir = 8
+"ufS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "ugN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -29543,6 +27344,10 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uiB" = (
+/obj/structure/bed/mattress,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "uiK" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -29607,71 +27412,11 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"ulV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/brotherhood/reactor)
 "umW" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"unG" = (
-/obj/structure/rack,
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 11
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -6;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = 2;
-	pixel_y = -10
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 13;
-	pixel_y = -8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "unL" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13{
@@ -29733,18 +27478,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/caves)
-"upE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "upT" = (
 /obj/structure/shelf_wood,
 /turf/open/floor/carpet/black,
@@ -29798,33 +27531,42 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"urr" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "urK" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"urZ" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/rnd)
-"usd" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "usG" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
+"usQ" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/item/storage/belt/utility/abductor/full,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
+"usT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "utC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -29879,13 +27621,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
-"uuV" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "uvu" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -29898,14 +27633,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"uvv" = (
-/obj/machinery/rnd/production/protolathe,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "uvF" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_3"
@@ -29927,30 +27654,6 @@
 	name = "metal plating"
 	},
 /area/f13/enclave)
-"uwe" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/operations)
 "uwo" = (
 /obj/structure/simple_door/metal/ventilation{
 	name = "drainage system"
@@ -30042,6 +27745,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
+"uzH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/gibs/human,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "uzY" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /obj/machinery/light/small{
@@ -30078,6 +27790,16 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"uAO" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/toolsgood,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "uBh" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -30129,26 +27851,15 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"uCb" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"uCn" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
+"uCa" = (
+/mob/living/simple_animal/hostile/chinese,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	name = "metal plating"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/radiation/crashsite)
 "uCB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30193,6 +27904,13 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"uEc" = (
+/obj/effect/decal/cleanable/blood/gibs/human,
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "bloodpaw1"
+	},
+/turf/open/floor/pod/light,
+/area/f13/radiation/crashsite)
 "uEp" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -30240,22 +27958,17 @@
 	icon_state = "bluerustyfull"
 	},
 /area/f13/vault)
-"uFI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "uFO" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"uGE" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light{
-	dir = 8
+"uGH" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/radiation/crashsite)
 "uGW" = (
 /obj/structure/guncase,
 /turf/open/floor/pod,
@@ -30278,23 +27991,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
-"uHs" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
-"uHx" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen/fourcolor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "uHK" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/building/museum)
@@ -30383,20 +28079,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"uKD" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/floor,
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "uKM" = (
 /obj/structure/railing{
 	dir = 9
@@ -30580,16 +28262,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"uTw" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/twig3,
-/turf/open/water,
-/area/f13/brotherhood/operations)
 "uTP" = (
 /obj/structure/chair/stool/bar,
 /mob/living/simple_animal/hostile/supermutant/legendary,
@@ -30627,6 +28299,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"uVy" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "uVz" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards{
@@ -30676,6 +28354,15 @@
 	name = "metal plating"
 	},
 /area/f13/city)
+"uWZ" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "bloodpaw1"
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "bloodpaw1"
+	},
+/turf/open/floor/pod/light,
+/area/f13/radiation/crashsite)
 "uXj" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/rust,
@@ -30688,27 +28375,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/tunnel)
-"uXy" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Brig";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"uXE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/rnd)
 "uYm" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/indestructible/ground/outside/ruins,
@@ -30733,9 +28399,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"vaB" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "vaR" = (
 /obj/structure/simple_door/wood,
 /obj/structure/barricade/wooden/planks,
@@ -30746,18 +28409,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
-"vaW" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Brig";
-	req_access_txt = "120"
+"vbd" = (
+/obj/machinery/abductor/pad{
+	team_number = 100
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosbriglock";
-	name = "brig lockdown"
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/area/f13/radiation/crashsite)
 "vbe" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/glass,
@@ -30765,6 +28424,10 @@
 	dir = 10
 	},
 /area/f13/caves)
+"vbg" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "vbm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30807,10 +28470,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"vcf" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "vck" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
@@ -30880,30 +28539,16 @@
 	name = "cave"
 	},
 /area/f13/caves)
-"vej" = (
-/obj/structure/fluff/railing{
-	color = "#968d87";
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "vep" = (
 /obj/structure/bed/old,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"veU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
+"veH" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "veV" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/cups,
@@ -31037,24 +28682,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"viA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "viE" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/machinery/light/small/broken{
@@ -31067,15 +28694,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"viO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 4
-	},
-/area/f13/brotherhood/mining)
 "vje" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -31221,9 +28839,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"vqC" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/mining)
 "vqO" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -31262,6 +28877,14 @@
 "vsj" = (
 /turf/open/floor/plasteel/caution,
 /area/f13/caves)
+"vsn" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "vsH" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31291,15 +28914,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"vtY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "vup" = (
 /obj/item/trash/f13/fancylads,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31325,6 +28939,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"vvu" = (
+/obj/machinery/door/airlock/glass_large,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/timeddoor{
+	deletion_time = 54000
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "vvw" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/pa_wear,
@@ -31339,6 +28961,16 @@
 /obj/item/airlock_painter,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
+"vwy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table,
+/obj/machinery/computer/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "vwJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -31370,14 +29002,6 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
-"vxY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/computer/security/bos{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "vyr" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/tunnel{
@@ -31414,13 +29038,16 @@
 	name = "metal plating"
 	},
 /area/f13/city)
-"vAE" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+"vAR" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "vBc" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -31494,16 +29121,6 @@
 /obj/structure/bed/pod,
 /turf/open/floor/plating,
 /area/f13/building/museum)
-"vDB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 8;
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "vDJ" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
@@ -31523,14 +29140,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
-"vEs" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/rnd)
 "vEA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -31548,6 +29157,16 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vFY" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/waste{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "vHg" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/dirt,
@@ -31573,6 +29192,14 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
+"vIN" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "vJq" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -31676,6 +29303,16 @@
 /obj/item/geiger_counter,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"vLL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/gibs/human,
+/obj/structure/barricade/concrete,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "vLM" = (
 /obj/structure/barricade/wooden,
 /obj/structure/spider/stickyweb,
@@ -31755,12 +29392,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
-"vPk" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 1
+"vPh" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/footprints{
+	icon_state = "bloodpaw1"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/turf/open/floor/pod/light,
+/area/f13/radiation/crashsite)
 "vPp" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31769,6 +29407,14 @@
 /obj/effect/landmark/start/f13/usscientist,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
+"vPS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "vQn" = (
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31788,6 +29434,24 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"vQz" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/barricade/concrete,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
+"vRx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "vRI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -31814,6 +29478,13 @@
 /obj/structure/window/fulltile/house/broken,
 /turf/open/water,
 /area/f13/tunnel)
+"vSB" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/soup/longpork_stew,
+/obj/item/reagent_containers/food/snacks/soup/longpork_stew,
+/obj/item/reagent_containers/food/snacks/soup/longpork_stew,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "vSH" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -31850,17 +29521,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/enclave)
-"vTe" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	name = "Reactor Camera";
-	network = list("BoS")
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "vTf" = (
 /obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -31868,24 +29528,27 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"vTt" = (
+/obj/machinery/door/poddoor/preopen{
+	name = "quarantine door";
+	id = "hangarlock1"
+	},
+/obj/structure/fans/tiny,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "vTP" = (
 /obj/structure/debris/v4,
 /obj/structure/flora/rock/jungle,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/water,
 /area/f13/caves)
-"vUS" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+"vTV" = (
+/obj/structure/barricade/concrete,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "vVe" = (
 /obj/structure/table/glass,
 /obj/item/healthanalyzer/advanced,
@@ -31965,15 +29628,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vWK" = (
-/obj/machinery/computer/camera_advanced/abductor{
-	name = "Inactive Radar Console"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "vWM" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -31995,13 +29649,6 @@
 	name = "metal plating"
 	},
 /area/f13/city)
-"vWY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "vXv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -32012,16 +29659,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker)
-"vYp" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "vYx" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -32030,25 +29667,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"vYA" = (
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -12;
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/camera/autoname{
-	dir = 10;
-	name = "Interior Entrance Camera";
-	network = list("BoS");
-	pixel_x = -1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "vYD" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -32112,13 +29730,6 @@
 /obj/structure/cross,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"wbm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "wbo" = (
 /obj/structure/vaultdoor,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -32226,19 +29837,6 @@
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wgW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "whm" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/dark,
@@ -32291,10 +29889,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building/museum)
-"wjr" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/mining)
 "wjH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32325,6 +29919,27 @@
 /obj/item/stack/ore/blackpowder/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wkJ" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Armory"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
+"wlw" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "wlL" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -32338,6 +29953,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
+"wmG" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "wmL" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd1";
@@ -32363,26 +29982,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/water,
 /area/f13/tunnel)
-"wnH" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 12
-	},
-/obj/structure/wreck/trash/machinepiletwo{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "woc" = (
 /mob/living/simple_animal/hostile/raider/ranged/biker{
 	name = "Texarkana Timothy"
@@ -32397,6 +29996,12 @@
 /obj/item/book/granter/trait/techno,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
+"wol" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "wox" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/indestructible/ground/inside/mountain,
@@ -32409,10 +30014,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
-"woN" = (
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "wpl" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32440,6 +30041,12 @@
 	icon_state = "darkredfull"
 	},
 /area/f13/enclave)
+"wpR" = (
+/mob/living/simple_animal/hostile/chinese,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "wpZ" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -32461,15 +30068,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"wql" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 4
-	},
-/area/f13/brotherhood/mining)
 "wqv" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -32521,17 +30119,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/vault)
-"wto" = (
-/obj/item/flag/bos,
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "wtq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -32551,6 +30138,12 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wuG" = (
+/obj/machinery/chem_dispenser/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "wuI" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -32603,6 +30196,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"wwz" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "wwC" = (
 /mob/living/simple_animal/hostile/radroach,
 /obj/structure/closet,
@@ -32645,6 +30244,15 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"wxY" = (
+/obj/machinery/power/rtg/abductor,
+/obj/effect/spawner/structure/window/hollow/plasma/reinforced/directional{
+	dir = 4
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "wyS" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -32657,6 +30265,19 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/vault)
+"wzx" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8;
+	spawn_list = list(/obj/structure/window/reinforced,/obj/structure/window/reinforced/spawner/north,/obj/structure/window/reinforced/spawner/east,/obj/structure/window/reinforced/spawner/west)
+	},
+/obj/item/shard,
+/obj/item/shard,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "wzF" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -32671,6 +30292,14 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"wzR" = (
+/obj/structure/chair,
+/mob/living/simple_animal/hostile/chinese,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/radiation/crashsite)
 "wzS" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/f13/military/leather,
@@ -32707,9 +30336,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
-"wAY" = (
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "wBa" = (
 /obj/machinery/door/poddoor/shutters/radiation{
 	id = "townengineaccess"
@@ -32732,15 +30358,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"wBu" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "wBy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/folding{
@@ -32772,6 +30389,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"wCu" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "wCw" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -32804,6 +30431,12 @@
 	name = "metal plating"
 	},
 /area/f13/city)
+"wDD" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "wDN" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -32846,18 +30479,6 @@
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
-"wEU" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/obj/structure/chair/f13foldupchair{
-	desc = "A folding chair, missing half the seat, probably for dropping something through it.";
-	dir = 1
-	},
-/obj/effect/landmark/start/f13/paladin,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "wEW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -32867,23 +30488,21 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"wFp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/rnd)
 "wFO" = (
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wFZ" = (
-/obj/structure/lattice{
-	density = 1
+"wGo" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/power/port_gen/pacman/super,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
 	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/radiation/crashsite)
 "wGD" = (
 /obj/machinery/button/door{
 	id = "townengineaccess";
@@ -33039,11 +30658,6 @@
 	dir = 4
 	},
 /area/f13/caves)
-"wQa" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "wQf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -33066,13 +30680,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wSw" = (
-/obj/structure/simple_door/bunker,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "wSA" = (
 /obj/structure/spider/stickyweb{
 	icon_state = "stickyweb2"
@@ -33086,12 +30693,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
-"wTe" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/bedsheet/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "wTf" = (
 /obj/structure/wreck/trash/autoshaft,
 /obj/effect/decal/cleanable/dirt,
@@ -33221,14 +30822,6 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
-"wZq" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "wZB" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -33269,21 +30862,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker)
-"xbi" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "xbx" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
 /turf/open/indestructible/ground/inside/mountain,
@@ -33366,6 +30944,13 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"xfL" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "xgj" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "68"
@@ -33420,6 +31005,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xha" = (
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "xhh" = (
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -33481,42 +31072,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/caves)
-"xkm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"xkt" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "xkB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -33556,12 +31111,28 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"xmn" = (
+/obj/structure/barricade/concrete,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "xms" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
 /area/f13/caves)
+"xmE" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/item/surgicaldrill/alien,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "xmL" = (
 /obj/structure/table/glass,
 /obj/machinery/light,
@@ -33577,12 +31148,6 @@
 	color = "#e4e4e4"
 	},
 /area/f13/caves)
-"xnq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "xnw" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
@@ -33614,21 +31179,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
-"xqd" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal,
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "xqn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33654,6 +31204,10 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"xqW" = (
+/obj/machinery/door/window/left/directional/north,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "xra" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33686,6 +31240,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"xsL" = (
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation/crashsite)
 "xsT" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/waste{
@@ -33693,30 +31250,16 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xtv" = (
+/obj/structure/chair/folding{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "xur" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"xuu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
-	},
-/obj/machinery/door/poddoor/shutters/radiation{
-	id = "bosengineaccess"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
-"xuH" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "xuR" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -33744,13 +31287,6 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
-"xwh" = (
-/obj/structure/simple_door/bunker,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operating)
 "xwF" = (
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
@@ -33818,6 +31354,18 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
+"xzC" = (
+/obj/structure/table/glass,
+/obj/structure/window/reinforced/spawner/north,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/radiation/crashsite)
 "xzH" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -33826,22 +31374,6 @@
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xzV" = (
-/obj/structure/table/survival_pod,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
-	},
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
 "xAc" = (
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
@@ -33879,16 +31411,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"xBh" = (
-/obj/machinery/workbench/forge{
-	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
-	icon_state = "generator_on";
-	name = "superheating forge"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "xBn" = (
 /obj/structure/fluff/rails,
 /obj/structure/handrail/g_central{
@@ -33923,6 +31445,13 @@
 	icon_state = "tealwhrusty_chess2"
 	},
 /area/f13/enclave)
+"xCc" = (
+/obj/effect/decal/waste{
+	pixel_x = 20;
+	pixel_y = 1
+	},
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "xCp" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
@@ -33962,6 +31491,10 @@
 /obj/item/clothing/head/helmet/f13/combat/environmental,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"xEH" = (
+/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/radiation/crashsite)
 "xEW" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb,
@@ -34019,12 +31552,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xGP" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "xGS" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -34062,6 +31589,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"xIm" = (
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "xIr" = (
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/indestructible/ground/inside/mountain,
@@ -34137,6 +31669,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/museum)
+"xLL" = (
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation/crashsite)
 "xMb" = (
 /obj/machinery/button/door{
 	id = "room52";
@@ -34167,17 +31704,16 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xNh" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosarmoryacc";
-	name = "Armory";
-	req_access_txt = "120"
+"xNe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	name = "bunker camera terminal"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/radiation/crashsite)
 "xNn" = (
 /obj/structure/table/booth,
 /obj/machinery/light{
@@ -34191,6 +31727,10 @@
 /obj/structure/nest/supermutant,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"xNI" = (
+/mob/living/simple_animal/hostile/chinese/ranged,
+/turf/open/floor/plating/rust,
+/area/f13/radiation/crashsite)
 "xNR" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/decal/cleanable/generic,
@@ -34201,11 +31741,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"xOu" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "xOD" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -34240,6 +31775,11 @@
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/caves)
+"xPR" = (
+/obj/structure/closet/crate/footlocker,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "xPT" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -34261,11 +31801,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"xQI" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
 "xQO" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -34286,14 +31821,16 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building/museum)
-"xRq" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+"xRA" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/waste{
+	pixel_x = 20;
+	pixel_y = 1
 	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/radiation/crashsite)
 "xSb" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
@@ -34343,14 +31880,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"xSG" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4;
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "xSO" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -34366,6 +31895,25 @@
 	icon_state = "stagestairs2"
 	},
 /area/f13/enclave)
+"xTO" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
+"xTS" = (
+/obj/structure/table/abductor{
+	name = "alien table"
+	},
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "xTT" = (
 /obj/machinery/light{
 	dir = 8;
@@ -34421,24 +31969,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"xVk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	pixel_y = -6;
-	termtag = "Secret"
-	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 4;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
-"xVt" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "xVN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -34474,15 +32004,6 @@
 	name = "stone floor"
 	},
 /area/f13/tunnel)
-"xWs" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/machinery/pool/drain,
-/obj/structure/toilet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "xWt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34541,12 +32062,6 @@
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
-"xYW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "xZu" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = "factorybasement";
@@ -34566,6 +32081,17 @@
 	name = "stone floor"
 	},
 /area/f13/tunnel)
+"xZM" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white{
+	name = "sterile tiles"
+	},
+/area/f13/radiation/crashsite)
 "yaq" = (
 /obj/structure/table,
 /obj/item/stack/crafting/goodparts/five,
@@ -34586,24 +32112,21 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ycd" = (
-/obj/structure/window/fulltile/store,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosbriglock";
-	name = "brig lockdown"
-	},
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "ycG" = (
 /obj/machinery/light/broken,
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"ycT" = (
+/obj/machinery/door/poddoor/preopen{
+	name = "quarantine door";
+	id = "hangarlock2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "ycU" = (
 /obj/structure/handrail/g_end{
 	pixel_x = 12;
@@ -34621,12 +32144,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"ydE" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
 "ydH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -34654,6 +32171,10 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"yez" = (
+/obj/structure/closet/fridge/cannibal,
+/turf/open/floor/plasteel/grimy,
+/area/f13/radiation/crashsite)
 "yeQ" = (
 /obj/item/storage/bag/ore/large,
 /obj/item/storage/bag/ore/large,
@@ -34693,6 +32214,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"ygN" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "ygR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34721,24 +32250,21 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"yhJ" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "yhM" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"yhW" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
-"yhZ" = (
-/obj/machinery/vending/cola{
-	name = "\improper Nuka Cola Vending Machine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+"yhQ" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/radiation/crashsite)
 "yig" = (
 /obj/structure/table,
 /obj/machinery/chem_heater,
@@ -34751,33 +32277,37 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"yir" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+"yiL" = (
+/obj/machinery/button/door{
+	id = "hangarlock1";
+	pixel_y = 28
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "yiX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"yjd" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/rnd)
 "yjg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"yjl" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/obj/machinery/door/window/right/directional/east,
+/obj/effect/mob_spawn/human/corpse/bs/paladin,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/f13/radiation/crashsite)
 "yjm" = (
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
@@ -34813,6 +32343,18 @@
 "ykm" = (
 /turf/closed/wall/rust,
 /area/f13/city)
+"ykX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	icon = 'icons/obj/machines/particle_accelerator.dmi';
+	icon_keyboard = "generic_key";
+	icon_screen = "generic";
+	icon_state = "control_boxp"
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "sterile floor"
+	},
+/area/f13/radiation/crashsite)
 "ylq" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -84763,7 +82305,7 @@ xwF
 xwF
 xwF
 xwF
-xwF
+aaB
 aaB
 aaB
 aaB
@@ -85020,8 +82562,8 @@ xwF
 xwF
 xwF
 xwF
-xwF
-bWr
+aaB
+bIg
 aaB
 aaB
 aaB
@@ -85276,9 +82818,9 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
+aak
+aaB
+aaB
 aaB
 aaB
 aaB
@@ -85532,9 +83074,9 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
+aak
+bIg
+aaB
 xwF
 xwF
 xwF
@@ -85789,9 +83331,9 @@ aak
 aak
 xwF
 xwF
-xwF
-xwF
-xwF
+aaB
+bIg
+aak
 xwF
 xwF
 xwF
@@ -86045,8 +83587,8 @@ xwF
 aak
 aak
 xwF
-xwF
-xwF
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -86302,8 +83844,8 @@ xwF
 aak
 xwF
 xwF
-xwF
-xwF
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -86559,8 +84101,8 @@ xwF
 xwF
 xwF
 xwF
-xwF
-aak
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -86816,8 +84358,8 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -87073,8 +84615,8 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
+aaB
+aaB
 aak
 xwF
 xwF
@@ -87330,8 +84872,8 @@ xwF
 aak
 aak
 xwF
-xwF
-xwF
+aaB
+aaB
 aak
 xwF
 xwF
@@ -87587,8 +85129,8 @@ xwF
 aak
 aak
 xwF
-xwF
-xwF
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -87844,8 +85386,8 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
+bIg
+bIg
 xwF
 aak
 xwF
@@ -88101,8 +85643,8 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
+aaB
+aaB
 xwF
 aak
 xwF
@@ -88358,8 +85900,8 @@ xwF
 xwF
 xwF
 aak
-aak
-xwF
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -88615,8 +86157,8 @@ aak
 xwF
 xwF
 xwF
-xwF
-xwF
+lUo
+aaB
 xwF
 xwF
 xwF
@@ -88871,9 +86413,9 @@ xwF
 aak
 aak
 aak
-xwF
-xwF
-xwF
+aaB
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -89128,9 +86670,9 @@ xwF
 xwF
 aak
 aak
-xwF
-xwF
-xwF
+aaB
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -89385,8 +86927,8 @@ xwF
 xwF
 aak
 aak
-xwF
-xwF
+aaB
+aaB
 xwF
 xwF
 aak
@@ -89642,8 +87184,8 @@ xwF
 xwF
 xwF
 xwF
-xwF
-aak
+bIg
+bIg
 xwF
 xwF
 xwF
@@ -89899,8 +87441,8 @@ xwF
 xwF
 xwF
 xwF
-xwF
-aak
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -90156,8 +87698,8 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -90368,11 +87910,11 @@ aae
 aae
 aae
 aae
-kqk
-kqk
-kqk
-kqk
-kqk
+aNJ
+aNJ
+aNJ
+aNJ
+dyy
 aae
 aae
 aae
@@ -90414,9 +87956,9 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
+aaB
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -90624,13 +88166,13 @@ aae
 aae
 aae
 aae
-kqk
-kqk
-kqk
-kqk
-kqk
-kqk
-kqk
+aNJ
+aNJ
+eTi
+dJp
+eTi
+aNJ
+aNJ
 aae
 aae
 aae
@@ -90671,9 +88213,9 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
+aak
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -90880,15 +88422,15 @@ aae
 aae
 aae
 aae
-kqk
-kqk
-qtg
-bPj
-rsu
-bPF
-qtg
-kqk
-kqk
+aae
+aNJ
+mxT
+eTi
+eTi
+mxT
+klA
+aNJ
+aNJ
 aae
 aae
 aae
@@ -90928,9 +88470,9 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
+aak
+bIg
+bIg
 xwF
 aak
 xwF
@@ -91137,15 +88679,15 @@ aae
 aae
 aae
 aak
-kqk
-kqk
-bPF
-wFZ
-fLs
-tFU
-bPF
-kqk
-kqk
+aae
+aNJ
+eTi
+klA
+htr
+klA
+eTi
+mxT
+aNJ
 aae
 aae
 aae
@@ -91185,9 +88727,9 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
+aaB
+aaB
+aaB
 xwF
 aak
 xwF
@@ -91395,25 +88937,25 @@ aaa
 aaa
 aaa
 aaa
-kqk
-fTZ
-fTZ
-fTZ
-fTZ
-fTZ
-kqk
-opI
-opI
-opI
-opI
-opI
-opI
-opI
-qdA
-qdA
-qdA
-qdA
-qdA
+aNJ
+klA
+eTi
+mxT
+eTi
+eTi
+eTi
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
 aae
 aae
 aae
@@ -91442,9 +88984,9 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
+aaB
+aaB
+aaB
 xwF
 xwF
 aak
@@ -91652,26 +89194,26 @@ ppz
 ppz
 qtN
 aaa
-opI
-xBh
-gsZ
-hCn
-gsZ
-xBh
-opI
-opI
-tPN
-uGE
-iDJ
-tqV
-fPg
-opI
-qdA
-mQQ
-mnl
-xSG
-qdA
-qdA
+aNJ
+guh
+bqu
+jaZ
+jaZ
+jaZ
+jaZ
+guh
+kIQ
+mgs
+oae
+oae
+hxh
+bDr
+xLL
+xmn
+oSt
+lCK
+aNJ
+aNJ
 aae
 aae
 aae
@@ -91699,9 +89241,9 @@ xwF
 xwF
 xwF
 aak
-xwF
-xwF
-xwF
+aaB
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -91909,37 +89451,37 @@ aQR
 tOC
 qtN
 aaa
-opI
-lvn
-gsZ
-gsZ
-gsZ
-bOB
-opI
-opI
-eZz
-nKo
-nKo
-vEs
-myW
-opI
-qdA
-bPy
-aon
-tmf
-bPe
-qdA
-qEc
+aNJ
+vPh
+asu
+uEc
+ogS
+oHA
+bmk
+guh
+kIQ
+oSt
+otN
+oSt
+pJl
+oSt
+nsH
+xmn
+oSt
+nlB
+lpP
+aNJ
+aNJ
 aae
 aak
 aae
 aae
 aae
 aae
-aZx
-aZx
-aZx
-aZx
+aNJ
+aNJ
+aNJ
+aNJ
 xwF
 xwF
 xwF
@@ -91955,10 +89497,10 @@ xwF
 xwF
 xwF
 xwF
-xwF
-aak
-aak
-xwF
+aaB
+aaB
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -92166,38 +89708,38 @@ fIC
 aQx
 qtN
 aaa
-opI
-bOL
-dZZ
-qPU
-cqM
-gkf
-iNG
-boj
-lem
-amQ
-cqM
-cqM
-dKc
-iNG
-qbd
-qbi
-bOD
-gpz
-iBj
-bPx
-qEc
+aNJ
+ijU
+noc
+ogS
+uWZ
+ijU
+bmk
+guh
+kIQ
+dKN
+eau
+eau
+hxh
+oSt
+xmn
+xmn
+oQa
+xLL
+oSt
+lCK
+aNJ
 aae
 aae
 aae
 aae
 aae
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
+aNJ
+aNJ
+mlu
+mlu
+aNJ
+aNJ
 xwF
 aak
 xwF
@@ -92211,11 +89753,11 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
-xwF
-aak
+aaB
+aaB
+aaB
+bIg
+aaB
 xwF
 xwF
 xwF
@@ -92423,39 +89965,39 @@ cpU
 qtN
 qtN
 aaa
-opI
-swd
-eCD
-nyk
-eCD
-eCD
-uCn
-urZ
-qka
-bxV
-eCD
-eCD
-jFS
-uCn
-bYC
-upE
-nhm
-dwU
-dwU
-tkA
-aZx
-lvB
-aZx
-aZx
-lvB
-aZx
-lvB
-lvB
-mdo
-rTn
-lvB
-lvB
-aZx
+aNJ
+guh
+eVq
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+hxh
+hxh
+urr
+xLL
+nlB
+xLL
+oSt
+frJ
+cTF
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+xfL
+oGw
+ePN
+fEF
+aNJ
+aNJ
 xwF
 xwF
 xwF
@@ -92468,11 +90010,11 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
-xwF
-xwF
+aaB
+aaB
+aaB
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -92680,39 +90222,39 @@ fIC
 iVF
 qtN
 aaa
-opI
-syJ
-cUm
-dsZ
-dsZ
-dsZ
-dsZ
-uXE
-jVt
-dsZ
-dsZ
-dsZ
-qjA
-qjA
-vtY
-sKb
-kAk
-dwU
-dwU
-chY
-aZx
-qCS
-lvB
-lvB
-lvB
-qCS
-lvB
-idb
-cvW
-rGh
-kmG
-lvB
-aZx
+aNJ
+qIv
+iok
+gRf
+qIv
+iSb
+dAr
+dAr
+iSb
+fcH
+guh
+guh
+guh
+guh
+ipc
+oSt
+xLL
+oSt
+xNe
+usT
+guh
+mJy
+owD
+eGG
+xsL
+veH
+eGG
+dNs
+ePN
+ePN
+dNs
+ksY
+aNJ
 xwF
 xwF
 xwF
@@ -92724,12 +90266,12 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -92937,39 +90479,39 @@ fIC
 fIC
 tJB
 aaa
-opI
-eEg
-hOo
-nyk
-eCD
-eCD
-eCD
-wFp
-wFp
-eCD
-eCD
-eCD
-jPY
-jPY
-aob
-aob
-fbL
-dwU
-wQa
-uTw
-aZx
-gHO
-vYp
-vTe
-vYp
-veU
-xuu
-veU
-kmA
-liW
-tpp
-lRn
-aZx
+aNJ
+gqX
+xZM
+fIp
+gRf
+ktP
+gRf
+uzH
+iQa
+gRf
+gRf
+uzH
+wCu
+guh
+guh
+guh
+wkJ
+guh
+guh
+guh
+guh
+pXU
+vbg
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+afU
+aNJ
 xwF
 xwF
 aak
@@ -92981,12 +90523,12 @@ aak
 aak
 aak
 aak
-aak
-xwF
-xwF
-xwF
-xwF
-xwF
+aaB
+bIg
+aaB
+aaB
+aaB
+aaB
 xwF
 xwF
 xwF
@@ -93194,55 +90736,55 @@ fIC
 udh
 qtN
 aaa
-opI
-opI
-viA
-cfi
-wZq
-pcM
-xkt
-gVf
-hNA
-ptr
-wZq
-wZq
-loN
-xkt
-mxA
-llf
-aJP
-hvG
-hvG
-bOR
-aZx
-rLd
-cvn
-cvn
-cvn
-mNG
-aZx
-gYN
-jAd
-jAd
-cGw
-aZx
-dYb
-dYb
-dYb
-dYb
-dYb
-hHs
-dYb
-dYb
-dYb
+aNJ
+ptO
+mNe
+ePB
+qpe
+nmb
+ufS
+vQz
+vQz
+gRf
+vwy
+mhg
+gRf
+guh
+pXU
+qUE
+owD
+exB
+owD
+mJy
+jVg
+owD
+owD
+jOy
+owD
+mJy
+mJy
+kTS
+owD
+srD
+guh
+xsL
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
 aae
 aae
 aae
@@ -93451,55 +90993,55 @@ fIC
 iVF
 qtN
 aaa
-opI
-cwa
-xuH
-vaB
-vaB
-vaB
-opI
-opI
-uHx
-fIa
-vaB
-vaB
-gbC
-opI
-qEc
-kto
-iZv
-fFt
-uwe
-qEc
-aZx
-agn
-cvn
-tuh
-tuh
-gez
-oJL
-qtj
-oQH
-oQH
-gJV
-aZx
-dYb
-fWS
-qDG
-nra
-amK
-qXn
-qRO
-jAi
-dYb
-dYb
+aNJ
+ptO
+gRf
+gRf
+gRf
+bfx
+mNe
+nmb
+eKL
+gRf
+aer
+aer
+aer
+guh
+owD
+exB
+pXU
+vTV
+bej
+xEH
+vTV
+pXU
+mJy
+guh
+ucd
+tXk
+pXU
+mJy
+mJy
+tua
+guh
+ePN
+fWV
+xsL
+fWV
+ePN
+xsL
+dNs
+dNs
+tfu
+aNJ
+aNJ
 aae
-aae
-aae
-aae
-aae
-aak
-aae
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
 aae
 aae
 aae
@@ -93708,55 +91250,55 @@ uGW
 qtN
 qtN
 aaa
-opI
-vWK
-vaB
-vaB
-vaB
-vaB
-fnL
-opI
-mGV
-yjd
-vaB
-vaB
-iMY
-opI
-qEc
-nUc
-iZv
-fFt
-opd
-qEc
-aZx
-rLd
-cvn
-tuh
-tuh
-fkN
-jTV
-tiq
-veU
-tjx
-jUX
-aZx
-dYb
-mwk
-fHe
-fHe
-fHe
-fHe
-fHe
-fHe
-wnH
-dYb
-dYb
-aae
-aae
-aae
-aae
-aae
-aae
+aNJ
+fXQ
+gRf
+vQz
+uzH
+vRx
+gRf
+vLL
+wlw
+qpe
+gzo
+qpe
+qpe
+fQi
+eJF
+vTV
+nCf
+exB
+mJy
+exB
+bDW
+mJy
+owD
+guh
+guh
+nHE
+ngi
+ngi
+nwr
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+afU
+guh
+guh
+guh
+aNJ
+aNJ
+nEi
+aaB
+aaB
+bIg
+aaB
+aaB
 aae
 aae
 aae
@@ -93965,55 +91507,55 @@ qtN
 qtN
 aaa
 aaa
-opI
-opo
-vaB
-vaB
-vaB
-vaB
-xzV
-opI
-izD
-nKo
-vaB
-vaB
-lzU
-opI
-qEc
-fFt
-iZv
-fFt
-oux
-qEc
-aZx
-agn
-cvn
-tuh
-tuh
-fLh
-rEe
-hlK
-vcf
-vDB
-chh
-aZx
-dYb
-fHe
-fHe
-evL
-bTN
-fHe
-bTN
-fHe
-fHe
-rEV
-dYb
-aae
-aae
-aae
-aae
-aae
-aae
+aNJ
+rvj
+iAz
+gRf
+iAz
+koa
+gRf
+vQz
+cMo
+gRf
+gRf
+iQa
+gRf
+jMU
+sgU
+vTV
+owD
+owD
+mJy
+qlC
+qlC
+owD
+mJy
+owD
+aLb
+mJy
+owD
+mJy
+owD
+jVg
+lHv
+edU
+mJy
+mJy
+tBg
+pXU
+owD
+lHv
+shu
+jVg
+mJy
+owD
+tON
+aaB
+aaB
+aaB
+aaB
+aaB
+bIg
 aae
 aae
 aae
@@ -94222,56 +91764,56 @@ aaa
 aaa
 aaa
 aaa
-opI
-pSR
-pag
-huk
-huk
-akt
-edg
-opI
-uvv
-nKo
-vaB
-ifv
-mEP
-opI
-qEc
-bdZ
-iZv
-fFt
-oux
-qEc
-aZx
-rLd
-cvn
-cvn
-cvn
-ulV
-aZx
-mHX
-jAd
-jAd
-xbi
-aZx
-uHs
-fHe
-fHe
-fHe
-fHe
-fHe
-fHe
-fHe
-fHe
-tfh
-hHs
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aNJ
+xzC
+kbs
+gRf
+kbs
+nph
+dDe
+qgL
+cVl
+gqX
+dDe
+fca
+kim
+guh
+lgv
+owD
+owD
+owD
+pXU
+pXU
+qlC
+pXU
+mJy
+owD
+owD
+vTV
+exB
+pXU
+mJy
+pXU
+edU
+shu
+mJy
+pXU
+shu
+shu
+mJy
+owD
+shu
+pXU
+mJy
+mJy
+mQb
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
 aak
 aae
 aae
@@ -94473,62 +92015,62 @@ aaa
 "}
 (233,1,1) = {"
 aaa
-qEc
-qEc
-qEc
-fjh
-qEc
-qEc
-rKx
-bOS
-opI
-opI
-opI
-opI
-opI
-opI
-rzB
-wbm
-vaB
-iHV
-mYi
-opI
-qEc
-sJK
-iZv
-fFt
-yhZ
-qEc
-aZx
-oQH
-pDv
-rLd
-pDv
-oQH
-jsW
-gjM
-nja
-jNn
-dRi
-qCS
-coO
-fHe
-bTN
-fHe
-bTN
-fHe
-bTN
-fHe
-fHe
-iGw
-dYb
-aae
-aae
-aae
-aae
-aak
-aak
-aak
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+sgU
+owD
+owD
+mJy
+exB
+exB
+owD
+mJy
+owD
+mJy
+owD
+bej
+vTV
+mJy
+mJy
+mJy
+mJy
+pXU
+mJy
+pXU
+bwW
+shu
+mJy
+pXU
+mJy
+owD
+mJy
+owD
+aNJ
+nEi
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
 aak
 aae
 aae
@@ -94730,62 +92272,62 @@ aaa
 "}
 (234,1,1) = {"
 aaa
-qEc
-qIN
-gAp
-akZ
-gAp
-gAp
-syO
-mmy
-qEc
-fjh
-qEc
-qEc
-qEc
-qEc
-fjh
-opI
-opI
-opI
-opI
-opI
-mmH
-kto
-iZv
-fFt
-uwe
-qEc
-aZx
-lRn
-aZx
-aZx
-aZx
-lRn
-aZx
-nlx
-soS
-nNw
-plW
-lvB
-snr
-fHe
-fHe
-fHe
-fHe
-fHe
-fHe
-fHe
-fHe
-tfh
-hHs
-aae
-aae
-aae
-aae
-aak
-aak
-aak
+aNJ
+mzW
+owD
+owD
+owD
+evS
+qlC
+owD
+evS
+owD
+qlC
+owD
+mzW
+guh
+qoS
+oPU
+xIm
+jvz
+ila
+guh
+sgU
+mJy
+mJy
+pXU
+exB
+bej
+mJy
+pXU
+owD
+owD
+pXU
+vTV
+exB
+mJy
+owD
+mJy
+shu
+shu
+owD
+mJy
+shu
+shu
+mJy
+owD
+shu
+mJy
+mJy
+mJy
+vvu
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
 aae
 aae
 aae
@@ -94987,62 +92529,62 @@ aaa
 "}
 (235,1,1) = {"
 aaa
-mmH
-qEc
-cmP
-cmP
-cmP
-cmP
-jyk
-ikS
-abG
-vUS
-uKD
-vUS
-vUS
-vUS
-uKD
-fjh
-qEc
-qEc
-qEc
-qEc
-mmH
-bOE
-iZv
-fFt
-mDZ
-qEc
-aZx
-fsp
-pIT
-fsp
-pIT
-fsp
-aZx
-ngl
-ayM
-sZI
-ngl
-dYb
-iZt
-fHe
-bTN
-fHe
-bTN
-fHe
-bTN
-fHe
-fHe
-iGw
-dYb
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aNJ
+sNZ
+hKh
+owD
+nMQ
+tRr
+tRr
+tRr
+tRr
+nMQ
+owD
+owD
+owD
+guh
+rlq
+xIm
+jpV
+yhJ
+jNx
+guh
+nbx
+owD
+owD
+mJy
+owD
+owD
+eGd
+owD
+owD
+owD
+tci
+owD
+owD
+owD
+owD
+tci
+xNI
+shu
+pXU
+mJy
+tci
+owD
+mJy
+lHv
+shu
+tci
+owD
+pXU
+mQb
+aaB
+aaB
+bIg
+aaB
+aaB
+aaB
+aaB
 aae
 aae
 aae
@@ -95244,60 +92786,60 @@ aaa
 "}
 (236,1,1) = {"
 aaa
-ppK
-qEc
-eLJ
-eLJ
-eLJ
-eLJ
-axa
-kRj
-hSw
-sKb
-sKb
-rAF
-nid
-wgW
-gdj
-svV
-fnh
-vtY
-vtY
-xkm
-lQZ
-tck
-smz
-tck
-tck
-tck
-ufZ
-kYJ
-kYJ
-kYJ
-kYJ
-kYJ
-bPn
-tck
-aFO
-tck
-tck
-jxk
-ydE
-fHe
-qxb
-fHe
-fHe
-fHe
-fHe
-fHe
-fOx
-dYb
-dYb
-aae
-aae
-aae
-aae
-aae
+aNJ
+qlC
+owD
+nMQ
+nMQ
+wxY
+wxY
+wxY
+wxY
+nMQ
+nMQ
+qlC
+rGA
+guh
+guh
+guh
+xIm
+fFA
+gHY
+ltf
+sgU
+owD
+mJy
+owD
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+owD
+mJy
+guh
+guh
+guh
+guh
+dWt
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+aNJ
+aNJ
+nEi
+aaB
+aaB
+aaB
+aaB
 aae
 aae
 aae
@@ -95501,54 +93043,54 @@ aaa
 "}
 (237,1,1) = {"
 aaa
-jUK
-fjh
-eLJ
-eLJ
-eLJ
-eLJ
-qyj
-dOk
-isB
-ixD
-ePu
-cJh
-dOk
-jcy
-ixD
-obE
-iLm
-aob
-aob
-fFt
-fFt
-fFt
-asV
-lAq
-fFt
-fFt
-fFt
-rGN
-rGN
-rGN
-rGN
-rGN
-fFt
-fFt
-iZv
-fFt
-fFt
-aJi
-fHe
-fHe
-tED
-fHe
-snv
-cbE
-ncb
-eqK
-dYb
-dYb
+aNJ
+gVW
+owD
+nMQ
+ndv
+wzx
+yjl
+eGe
+ohP
+rrE
+nMQ
+owD
+xIm
+iVL
+fcQ
+vTt
+gvf
+xIm
+xIm
+guh
+sgU
+owD
+pXU
+owD
+guh
+kQe
+bwD
+qFQ
+dyN
+kfh
+cGV
+kQe
+guh
+mJy
+mJy
+owD
+kIq
+owD
+iJj
+qlC
+owD
+hxi
+hxi
+bmo
+cOy
+qms
+aNJ
+aNJ
 aaB
 aae
 aak
@@ -95758,53 +93300,53 @@ aaa
 "}
 (238,1,1) = {"
 aaa
-aXv
-qEc
-eLJ
-eLJ
-eLJ
-kwX
-hzp
-vYA
-qEc
-nbN
-lyt
-nbN
-nbN
-nbN
-lyt
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-wto
-iZv
-lAq
-bOZ
-lUj
-lUj
-lUj
-lUj
-lUj
-lUj
-lUj
-lUj
-lUj
-abD
-otv
-vqC
-dYb
-dYb
-dYb
-dYb
-dYb
-dYb
-hHs
-dYb
-dYb
-dYb
+aNJ
+owD
+qlC
+sVJ
+rlV
+rlV
+rlV
+rlV
+rlV
+rlV
+ruv
+qlC
+uGH
+guh
+guh
+guh
+yiL
+jpV
+nRu
+guh
+emw
+mJy
+owD
+vbg
+guh
+xPR
+pnF
+iBX
+pnF
+nEq
+nEq
+nmZ
+guh
+owD
+mJy
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+guh
+aNJ
+aNJ
 aaB
 aaB
 aae
@@ -96015,52 +93557,52 @@ aaa
 "}
 (239,1,1) = {"
 aaa
-ppK
-qEc
-eLJ
-eLJ
-eLJ
-eLJ
-jyk
-lTT
-qEc
-fjh
-qEc
-mdN
-mdN
-qEc
-fjh
-qEc
-sab
-cvx
-eSs
-tbi
-qEc
-kto
-iZv
-fFt
-uwe
-lUj
-xVk
-mbX
-hcW
-lUj
-rpb
-vAE
-bjs
-iIK
-sAE
-rpW
-abE
-rru
-bRW
-pRg
-viO
-qOM
-qcR
-cIX
-tVB
-vqC
+aNJ
+owD
+owD
+nak
+rlV
+rlV
+azc
+azc
+rlV
+rlV
+sVJ
+owD
+owD
+pUW
+ePp
+xIm
+rYA
+xIm
+jpV
+guh
+sgU
+owD
+mJy
+owD
+guh
+cMD
+tUC
+dyN
+iRu
+kQe
+nvi
+aGp
+guh
+owD
+pXU
+guh
+eqh
+eop
+qxa
+qxa
+vsn
+qxa
+qxa
+uCa
+rlG
+aNJ
 abV
 aaB
 aae
@@ -96272,52 +93814,52 @@ aaa
 "}
 (240,1,1) = {"
 aaa
-ppK
-qEc
-qEc
-fjh
-qEc
-qEc
-fjh
-qEc
-qEc
-qEc
-qqH
-fgI
-bOM
-qqH
-qEc
-gsY
-dZK
-fzB
-eka
-jHi
-bOH
-xGP
-iZv
-fFt
-eaj
-jjm
-usd
-nNV
-nNV
-nbE
-nNV
-nNV
-bjs
-lUj
-raI
-mWk
-teg
-tXz
-fxA
-mpz
-lhB
-vqC
-vqC
-vqC
-vqC
-wjr
+aNJ
+owD
+rpr
+nMQ
+ojc
+rlV
+rlV
+rlV
+rlV
+ffS
+nMQ
+rpr
+owD
+pUW
+coJ
+xIm
+twz
+nuH
+ixE
+ltf
+nbx
+pXU
+mJy
+owD
+guh
+wmG
+wmG
+xtv
+xtv
+nEq
+iBX
+svF
+guh
+mJy
+owD
+guh
+mpO
+qxa
+xha
+wGo
+aqd
+nUB
+xRA
+qxa
+hmN
+aNJ
 aaB
 abV
 aae
@@ -96529,52 +94071,52 @@ aaa
 "}
 (241,1,1) = {"
 aaa
-qEc
-qEc
-kaL
-qEc
-qEc
-fjh
-qEc
-qEc
-fjh
-qEc
-xqd
-pnU
-pnU
-sWp
-qEc
-qEc
-sqT
-aPE
-pnU
-ens
-tVi
-woN
-iZv
-fFt
-gCh
-jRb
-nNV
-nNV
-mvR
-lUj
-tuq
-nNV
-bjs
-lUj
-jmM
-huI
-kwq
-wql
-kxU
-tea
-jYX
 aNJ
-tkX
-nfk
-hPt
-crA
+owD
+owD
+nMQ
+grE
+rlV
+rlV
+rlV
+rlV
+xmE
+nMQ
+owD
+owD
+pUW
+ykX
+gHY
+twz
+yhJ
+dMQ
+guh
+sgU
+mJy
+pXU
+qlC
+mDO
+pnF
+wmG
+dJE
+cvW
+cXo
+iBX
+snA
+guh
+owD
+kMV
+kbu
+iXy
+qxa
+dvu
+kew
+mJi
+kew
+nsz
+eop
+ccD
+aNJ
 aaB
 aak
 aae
@@ -96786,52 +94328,52 @@ aaa
 "}
 (242,1,1) = {"
 aaa
-qEc
-dLT
-fFt
-pMC
-ycd
-akd
-enO
-pNx
-hMO
-fqs
-pii
-jqF
-jqF
-jqF
-uXy
-vtY
-kNs
-jqF
-jqF
-jqF
-xNh
-ixO
-uCb
-tck
-jNm
-wSw
-lUJ
-nNV
-nNV
-lUj
-lUj
-lUj
-lUj
-lUj
-bAd
-aiM
-mpz
-mpz
-jXQ
-kSg
-tmr
-sdN
-oiI
-nfk
-eRd
-ljh
+aNJ
+owD
+owD
+nMQ
+nMQ
+nMQ
+sVJ
+sVJ
+nMQ
+nMQ
+nMQ
+owD
+owD
+pUW
+mKt
+xIm
+twz
+ila
+stP
+guh
+sgU
+owD
+mJy
+owD
+mDO
+pnF
+lOt
+qrn
+vIN
+cXo
+pnF
+ter
+guh
+pXU
+owD
+jAp
+qxa
+eop
+jfA
+kew
+ikM
+oqX
+nyP
+qxa
+ccD
+aNJ
 aaB
 aak
 aae
@@ -97043,52 +94585,52 @@ aaa
 "}
 (243,1,1) = {"
 aaa
-fjh
-smq
-fFt
-fFt
-ycd
-oer
-fFt
-fFt
-fFt
-cqS
-qQa
-pnU
-pnU
-pom
-obp
-aob
-yir
-tZM
-pom
-eYO
-qEc
-dCq
-fFt
-fFt
-wEU
-lUj
-clt
-nNV
-nNV
-nNV
-cnH
-xQI
-xQI
-iIK
-eWb
-xnq
-myZ
-mpz
-mJz
-vqC
-pEV
-vqC
-vqC
-vqC
-vqC
-wjr
+aNJ
+sNZ
+qlC
+hKh
+nMQ
+bAh
+rlV
+rlV
+usQ
+nMQ
+hKh
+owD
+owD
+pUW
+aij
+gHY
+jnK
+wDD
+wDD
+qlP
+uVy
+pXU
+mJy
+mJy
+guh
+wmG
+wmG
+tNu
+tNu
+nEq
+pnF
+yez
+guh
+owD
+pXU
+jAp
+qxa
+qxa
+fiP
+kew
+ikM
+oqX
+nyP
+qxa
+wwz
+aNJ
 aae
 aae
 aak
@@ -97300,52 +94842,52 @@ aaa
 "}
 (244,1,1) = {"
 aaa
-qEc
-hzj
-lAq
-lAq
-qlb
-fFt
-lAq
-fFt
-cWz
-qEc
-mmH
-mjo
-sxg
-sxg
-qEc
-qEc
-pnU
-sGN
-pnU
-cDS
-mmH
-kto
-fFt
-fFt
-uwe
-lUj
-qhg
-nNV
-nNV
-vPk
-pJr
-bOW
-hVv
-lUj
-aLI
-rzq
-xnq
-pFY
-qgC
-xRq
-hZA
-tmr
-tmr
-lqk
-vqC
-vqC
+aNJ
+sNZ
+owD
+owD
+nMQ
+kwf
+rlV
+rlV
+lXU
+nMQ
+owD
+qlC
+wol
+pUW
+hiw
+gHY
+xIm
+jpV
+stP
+guh
+mJy
+mJy
+pXU
+qlC
+guh
+dOw
+cMD
+kQe
+raj
+vAR
+buy
+buy
+guh
+mJy
+vbg
+kbu
+iXy
+qxa
+rWJ
+mJi
+kew
+mJi
+nEn
+qxa
+wwz
+aNJ
 aae
 aae
 aae
@@ -97557,52 +95099,52 @@ aaa
 "}
 (245,1,1) = {"
 aaa
-qEc
-wTe
-gmd
-blC
-fmd
-bjl
-lAq
-lAq
-vxY
-mmH
-fFt
-fFt
-fFt
-gTC
-qEc
-sGN
-pnU
-sGN
-pnU
-sGN
-mmH
-rMm
-fFt
-fFt
-llk
-lUj
-hof
-nNV
-nNV
-gIh
-pJr
-lpo
-lpo
-lUj
-shW
-vqC
-jlE
-vqC
-iNA
-vqC
-bih
-bDx
-hZA
-hcP
-vqC
-vqC
+aNJ
+owD
+xCc
+nMQ
+nMQ
+nMQ
+sVJ
+sVJ
+nMQ
+nMQ
+nMQ
+owD
+owD
+pUW
+coJ
+jpV
+xIm
+jNx
+yhJ
+guh
+geK
+owD
+mJy
+dDz
+guh
+xPR
+pnF
+pnF
+iBX
+ait
+ait
+dQS
+guh
+owD
+pXU
+guh
+hOd
+qxa
+qzM
+fhh
+dIn
+nVv
+vFY
+qxa
+pcv
+aNJ
 aae
 aae
 aae
@@ -97814,52 +95356,52 @@ aaa
 "}
 (246,1,1) = {"
 aaa
-qEc
-qEc
-qEc
-qEc
-qEc
-vej
-lAq
-lAq
-vWY
-mmH
-spR
-fFt
-aAF
-fFt
-qEc
-wBu
-pnU
-sGN
-pnU
-oHS
-rQY
-xYW
-oYb
-oYb
-xYW
-iZb
-clt
-nNV
-nNV
-nNV
-cnH
-xQI
-xQI
-lUj
-dAS
-mPP
-mPP
-mPP
-mPP
-vqC
-vqC
-vqC
-vqC
-vqC
-vqC
-bOY
+aNJ
+owD
+owD
+nMQ
+wuG
+rlV
+rlV
+rlV
+rlV
+fKS
+nMQ
+qlC
+owD
+pUW
+ykX
+gHY
+xIm
+fFA
+gHY
+ltf
+owD
+owD
+mJy
+owD
+guh
+uiB
+gAN
+buy
+nrX
+jwz
+bjk
+msH
+guh
+pXU
+owD
+guh
+uAO
+eop
+eop
+eop
+vPS
+eop
+eop
+wpR
+hHj
+aNJ
 aae
 aae
 aae
@@ -98071,52 +95613,52 @@ aaa
 "}
 (247,1,1) = {"
 aaa
-fjh
-xWs
-pVB
-ycd
-uFI
-nER
-fFt
-fFt
-fxo
-mmH
-kok
-xVt
-uuV
-qaO
-qEc
-bOO
-ctK
-pnU
-pnU
-gPv
-iZb
-qnl
-nTq
-nTq
-nTq
-cpp
-bPH
-nNV
-aUc
-rLw
-pJr
-bOW
-hVv
-lUj
-vqC
-vqC
-vqC
-vqC
-vqC
-vqC
-vqC
-vqC
-vqC
-vqC
-bOY
-bOY
+aNJ
+fiL
+owD
+nMQ
+hnr
+rlV
+aDT
+rlV
+rlV
+bAh
+nMQ
+owD
+qlC
+pUW
+erN
+xIm
+ila
+xIm
+iKk
+guh
+owD
+qlC
+mJy
+mJy
+guh
+guh
+guh
+guh
+guh
+guh
+ltf
+guh
+guh
+guh
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
 aae
 aae
 aae
@@ -98328,41 +95870,41 @@ aaa
 "}
 (248,1,1) = {"
 aaa
-kaL
-boM
-uFI
-vaW
-xOu
-mJC
-fFt
-gmd
-qEc
-qEc
-qEc
-qEc
-qEc
-qAd
-mmH
-qEc
-jVd
-qOl
-icb
-icb
-rQY
-pTW
-qXt
-poN
-poN
-sOM
-mIk
-mvR
-bPi
-bPi
-bPi
-bPi
-bPi
-bPi
-aae
+aNJ
+owD
+qlC
+nMQ
+cpx
+rlV
+gaJ
+aDT
+rlV
+tTP
+nMQ
+owD
+owD
+pUW
+ily
+xIm
+xIm
+ila
+nRu
+guh
+qlC
+pXU
+pXU
+mJy
+guh
+wzR
+kZx
+kZx
+tMT
+gqK
+ltF
+xqW
+yhQ
+kVo
+aNJ
 aae
 aae
 aae
@@ -98585,41 +96127,41 @@ aaa
 "}
 (249,1,1) = {"
 aaa
-qEc
-rRT
-fWI
-eAH
-uFI
-bPh
-qEc
-qEc
-qEc
-jaC
-jaC
-tyb
-eQn
-pom
-pnU
-sws
-pom
-pom
-jmY
-hwW
-rQY
-owd
-dyC
-gTO
-poN
-aOp
-mIk
-nNV
-gzY
-fzh
-sVs
-sVs
-sVs
-bPi
-aae
+aNJ
+owD
+owD
+nMQ
+vbd
+rlV
+kIY
+ygN
+pcr
+qoM
+nMQ
+gVW
+uGH
+guh
+guh
+guh
+pTq
+jpV
+xIm
+guh
+geK
+owD
+pXU
+vbg
+guh
+imO
+kZx
+kZx
+nOX
+lAi
+lAi
+soy
+yhQ
+nOe
+aNJ
 aae
 aae
 aak
@@ -98842,41 +96384,41 @@ aaa
 "}
 (250,1,1) = {"
 aaa
-qEc
-qEc
-qEc
-qEc
-aKr
-sEu
-qEc
-red
-jaC
-jaC
-jaC
-bWb
-irN
-pom
-jnc
-iuf
-bOA
-hWl
-pom
-unG
-iZb
-iZb
-iZb
-iZb
-iZb
-iZb
-mIk
-nNV
-gzY
-fNs
-sVs
-fKu
-yhW
-bPi
-aae
+aNJ
+owD
+owD
+nMQ
+nMQ
+icj
+pya
+svo
+xTS
+nMQ
+nMQ
+owD
+xIm
+cVV
+pKu
+ycT
+xIm
+fFA
+gHY
+ltf
+owD
+mJy
+mJy
+mJy
+mmj
+fAi
+lAi
+lAi
+fAi
+lAi
+lAi
+pln
+yhQ
+sxf
+aNJ
 aae
 aae
 aae
@@ -99099,41 +96641,41 @@ aaa
 "}
 (251,1,1) = {"
 aaa
-fjh
-bmW
-fWI
-eAH
-boM
-siR
-qEc
-jaC
-jaC
-jaC
-jaC
-bWb
-irN
-pom
-apt
-iuf
-fFh
-pom
-pom
-oVw
-kPA
-pQZ
-mAL
-nvP
-iRj
-lUj
-mIk
-nNV
-gzY
-qje
-onN
-knq
-sVs
-bDP
-aae
+aNJ
+owD
+owD
+owD
+nMQ
+hYX
+lrr
+lrr
+hYX
+nMQ
+owD
+qlC
+uGH
+guh
+guh
+guh
+xIm
+hvZ
+yhJ
+guh
+owD
+mJy
+owD
+mJy
+mmj
+lAi
+lAi
+fAi
+lAi
+lAi
+fAi
+pln
+kER
+vSB
+aNJ
 aae
 aae
 aae
@@ -99356,41 +96898,41 @@ aaa
 "}
 (252,1,1) = {"
 aaa
-kaL
-uFI
-uFI
-vaW
-uFI
-rGi
-qEc
-jaC
-tbl
-jaC
-jaC
-bWb
-irN
-pom
-pie
-iuf
-dRQ
-pom
-pom
-fdj
-kPA
-gUb
-rOY
-wAY
-wAY
-tNp
-pzC
-qOS
-xwh
-gdb
-sVs
-sVs
-sVs
-bPi
-aae
+aNJ
+sNZ
+qlC
+ptX
+kkz
+hKh
+lrr
+lrr
+lrr
+xCc
+owD
+owD
+owD
+guh
+xTO
+ila
+jpV
+ila
+xIm
+guh
+jOR
+owD
+owD
+nEw
+guh
+lFl
+kZx
+kZx
+nOX
+fAi
+fAi
+qOB
+yhQ
+paM
+aNJ
 aae
 aak
 aae
@@ -99613,41 +97155,41 @@ aaa
 "}
 (253,1,1) = {"
 aaa
-qEc
-rUI
-grp
-eqM
-lDt
-tWF
-qEc
-afd
-jaC
-jaC
-jaC
-jaC
-hEs
-ggc
-fOl
-qEc
-fSe
-aCI
-nJF
-pUC
-kPA
-agA
-nsy
-bcz
-toj
-lUj
-icn
-qVc
-bPi
-fuT
-cWQ
-sVs
-tRs
-bPi
-aae
+aNJ
+mzW
+owD
+owD
+hOt
+lrr
+lrr
+lrr
+owD
+owD
+owD
+qlC
+mzW
+guh
+oPU
+jhM
+ila
+tkF
+xIm
+guh
+owD
+pXU
+mJy
+owD
+guh
+aXy
+kZx
+kZx
+nOX
+gqK
+ekR
+sTk
+yhQ
+paM
+aNJ
 aae
 aae
 aae
@@ -99870,41 +97412,41 @@ aaa
 "}
 (254,1,1) = {"
 aaa
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-qEc
-amX
-amX
-amX
-pTX
-lUj
-lUj
-lUj
-lUj
-lUj
-lUj
-lUj
-bPi
-bPi
-bPi
-bPi
-bPi
-bPi
-aae
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
+aNJ
 aae
 aae
 aae

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -11,27 +11,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"aaj" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/obj/structure/fence/handrail{
-	pixel_y = 18
-	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/offices1st)
 "aaL" = (
 /obj/structure/fluff/railing,
 /turf/open/transparent/openspace{
@@ -167,11 +146,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"aeX" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/weightmachine/stacklifter,
-/turf/open/floor/plating/rust,
-/area/f13/wasteland)
 "afb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -184,10 +158,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building/khanfort)
-"ahp" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "ahs" = (
 /turf/open/floor/carpet/red,
 /area/f13/legion)
@@ -218,11 +188,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/khans)
-"amh" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "ant" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -306,22 +271,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"awI" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = 9;
-	pixel_y = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "awU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -332,30 +281,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"axN" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
-"ayH" = (
-/obj/structure/chair/f13foldupchair{
-	desc = "A folding chair, missing half the seat, probably for dropping something through it.";
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"ayV" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "azJ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -395,25 +320,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
-"aCB" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_y = 5;
-	termtag = "Security"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"aCK" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -15
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "aGA" = (
 /obj/structure/obstacle/barbedwire,
 /obj/structure/railing/corner{
@@ -432,14 +338,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
-"aGS" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/computer/shuttle/bosentryelevator,
-/obj/effect/turf_decal/stripes/white/box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "aGW" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
@@ -492,18 +390,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"aSY" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/branch,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "aTt" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -610,43 +496,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/f13/city)
-"baQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "bbj" = (
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
 /area/f13/city)
-"bcw" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"bcH" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/tallgrass1,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "bcZ" = (
 /obj/structure/window/fulltile/house,
 /turf/closed/wall/f13/wood/house,
@@ -765,20 +620,6 @@
 "blr" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"blF" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
-"bne" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8;
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "bov" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13{
@@ -839,13 +680,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"btg" = (
-/turf/open/floor/carpet,
-/area/f13/brotherhood/offices1st)
-"btn" = (
-/obj/machinery/smartfridge,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/leisure)
 "buW" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -875,24 +709,6 @@
 	icon_state = "bar"
 	},
 /area/f13/city)
-"bxe" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/junglebush/b,
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/dorms)
 "bxB" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -961,13 +777,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"bBd" = (
-/obj/structure/decoration/vent{
-	pixel_y = 32
-	},
-/obj/structure/fence/corner/wooden,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "bBI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -1050,19 +859,6 @@
 /obj/structure/stairs/west,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"bHg" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/tallgrass1,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "bHN" = (
 /obj/structure/table,
 /obj/structure/railing{
@@ -1143,9 +939,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/followers)
-"bPp" = (
-/turf/open/floor/circuit/f13_blue,
-/area/f13/brotherhood/dorms)
 "bPK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -1239,12 +1032,6 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"bYm" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "caq" = (
 /obj/structure/railing,
 /obj/machinery/light{
@@ -1268,18 +1055,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/ncr)
-"ccy" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "ccz" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -1315,13 +1090,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
-"cde" = (
-/obj/structure/table/reinforced,
-/obj/item/trash/f13/electronic/toaster/atomics,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "cdi" = (
 /obj/structure/table/glass,
 /obj/machinery/light/small{
@@ -1338,17 +1106,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"ceD" = (
-/obj/machinery/computer/card/bos{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/offices1st)
-"cgW" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "chc" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/radiation,
@@ -1386,11 +1143,6 @@
 "cnx" = (
 /turf/open/floor/wood_common,
 /area/f13/building)
-"cny" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
 "cnB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -1430,16 +1182,6 @@
 	icon_state = "fancy_dark-broken1"
 	},
 /area/f13/city)
-"cuy" = (
-/obj/structure/decoration/vent{
-	pixel_y = 32
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "cuC" = (
 /obj/structure/fluff/railing{
 	dir = 1
@@ -1449,10 +1191,6 @@
 "cvc" = (
 /turf/open/transparent/openspace,
 /area/f13/followers)
-"cvH" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "cwk" = (
 /obj/machinery/light{
 	dir = 8
@@ -1474,37 +1212,6 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
-"cwT" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/tallgrass1,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
-	},
-/area/f13/brotherhood/leisure)
-"cxa" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "cxI" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -1554,12 +1261,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland/ncr)
-"cCc" = (
-/obj/structure/fluff/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "cDH" = (
 /obj/machinery/shower{
 	dir = 8
@@ -1569,12 +1270,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"cFm" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "cFr" = (
 /obj/structure/railing{
 	dir = 6;
@@ -1585,10 +1280,6 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland/khans)
-"cFU" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "cGh" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/wood_common,
@@ -1610,9 +1301,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
-"cIz" = (
-/turf/closed/wall/f13/wood,
-/area/f13/brotherhood/offices1st)
 "cJg" = (
 /obj/structure/chair{
 	dir = 1
@@ -1642,15 +1330,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
-"cMd" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/leisure)
 "cMC" = (
 /obj/structure/closet/cabinet/anchored,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -1680,31 +1359,10 @@
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/arcade,
 /area/f13/city)
-"cRP" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_2";
-	name = "Level 2: Life Support";
-	width = 4
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/leisure)
 "cSz" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"cSW" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/vending/cola/space_up,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "cTb" = (
 /obj/structure/railing{
 	dir = 6;
@@ -1755,13 +1413,6 @@
 "cVV" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/khanfort)
-"cWs" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/leisure)
 "cWQ" = (
 /obj/item/clothing/mask/ncr_facewrap,
 /turf/open/floor/f13/wood,
@@ -1773,26 +1424,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"cYB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "daP" = (
 /turf/open/floor/plating/f13/outside/roof/wood/old,
 /area/f13/wasteland/khans)
@@ -1806,9 +1437,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
-"dcJ" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
 "dcO" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood1-broken"
@@ -1832,26 +1460,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/village)
-"dfz" = (
-/obj/item/candle{
-	pixel_y = 7
-	},
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 34
-	},
-/obj/item/gun/energy/laser/plasma/scatter{
-	anchored = 1;
-	cell_type = null;
-	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
-	name = "display multiplas rifle";
-	pin = null;
-	pixel_y = 32
-	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/offices1st)
 "dfR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -1900,12 +1508,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"djM" = (
-/obj/structure/table,
-/obj/item/pda/detective,
-/obj/item/pda/detective,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "dkw" = (
 /obj/structure/bed/wooden,
 /turf/open/floor/carpet/royalblack,
@@ -1936,18 +1538,6 @@
 "dpc" = (
 /turf/open/floor/plating/f13/outside/roof/wood/old,
 /area/f13/wasteland/ncr)
-"dpm" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "dpX" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light{
@@ -1976,39 +1566,6 @@
 "dtb" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"dtv" = (
-/obj/structure/table/booth,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"dvH" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/tallgrass2,
-/obj/structure/flora/ausbushes/genericbush,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
-"dwq" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/change,
-/turf/closed/wall/f13/wood,
-/area/f13/brotherhood/offices1st)
-"dxB" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "dAK" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/wood_common,
@@ -2019,31 +1576,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
-"dBt" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/obj/structure/fence/handrail{
-	pixel_y = 18
-	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/offices1st)
-"dBJ" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
 "dBK" = (
 /obj/structure/window/fulltile/house,
 /turf/closed/wall/f13/wood/house,
@@ -2059,12 +1591,6 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/wasteland)
-"dDU" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "dDZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood{
@@ -2072,25 +1598,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"dEA" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
-"dEN" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 34
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "dGM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -2109,14 +1616,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblack,
 /area/f13/city)
-"dJa" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "dJK" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/wood_common,
@@ -2177,12 +1676,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
-"dQO" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/offices1st)
 "dRc" = (
 /obj/structure/railing{
 	dir = 10
@@ -2225,12 +1718,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/ncr)
-"dTZ" = (
-/obj/machinery/vr_sleeper/bos{
-	dir = 4
-	},
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
 "dUa" = (
 /obj/machinery/door/window{
 	dir = 8
@@ -2279,14 +1766,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/city)
-"dYl" = (
-/obj/structure/sign/poster/prewar/poster65,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
-"dYq" = (
-/obj/structure/window/fulltile/store,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/offices1st)
 "dYT" = (
 /turf/closed/wall/r_wall,
 /area/f13/city)
@@ -2325,15 +1804,6 @@
 	icon_state = "fancy_dark-broken6"
 	},
 /area/f13/city)
-"eaz" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm9";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/dorms)
 "eaI" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -2342,12 +1812,6 @@
 	icon_state = "fancy_dark-broken5"
 	},
 /area/f13/village)
-"eba" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "ebv" = (
 /turf/open/transparent/openspace,
 /area/f13/legion)
@@ -2357,27 +1821,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/city)
-"ecL" = (
-/obj/item/candle{
-	pixel_y = -7
-	},
-/obj/structure/noticeboard{
-	dir = 1;
-	name = "display plate";
-	pixel_y = -32
-	},
-/obj/item/gun/energy/laser/rcw{
-	anchored = 1;
-	cell_type = null;
-	desc = "A rapid-fire laser rifle modeled after the familiar Thompson Submachine Gun. It features high-accuracy burst fire that will whittle down targets in a matter of seconds. This one is for display, and no longer fires.";
-	name = "display laser RCW";
-	pin = null;
-	pixel_y = -32
-	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/offices1st)
 "efm" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -2387,15 +1830,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/city)
-"efJ" = (
-/obj/machinery/button/door{
-	id = "bosdorm6";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "egq" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
@@ -2403,12 +1837,6 @@
 	sunlight_state = 1
 	},
 /area/f13/building/hospital)
-"egE" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
 "ehG" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -2429,16 +1857,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/radiation)
-"eiT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "ejc" = (
 /turf/open/floor/plating/f13/outside/roof/metal,
 /area/f13/wasteland)
@@ -2446,12 +1864,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/f13/ncr)
-"ekl" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "emv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2485,10 +1897,6 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/ncr)
-"etV" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "evf" = (
 /obj/structure/closet/crate/trashcart,
 /obj/machinery/light,
@@ -2515,22 +1923,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"ezJ" = (
-/obj/structure/decoration/vent{
-	pixel_x = 32
-	},
-/obj/structure/fence/corner/wooden{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -15
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "ezL" = (
 /obj/structure/chair/f13chair1{
 	dir = 8
@@ -2571,12 +1963,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"eBz" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/offices1st)
 "eCq" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -2594,12 +1980,6 @@
 /obj/item/lighter/greyscale,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"eDW" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "eEi" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -2609,11 +1989,6 @@
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"eGT" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/books,
-/turf/open/floor/carpet,
-/area/f13/brotherhood/offices1st)
 "eHj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -2622,15 +1997,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"eHr" = (
-/obj/item/candle{
-	pixel_x = -7
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/offices1st)
 "eHs" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowbrokenvertical"
@@ -2647,16 +2013,6 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"eHC" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/brushwood,
-/obj/structure/flora/ausbushes/leafybush,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "eIa" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/decal/cleanable/dirt,
@@ -2674,14 +2030,6 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
-"eJY" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/item/reagent_containers/food/drinks/sillycup,
-/obj/item/reagent_containers/food/drinks/sillycup,
-/obj/item/reagent_containers/food/drinks/sillycup,
-/obj/item/reagent_containers/food/drinks/sillycup,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "eLn" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -2732,14 +2080,6 @@
 /obj/machinery/light,
 /turf/closed/wall/rust,
 /area/f13/ncr)
-"ePZ" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "eRm" = (
 /obj/structure/closet,
 /obj/item/storage/box/masks,
@@ -2749,21 +2089,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"eRN" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "eSE" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -2777,13 +2102,6 @@
 /obj/structure/chair/f13chair1,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/legion)
-"eTz" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Head Knight's Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "eTN" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/gibs{
@@ -2808,25 +2126,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/city)
-"eWH" = (
-/obj/structure/decoration/rag,
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
 "eWN" = (
 /obj/machinery/vending/cola/red,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/city)
-"eXH" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "eZe" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13/wood,
@@ -2872,13 +2177,6 @@
 /obj/structure/simple_door/glass,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"faR" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "fbK" = (
 /obj/structure/railing,
 /turf/open/transparent/openspace,
@@ -2961,10 +2259,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
-"fiP" = (
-/obj/item/stack/sheet/hay,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "fjM" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -3098,10 +2392,6 @@
 	},
 /turf/open/floor/carpet/arcade,
 /area/f13/city)
-"fDR" = (
-/obj/structure/sign/poster/prewar/poster60,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "fDV" = (
 /obj/structure/railing{
 	dir = 8
@@ -3118,9 +2408,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"fFp" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood/dorms)
 "fFB" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -3130,13 +2417,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"fGW" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
 "fHN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -3147,24 +2427,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/carpet/royalblack,
 /area/f13/city)
-"fKQ" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle,
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/dorms)
 "fLw" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -3177,14 +2439,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/followers)
-"fOP" = (
-/obj/item/candle{
-	pixel_y = -7
-	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/offices1st)
 "fPJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3201,12 +2455,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
-"fQU" = (
-/obj/effect/light_emitter/red_energy_sword,
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
-/area/f13/brotherhood/offices1st)
 "fRz" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -3246,9 +2494,6 @@
 /obj/machinery/microwave/stove,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"fWx" = (
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
 "fWH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3301,25 +2546,6 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
-"gai" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "gbV" = (
 /obj/structure/closet/crate/bin{
 	pixel_y = 8
@@ -3330,23 +2556,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"gec" = (
-/obj/machinery/light/small,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "geI" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"gfo" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/bag/tray,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "gfF" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -3369,16 +2584,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland/ncr)
-"giY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
-"gku" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "gkO" = (
 /obj/structure/toilet{
 	pixel_y = 7
@@ -3397,14 +2602,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
-"goc" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = null;
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/offices1st)
 "gos" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/radiation,
@@ -3545,12 +2742,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"gKQ" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "gLr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3565,13 +2756,6 @@
 /obj/item/toy/plush/lampplushie,
 /turf/open/floor/carpet/red,
 /area/f13/city)
-"gLC" = (
-/turf/open/floor/f13{
-	color = "#f7e8e1";
-	dir = 4;
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/offices1st)
 "gLD" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -3600,36 +2784,16 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"gOS" = (
-/obj/machinery/light/floor,
-/obj/item/flag/bos,
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/leisure)
 "gPr" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"gPv" = (
-/obj/structure/barricade/wooden,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "gPM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"gQZ" = (
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
-/area/f13/brotherhood/offices1st)
 "gRD" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -3642,28 +2806,11 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"gRI" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "gRV" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/wasteland)
-"gSi" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	layer = 6;
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "gSj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stock_parts/cell/ammo/breeder,
@@ -3679,16 +2826,6 @@
 /obj/structure/bed/wooden,
 /turf/open/floor/wood_common,
 /area/f13/city)
-"gXj" = (
-/obj/structure/toilet{
-	pixel_y = 10
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = -10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/offices1st)
 "gYD" = (
 /turf/closed/wall/f13/wood,
 /area/f13/city)
@@ -3723,17 +2860,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"hbd" = (
-/obj/structure/table/wood,
-/obj/machinery/bookbinder{
-	icon_state = "bigscanner";
-	pixel_y = 7
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/offices1st)
 "hbh" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -3744,9 +2870,6 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"hbQ" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "hcj" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3795,21 +2918,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"hgR" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/dorms)
 "hjt" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light{
@@ -3861,12 +2969,6 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"hmp" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "hmX" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -3909,19 +3011,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"hqC" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
-	},
-/obj/effect/landmark/start/f13/headscribe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"hqH" = (
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "hrd" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/item/kirbyplants/random,
@@ -3954,15 +3043,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"hue" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
-"hun" = (
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "huB" = (
 /obj/structure/junk/arcade,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -3973,10 +3053,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"hva" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "hvE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4041,22 +3117,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"hFw" = (
-/obj/structure/fence/wooden,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
-"hFM" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm8";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/dorms)
 "hHz" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
@@ -4105,24 +3165,6 @@
 	dir = 4
 	},
 /area/f13/building/hospital)
-"hLt" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/tallgrass2,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/brushwood,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
-	},
-/obj/structure/flora/tallgrass1,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "hMq" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
@@ -4133,12 +3175,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"hNa" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "hNf" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -4200,38 +3236,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/wasteland)
-"hZs" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_x = 16;
-	pixel_y = 34
-	},
-/obj/item/gun/energy/laser/plasma/scatter{
-	anchored = 1;
-	cell_type = null;
-	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
-	name = "display multiplas rifle";
-	pin = null;
-	pixel_x = 16;
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "hZY" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"ibC" = (
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/leisure)
 "icv" = (
 /obj/machinery/light{
 	dir = 4;
@@ -4239,21 +3249,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"icG" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
-"icQ" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood/offices1st)
-"idx" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "idL" = (
 /obj/machinery/autolathe/ammo/unlocked,
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
@@ -4410,15 +3405,6 @@
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"iqf" = (
-/obj/structure/bookcase/manuals/engineering{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Archives"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
 "iqu" = (
 /obj/structure/railing{
 	dir = 1
@@ -4432,16 +3418,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"iqT" = (
-/obj/machinery/vr_sleeper/bos{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
 "ira" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/structure/guncase{
@@ -4455,13 +3431,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"irl" = (
-/obj/structure/lattice/catwalk/clockwork,
-/obj/effect/light_emitter/red_energy_sword,
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/offices1st)
 "itg" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -4523,44 +3492,11 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"izg" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6;
-	pixel_x = 7
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "izJ" = (
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/legion)
-"izT" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/junglebush/b,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
-"iAb" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
-"iAA" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood/leisure)
 "iAB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -4646,30 +3582,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/city)
-"iKV" = (
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
-"iMF" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
-"iNt" = (
-/obj/machinery/button/door{
-	id = "bosdorm9";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "iNE" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4812,19 +3724,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"jcD" = (
-/obj/structure/railing{
-	color = null;
-	dir = 9
-	},
-/obj/structure/bookcase/manuals/engineering{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Archives"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
 "jdQ" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/barricade/bars,
@@ -4856,17 +3755,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"jfi" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	name = "prewar lounge chair"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "jfC" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/tires/five,
@@ -4884,17 +3772,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/legion)
-"jfO" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/tallgrass2,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "jic" = (
 /obj/item/bodypart/l_arm,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -4921,15 +3798,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
-"jml" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "jmO" = (
 /obj/structure/bed/mattress,
 /obj/effect/landmark/start/f13/legionary,
@@ -4939,10 +3807,6 @@
 /obj/effect/landmark/start/f13/ncrmp,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"jnb" = (
-/obj/machinery/vending/cola/red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
 "jnz" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -4976,32 +3840,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"jpY" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
-"jqM" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/tallgrass1,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "jqW" = (
 /obj/structure/lattice/catwalk,
 /obj/item/kirbyplants/random,
@@ -5080,14 +3918,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"jxS" = (
-/obj/machinery/bookbinder{
-	icon_state = "bigscanner";
-	pixel_y = 7
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "jyS" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -5130,15 +3960,6 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"jDD" = (
-/obj/machinery/button/door{
-	id = "bosdorm8";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "jDW" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -5156,10 +3977,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
 /area/f13/followers)
-"jHu" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "jIf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -5195,29 +4012,9 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/ncr)
-"jIR" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "headscribedorm";
-	name = "Head Scribe's Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "jJi" = (
 /turf/open/indestructible,
 /area/f13/wasteland)
-"jJp" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/structure/railing{
-	dir = 6;
-	layer = 4.1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "jJr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/dogbed,
@@ -5338,12 +4135,6 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"kbk" = (
-/obj/machinery/vr_sleeper/bos{
-	dir = 1
-	},
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
 "kdI" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -5390,22 +4181,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"kgE" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood/leisure)
-"kgX" = (
-/obj/structure/table,
-/obj/machinery/light/small,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_y = 5;
-	termtag = "Security"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "khl" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -5448,10 +4223,6 @@
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"klH" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "kmu" = (
 /turf/open/transparent/openspace,
 /area/f13/building)
@@ -5465,10 +4236,6 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
-"kmZ" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
 "knt" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -5519,31 +4286,6 @@
 	icon_state = "hydrofloor"
 	},
 /area/f13/building)
-"kvH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/vinegar,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/soysauce,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/quality_oil,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/peanut_butter,
-/obj/item/reagent_containers/food/condiment/mayonnaise,
-/obj/item/reagent_containers/food/condiment/ketchup,
-/obj/item/reagent_containers/food/condiment/honey,
-/obj/item/reagent_containers/food/condiment/cherryjelly,
-/obj/item/reagent_containers/food/condiment/bbqsauce,
-/obj/item/storage/fancy/egg_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "kwW" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -5572,11 +4314,6 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"kCf" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "kCU" = (
 /obj/effect/overlay/junk/oldpipes,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
@@ -5652,10 +4389,6 @@
 "kJl" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
-"kMs" = (
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "kMB" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -5756,9 +4489,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/f13/wasteland)
-"kWA" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
 "kWR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5804,10 +4534,6 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
-"lat" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
 "laB" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
@@ -5826,23 +4552,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"lcT" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_x = 16;
-	pixel_y = 34
-	},
-/obj/item/gun/energy/pulse{
-	anchored = 1;
-	cell_type = null;
-	desc = "A heavy-duty, multifaceted energy rifle with three modes. Preferred by front-line combat personnel. This one is for display, and no longer fires.";
-	name = "display pulse rifle";
-	pin = null;
-	pixel_x = 16;
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "ldu" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13{
@@ -5876,32 +4585,9 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"lit" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
-"liA" = (
-/obj/machinery/smartfridge,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "ljc" = (
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/legion)
-"lmj" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "lnz" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
@@ -5942,11 +4628,6 @@
 	icon_state = "bluedirty"
 	},
 /area/f13/building/hospital)
-"lpf" = (
-/obj/structure/table,
-/obj/item/statuebust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "lqF" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -5959,43 +4640,12 @@
 "lqO" = (
 /turf/closed/wall/f13/store,
 /area/f13/building/hospital)
-"lsE" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "lta" = (
 /obj/machinery/mineral/mint,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
-"lut" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/poppy{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/snacks/grown/poppy/lily{
-	pixel_y = -5
-	},
-/obj/item/reagent_containers/food/snacks/grown/poppy/geranium{
-	pixel_x = -5
-	},
-/obj/item/card/id/dogtag{
-	desc = "Never thirsty is the grave of the fallen Brother, for their kin floods the ground with the blood of the blind.";
-	name = "The Fallen Brother's Holotags";
-	pixel_y = -2
-	},
-/obj/item/candle{
-	pixel_y = 7
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/offices1st)
 "lvE" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 4
@@ -6022,15 +4672,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"lxH" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm6";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/dorms)
 "lyF" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -6095,12 +4736,6 @@
 /obj/structure/simple_door/metal/fence/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"lHa" = (
-/obj/structure/fans/tiny{
-	pixel_y = -33
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "lHU" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -6113,10 +4748,6 @@
 "lIQ" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
-"lJT" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "lKV" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -6179,21 +4810,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"lPi" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "bos_upper"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "lPo" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -6240,24 +4856,6 @@
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"lUq" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"lVs" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "lXL" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -6299,41 +4897,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/city)
-"lZP" = (
-/obj/machinery/computer/terminal{
-	density = 0;
-	desc = "A pre-war high security terminal. There's virtually no way to hack into this thing; it holds the most secure information the Brotherhood has to offer.";
-	doc_content_1 = "The preservation of technology is our primary goal, all others are secondary. <br> <br>  Shield yourself from those not bound to you by steel, for they are the blind. Aid them when you can, but lose not sight of yourself.";
-	doc_content_2 = "Give way your suspicions to the wisdom of thine Elder. Where he shows trust, so shall you. <br> <br> Fear those who do not pledge to the Brotherhood for though their eyes may be opened through service, they are now blind. ";
-	doc_content_3 = "Through discourse, we gain the strength of our Brothers' minds. Deceit and lies of all ilk serve only to harm that strength. <br> <br> Your caste and duties mean everything, you will follow your leader and your leader will lead you. <br> <br> You may only follow the orders of another if it will save the life of a brother. ";
-	doc_content_4 = "Theft is for lesser men, the Brotherhood provides for you and you provide for the Brotherhood. <br> <br>  What lesser men see as fashionable shall be shunned. Foreign garment and practice will do nothing but shame your fellow brothers.  ";
-	doc_content_5 = "The Blind can not read, only those who have taken the Oath of Fraternity may read this text.";
-	doc_title_1 = "Doctrine pt. 1";
-	doc_title_2 = "Doctrine pt. 2";
-	doc_title_3 = "Doctrine pt. 3";
-	doc_title_4 = "Doctrine pt. 4";
-	doc_title_5 = "Doctrine pt. 5";
-	icon_screen = null;
-	icon_state = "ratvarcomputer1";
-	idle_power_usage = 1;
-	light_color = "#6e1722";
-	light_power = 2;
-	light_range = 3;
-	max_integrity = 1000;
-	name = "The Codex";
-	note = "Scribe Note of the Week:";
-	termtag = "Codex"
-	},
-/obj/item/projectile/magic/animate{
-	pixel_x = -32
-	},
-/obj/structure/destructible/clockwork/wall_gear{
-	pixel_x = -32
-	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/offices1st)
 "lZT" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -6407,12 +4970,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
-"mgK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "mha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/kitchenspike,
@@ -6423,27 +4980,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"mhb" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
-"mhP" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "mhV" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -6543,13 +5079,6 @@
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"msY" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/leisure)
 "msZ" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -6569,28 +5098,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"mue" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "mvc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/campfire/stove{
@@ -6635,10 +5142,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"mAf" = (
-/obj/item/storage/money_stack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "mAu" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -6667,10 +5170,6 @@
 "mCO" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland/khans)
-"mGj" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "mGE" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/ladder/unbreakable{
@@ -6679,28 +5178,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/radiation)
-"mGG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
 "mGL" = (
 /obj/structure/chair/stool/f13stool,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -6727,19 +5204,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/city)
-"mLh" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/rock/jungle,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "mLV" = (
 /obj/machinery/light{
 	dir = 1;
@@ -6763,17 +5227,6 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"mOp" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
-"mOu" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "mQC" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden,
@@ -6873,58 +5326,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/wasteland)
-"nat" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
-"nbF" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/leisure)
-"ncO" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "ncX" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
@@ -6939,13 +5340,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"ndW" = (
-/obj/machinery/light,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "nem" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -6985,42 +5379,6 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"nfy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = null;
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
-"nfG" = (
-/obj/structure/table/booth,
-/obj/machinery/light,
-/obj/structure/noticeboard{
-	dir = 1;
-	name = "display plate";
-	pixel_y = -32
-	},
-/obj/item/gun/energy/laser/rcw{
-	anchored = 1;
-	cell_type = null;
-	desc = "A rapid-fire laser rifle modeled after the familiar Thompson Submachine Gun. It features high-accuracy burst fire that will whittle down targets in a matter of seconds. This one is for display, and no longer fires.";
-	name = "display laser RCW";
-	pin = null;
-	pixel_y = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
-"nfW" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "nfY" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -7060,16 +5418,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblack,
 /area/f13/city)
-"nmN" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm7";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/dorms)
 "nnp" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/blood/old{
@@ -7093,10 +5441,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/city)
-"noz" = (
-/obj/structure/bookcase,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "noI" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -7120,35 +5464,10 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"npu" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "npY" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"nqH" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/bookcase/manuals/engineering{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Archives"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
-"nrf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "nsa" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -7171,13 +5490,6 @@
 	icon_state = "bar"
 	},
 /area/f13/city)
-"ntv" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
 "ntT" = (
 /obj/structure/railing{
 	dir = 8
@@ -7237,17 +5549,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nAN" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/branch,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "nBq" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -7268,26 +5569,6 @@
 "nCS" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"nDo" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	dir = 4;
-	name = "prewar lounge chair"
-	},
-/obj/effect/landmark/start/f13/knightcap,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/offices1st)
-"nEV" = (
-/obj/item/candle{
-	pixel_y = 7
-	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/offices1st)
 "nFw" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -7420,12 +5701,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"nRx" = (
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "nSn" = (
 /obj/structure/fluff/railing,
 /turf/open/transparent/openspace,
@@ -7486,13 +5761,6 @@
 	dir = 8
 	},
 /area/f13/building/hospital)
-"nYe" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
 "nYz" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -7501,30 +5769,12 @@
 	icon_state = "housewood1-broken"
 	},
 /area/f13/building)
-"nYW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
-"nZK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "oab" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
-"oac" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "obr" = (
 /obj/item/trash/candy,
 /obj/item/trash/sosjerky,
@@ -7552,34 +5802,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"odt" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -8;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "odJ" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -7596,12 +5818,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"oed" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "oez" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
@@ -7613,31 +5829,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"ofy" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "ohv" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ohK" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "oiY" = (
 /obj/structure/filingcabinet{
 	pixel_x = -10
@@ -7658,17 +5854,6 @@
 "ojh" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
-"ojG" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/pda/heads/cmo{
-	name = "Head Scribe PipBoy"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "ojP" = (
 /turf/open/floor/plating/f13/outside/roof/red,
 /area/f13/wasteland)
@@ -7691,13 +5876,6 @@
 "olL" = (
 /turf/open/floor/plating/f13/outside/roof/metal/verdigris,
 /area/f13/wasteland)
-"olZ" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/box/cups,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
 "ona" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fence/handrail{
@@ -7805,15 +5983,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/followers)
-"oAO" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "oBn" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/stripes/white/box,
@@ -7829,33 +5998,6 @@
 /obj/item/radio/headset/headset_ncr,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"oBO" = (
-/obj/structure/table/booth,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 34
-	},
-/obj/item/gun/energy/laser/plasma/scatter{
-	anchored = 1;
-	cell_type = null;
-	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
-	name = "display multiplas rifle";
-	pin = null;
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
-"oCS" = (
-/obj/structure/table,
-/obj/item/pda/warden,
-/obj/item/pda/warden,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "oDl" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/bag/trash,
@@ -7874,17 +6016,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
 /area/f13/ncr)
-"oEf" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"oEC" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/leisure)
 "oGu" = (
 /obj/machinery/vending/cola/space_up,
 /obj/machinery/light,
@@ -7925,16 +6056,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"oIX" = (
-/obj/item/flag/bos,
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
-/area/f13/brotherhood/offices1st)
-"oLf" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
 "oLL" = (
 /obj/machinery/teleport/station{
 	name = "power unit"
@@ -7957,16 +6078,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"oNt" = (
-/obj/machinery/light/floor{
-	color = "#FF7F7F";
-	critical_machine = 1;
-	flicker_chance = 0;
-	light_color = "#FF7F7F";
-	nightshift_light_color = "#660000"
-	},
-/turf/open/floor/circuit/red,
-/area/f13/brotherhood/dorms)
 "oOo" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -7976,13 +6087,6 @@
 "oPT" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland/ncr)
-"oQh" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "oRm" = (
 /obj/structure/barricade/wooden,
 /obj/structure/window/fulltile/store{
@@ -8007,24 +6111,6 @@
 /obj/item/reagent_containers/hypospray/medipen/medx,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"oSA" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
-"oTn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
 "oTC" = (
 /obj/machinery/light{
 	dir = 1;
@@ -8063,10 +6149,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"oYS" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/leisure)
 "oYZ" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -8086,10 +6168,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
-"oZu" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
 "paq" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/shorts/polychromic/pantsu,
@@ -8121,31 +6199,6 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"pgf" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket/plastic,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"pgI" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "phh" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -8153,13 +6206,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"phu" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/table,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "pkR" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/caves)
@@ -8198,13 +6244,6 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"pmz" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "poV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet/anchored,
@@ -8271,11 +6310,6 @@
 /obj/item/gun/ballistic/automatic/pistol/ninemil,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"pvZ" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "pws" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -8287,21 +6321,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"pwD" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
-	},
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/item/pen/fountain{
-	pixel_x = 15;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "pzS" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -8312,28 +6331,6 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"pAO" = (
-/obj/structure/table/reinforced,
-/obj/item/book/granter/trait/pa_wear,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/offices1st)
-"pAP" = (
-/obj/machinery/button/door{
-	id = "headscribedorm";
-	normaldoorcontrol = 1;
-	pixel_x = -8;
-	pixel_y = -24;
-	specialfunctions = 4
-	},
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "pAS" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -8343,21 +6340,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"pCz" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen{
-	pixel_y = 9
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/offices1st)
-"pDF" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "pEr" = (
 /obj/structure/fluff/railing/corner{
 	dir = 8
@@ -8403,13 +6385,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"pGS" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
 "pHG" = (
 /obj/machinery/light{
 	dir = 1
@@ -8423,12 +6398,6 @@
 "pIR" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
-"pJx" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
 "pLa" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13/wood,
@@ -8444,15 +6413,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
-"pMT" = (
-/obj/structure/bed,
-/obj/item/bedsheet/rd{
-	desc = "A fine quilted blanket, made with purple and yellow fabric.";
-	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
-	name = "fine bedsheet"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "pOP" = (
 /obj/structure/simple_door/glass{
 	name = "Research and Development office"
@@ -8490,33 +6450,6 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"pRS" = (
-/obj/structure/table,
-/obj/item/storage/fancy/candle_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"pUs" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
-"pUI" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"pVc" = (
-/obj/machinery/processor,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "pWV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8532,39 +6465,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"pYl" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/junglebush/c,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/dorms)
 "pZk" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"pZs" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/tallgrass1,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "pZN" = (
 /obj/structure/table,
 /obj/machinery/light/small/broken{
@@ -8579,37 +6483,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/city)
-"qcQ" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "qcT" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/wood_common,
 /area/f13/city)
-"qfx" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"qgv" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "qgz" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -8629,12 +6508,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"qhk" = (
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/leisure)
 "qhz" = (
 /obj/structure/railing{
 	dir = 5
@@ -8658,12 +6531,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/caves)
-"qkw" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "qkB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8679,16 +6546,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"qlS" = (
-/obj/structure/table,
-/obj/item/clothing/neck/mantle/bos/paladin,
-/obj/item/clothing/neck/mantle/bos/paladin,
-/obj/item/clothing/neck/mantle/bos,
-/obj/item/clothing/neck/mantle/bos,
-/obj/item/clothing/neck/mantle/bos/right,
-/obj/item/clothing/neck/mantle/bos/right,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "qnj" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8705,12 +6562,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"qoO" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "qqF" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 1;
@@ -8740,26 +6591,12 @@
 "qsA" = (
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated/green,
 /area/f13/wasteland/ncr)
-"qth" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "qtF" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland/ncr)
-"qtP" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "quJ" = (
 /obj/structure/chair/sofa/corner,
 /obj/machinery/light/small{
@@ -8797,30 +6634,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"qyB" = (
-/obj/item/ship_in_a_bottle{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/structure/table/wood/fancy/black,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "qzj" = (
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qzp" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/machinery/vending/nukacolavend,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/leisure)
 "qzu" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -8844,35 +6660,6 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"qBr" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
-	},
-/area/f13/brotherhood/leisure)
 "qCT" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood/house,
@@ -8884,18 +6671,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"qFz" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 8;
-	name = "prewar lounge chair"
-	},
-/obj/effect/landmark/start/f13/sentinel,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/offices1st)
 "qFA" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -8935,9 +6710,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
-"qJn" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
 "qJy" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -8952,10 +6724,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"qKZ" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "qLd" = (
 /obj/item/melee/onehanded/machete/training,
 /turf/open/floor/f13/wood,
@@ -9044,10 +6812,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"qRR" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "qUA" = (
 /obj/structure/simple_door/house,
 /obj/structure/barricade/wooden,
@@ -9084,13 +6848,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"raf" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Archives";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "raE" = (
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
@@ -9108,12 +6865,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/city)
-"rbY" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "rdo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -9121,21 +6872,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/legion)
-"rfr" = (
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/offices1st)
-"rgw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "rhv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fence/handrail{
@@ -9190,16 +6926,6 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/ncr)
-"rng" = (
-/obj/machinery/shower{
-	pixel_y = 27
-	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
 "rnq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9246,12 +6972,6 @@
 	},
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated/green,
 /area/f13/wasteland/ncr)
-"rss" = (
-/obj/machinery/smartfridge,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "rsw" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/wasteland/ncr)
@@ -9271,37 +6991,8 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"rvE" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -11;
-	pixel_y = 4
-	},
-/obj/machinery/microwave{
-	density = 0;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "rvI" = (
 /turf/open/floor/plating/rust,
-/area/f13/wasteland)
-"rvM" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"rvT" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
-"rvZ" = (
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/offices1st)
-"rwf" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/weightmachine/weightlifter,
-/turf/open/transparent/openspace,
 /area/f13/wasteland)
 "rwk" = (
 /turf/closed/mineral/random/high_chance,
@@ -9316,12 +7007,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/legion)
-"ryC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "rza" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/dirt,
@@ -9329,25 +7014,11 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"rAK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
 "rBj" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/city)
-"rBF" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/offices1st)
 "rBR" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/reinforced/fulltile,
@@ -9365,22 +7036,6 @@
 /obj/structure/window/fulltile/ruins,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"rCE" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/tallgrass2,
-/obj/structure/flora/brushwood,
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "rDr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9400,35 +7055,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"rGb" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/branch,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/flora/tallgrass1,
-/turf/open/water,
-/area/f13/brotherhood/dorms)
-"rGO" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "rGU" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal"
@@ -9476,26 +7102,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
-"rJu" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
-	},
-/area/f13/brotherhood/offices1st)
-"rKI" = (
-/obj/machinery/light/floor,
-/obj/item/flag/bos,
-/obj/structure/railing{
-	dir = 6;
-	layer = 4.1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/leisure)
 "rLB" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland/ncr)
@@ -9519,11 +7125,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
-"rOk" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "rOF" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/wasteland)
@@ -9546,14 +7147,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building/khanfort)
-"rRe" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "rRp" = (
 /obj/structure/fluff/railing/corner{
 	dir = 1
@@ -9563,14 +7156,6 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/ncr)
-"rRu" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4;
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "rRC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9599,11 +7184,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"rTi" = (
-/obj/structure/table/booth,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "rVk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -9614,25 +7194,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/followers)
-"rVr" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "rVI" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -9684,15 +7245,6 @@
 /obj/effect/landmark/start/f13/mayor,
 /turf/open/floor/carpet/red,
 /area/f13/city)
-"scQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_y = -1
-	},
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "sdB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9738,12 +7290,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
-"siJ" = (
-/obj/structure/chair/f13foldupchair{
-	pixel_y = 14
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "sjx" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13{
@@ -9757,14 +7303,6 @@
 /obj/structure/fluff/beach_umbrella/syndi,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"sjz" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = 32;
-	density = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "sjM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -9772,13 +7310,6 @@
 /obj/machinery/chem_dispenser/low_power,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"skE" = (
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/pug{
-	name = "Paladin Ramos"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "slZ" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8;
@@ -9787,13 +7318,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/city)
-"smK" = (
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
-	},
-/obj/structure/grille,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/leisure)
 "smS" = (
 /obj/effect/overlay/junk/oldpipes,
 /obj/item/storage/trash_stack,
@@ -9802,47 +7326,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"sox" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
-	},
-/area/f13/brotherhood/leisure)
-"spz" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "srw" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -9894,14 +7377,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"svo" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/structure/table,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "svC" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -9923,10 +7398,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"sxr" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
 "sxs" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old{
@@ -9939,10 +7410,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"szw" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
 "szH" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -10021,19 +7488,6 @@
 /obj/item/melee/onehanded/slavewhip,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"sGM" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "sHx" = (
 /obj/machinery/light{
 	dir = 4;
@@ -10044,13 +7498,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"sHR" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/fluff/railing/corner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "sIn" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -10083,10 +7530,6 @@
 /obj/machinery/computer/arcade/battle,
 /turf/open/floor/carpet/arcade,
 /area/f13/city)
-"sMW" = (
-/obj/effect/landmark/start/f13/elder,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/offices1st)
 "sNs" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -10158,21 +7601,11 @@
 	name = "concrete wall"
 	},
 /area/f13/wasteland)
-"sTs" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "sUD" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"sUQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "sVC" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -10209,13 +7642,6 @@
 "sYU" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/wasteland)
-"tap" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
 "taC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fence/handrail{
@@ -10241,45 +7667,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
-"tdd" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
-	},
-/area/f13/brotherhood/leisure)
-"tdB" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/railing{
-	color = null;
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/leisure)
 "teM" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -10317,11 +7704,6 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
-"thi" = (
-/obj/structure/table,
-/obj/item/pda/heads/hos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "tik" = (
 /turf/open/transparent/openspace,
 /area/f13/radiation)
@@ -10334,21 +7716,9 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland/khans)
-"tiw" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "tiP" = (
 /turf/open/floor/wood_fancy,
 /area/f13/ncr)
-"tjA" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "tkq" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -10374,14 +7744,6 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"tni" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "tnq" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
@@ -10433,25 +7795,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"tuI" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/dorms)
 "tvg" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt{
@@ -10472,22 +7815,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/legion)
-"twz" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "txr" = (
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"txY" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "tzL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -10515,10 +7846,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"tDP" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
 "tEW" = (
 /obj/structure/railing{
 	dir = 1
@@ -10558,10 +7885,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/followers)
-"tLX" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/offices1st)
 "tMg" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -10578,9 +7901,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood_common,
 /area/f13/city)
-"tOZ" = (
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/offices1st)
 "tPa" = (
 /obj/structure/fluff/railing{
 	dir = 4
@@ -10613,33 +7933,6 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/ncr)
-"tTV" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"tUy" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"tUX" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/tallgrass1,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "tUY" = (
 /turf/open/floor/wood_common{
 	icon_state = "common-broken4"
@@ -10658,12 +7951,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
-"tWi" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "tWj" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -10704,10 +7991,6 @@
 	sunlight_state = 1
 	},
 /area/f13/building/khanfort)
-"tXK" = (
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "tYb" = (
 /obj/structure/chair/sofa,
 /obj/effect/decal/cleanable/dirt,
@@ -10722,12 +8005,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/f13/outside/roof/wood,
 /area/f13/wasteland)
-"ubN" = (
-/obj/machinery/plantgenes,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "ucd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -10786,16 +8063,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"uiI" = (
-/obj/machinery/vr_sleeper/bos{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
-	},
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
 "uiJ" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13{
@@ -10874,13 +8141,6 @@
 	dir = 6
 	},
 /area/f13/building/hospital)
-"upI" = (
-/obj/structure/table,
-/obj/item/radio/headset/headset_bos,
-/obj/item/radio/headset/headset_bos,
-/obj/item/radio/headset/headset_bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "uro" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/f13/wood,
@@ -10889,12 +8149,6 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/hospital)
-"usy" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "usA" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/oil{
@@ -10920,16 +8174,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/followers)
-"uvM" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/genericbush,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "uwZ" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13{
@@ -10950,25 +8194,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/followers)
-"uxL" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "uxS" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/dirt{
@@ -10989,14 +8214,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/followers)
-"uzT" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
-"uBZ" = (
-/obj/structure/sign/poster/prewar/poster61,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "uEc" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
@@ -11010,9 +8227,6 @@
 	dir = 5
 	},
 /area/f13/building/hospital)
-"uEE" = (
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "uEU" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11068,12 +8282,6 @@
 /obj/item/clothing/under/f13/khan/booty,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"uJt" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
 "uJR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -11095,49 +8303,9 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/city)
-"uMO" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 31
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
 "uNh" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/city)
-"uNk" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
-"uNn" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/leisure)
 "uNA" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -11173,12 +8341,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"uRh" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "uRB" = (
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/outside/dirt,
@@ -11239,20 +8401,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/ncr)
-"vci" = (
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
-"ves" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
 "vfp" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13{
@@ -11332,12 +8480,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/city)
-"vwg" = (
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "vAd" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -11363,31 +8505,9 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"vCK" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -13
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "vCZ" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/legion)
-"vDs" = (
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/leisure)
-"vDH" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "vDY" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -11454,10 +8574,6 @@
 	dir = 9
 	},
 /area/f13/building/hospital)
-"vGo" = (
-/obj/effect/landmark/start/f13/elder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "vIH" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
@@ -11480,14 +8596,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"vLK" = (
-/obj/structure/table/wood,
-/obj/machinery/bookbinder{
-	icon_state = "bigscanner";
-	pixel_y = 7
-	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/offices1st)
 "vMs" = (
 /obj/machinery/light/small,
 /turf/open/transparent/openspace,
@@ -11589,14 +8697,6 @@
 	icon_state = "common-broken3"
 	},
 /area/f13/building)
-"vYa" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "vYm" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -11617,15 +8717,6 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
-"vZd" = (
-/obj/machinery/door/airlock/vault{
-	desc = "A massive gear set into two heavy slabs of brass.";
-	icon = 'icons/obj/doors/airlocks/clockwork/pinion_airlock.dmi';
-	name = "Codex";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "vZT" = (
 /obj/machinery/shower{
 	dir = 8
@@ -11666,27 +8757,6 @@
 /obj/item/radio/tribal,
 /turf/open/floor/f13/wood,
 /area/f13/building/khanfort)
-"wcQ" = (
-/obj/structure/destructible/clockwork/wall_gear{
-	pixel_x = -32
-	},
-/obj/item/projectile/magic/animate{
-	pixel_x = -32
-	},
-/obj/item/candle{
-	pixel_x = 7
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/offices1st)
-"wes" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "wex" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -11694,57 +8764,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
-"wfp" = (
-/obj/structure/table,
-/obj/item/encryptionkey/headset_bos,
-/obj/item/encryptionkey/headset_bos,
-/obj/item/encryptionkey/headset_bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"wfK" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "whs" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 9
 	},
 /area/f13/building/hospital)
-"whK" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/dorms)
-"whT" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
-"wiS" = (
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "wja" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11788,25 +8812,6 @@
 "wqF" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
-"wrx" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/tallgrass2,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/dorms)
 "wrF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11867,12 +8872,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/city)
-"wwZ" = (
-/obj/structure/table/wood/fancy/black,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "wxo" = (
 /obj/structure/railing{
 	dir = 4
@@ -11880,46 +8879,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
-"wzc" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "wzC" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"wzT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 31
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "wAV" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden,
@@ -11942,33 +8907,6 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
-"wDM" = (
-/obj/machinery/vr_sleeper/bos{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
-"wEn" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/dorms)
 "wEu" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -11986,22 +8924,9 @@
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"wEZ" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
 "wGG" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/village)
-"wHz" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Head Paladin's Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "wHU" = (
 /obj/structure/cable,
 /obj/machinery/power/solar,
@@ -12023,33 +8948,10 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"wKk" = (
-/obj/structure/fans/tiny{
-	pixel_y = -33
-	},
-/obj/machinery/light,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "wLE" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wLN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/offices1st)
 "wMt" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenrustychess"
@@ -12079,22 +8981,12 @@
 /obj/effect/landmark/start/f13/venator,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"wOT" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "wPa" = (
 /obj/machinery/vending/cigarette{
 	pixel_y = -10
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"wPf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "wPE" = (
 /obj/machinery/light/small,
 /obj/structure/chair/f13foldupchair{
@@ -12116,12 +9008,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/city)
-"wRO" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "wTd" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -12132,30 +9018,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/city)
-"wTJ" = (
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"wTR" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"wUe" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/table/reinforced,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/knife,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "wUx" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -12175,54 +9037,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"wUG" = (
-/obj/structure/railing{
-	color = null;
-	dir = 9
-	},
-/obj/structure/table,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"wUO" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/tallgrass1,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
-"wVy" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/branch,
-/obj/structure/flora/tallgrass2,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
-	},
-/area/f13/brotherhood/leisure)
-"wWE" = (
-/obj/item/projectile/magic/change,
-/obj/structure/destructible/clockwork/wall_gear,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
 "wWL" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -12282,16 +9096,6 @@
 	name = "concrete wall"
 	},
 /area/f13/ncr)
-"xcW" = (
-/obj/machinery/button/door{
-	id = "bosdorm7";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "xdk" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -12333,10 +9137,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"xhY" = (
-/obj/item/reagent_containers/glass/bucket/wood,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "xiI" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -12351,19 +9151,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
-"xjt" = (
-/obj/structure/simple_door/bunker/glass,
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
-"xjO" = (
-/obj/structure/sign/poster/prewar/poster71,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "xkd" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -12371,14 +9158,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"xkQ" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/machinery/vending/cola/starkist,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/leisure)
 "xmI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12415,11 +9194,6 @@
 /obj/structure/fluff/beach_umbrella/science,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"xrX" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/store,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/leisure)
 "xsd" = (
 /obj/structure/railing{
 	color = null;
@@ -12441,24 +9215,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"xuv" = (
-/obj/structure/fluff/railing{
-	dir = 9
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "xuN" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
-"xve" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices1st)
 "xvZ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -12484,20 +9246,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/hospital)
-"xCy" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 8;
-	name = "prewar lounge chair"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
-"xCW" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "xCY" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -12547,12 +9295,6 @@
 "xJg" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
-"xJo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "xJA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -12580,18 +9322,6 @@
 /obj/machinery/computer/terminal,
 /turf/open/floor/carpet/royalblack,
 /area/f13/city)
-"xLe" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"xLD" = (
-/obj/machinery/light,
-/obj/structure/table/reinforced,
-/obj/item/paper/secretrecipe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "xLZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -12643,16 +9373,6 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
-"xNP" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "xQx" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -12660,15 +9380,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"xRb" = (
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
-"xSG" = (
-/obj/machinery/vr_sleeper/bos{
-	dir = 8
-	},
-/turf/open/floor/circuit/f13_red,
-/area/f13/brotherhood/dorms)
 "xSN" = (
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
@@ -12730,25 +9441,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"xXN" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/dorms)
 "xXQ" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -12774,37 +9466,10 @@
 /obj/item/toy/plush/lampplushie,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
-"ycq" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
-"ydg" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "ydO" = (
 /obj/structure/window/fulltile/house,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"yfH" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "ygg" = (
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/wasteland)
@@ -12846,12 +9511,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"ykU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "ylr" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -38581,13 +35240,13 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -38837,15 +35496,15 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-dcJ
-oIX
-dcJ
-cIz
-dcJ
-oIX
-dcJ
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 tbQ
@@ -39094,15 +35753,15 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-gQZ
-irl
-cIz
-lZP
-cIz
-irl
-gQZ
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 tbQ
@@ -39351,15 +36010,15 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-dfz
-gQZ
-wcQ
-sMW
-wcQ
-gQZ
-ecL
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -39608,15 +36267,15 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-fQU
-rvZ
-rvZ
-rvZ
-rvZ
-rvZ
-fQU
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -39865,15 +36524,15 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-cIz
-rvZ
-eHr
-dwq
-eHr
-rvZ
-cIz
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -40122,15 +36781,15 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-nEV
-rvZ
-cIz
-lut
-cIz
-rvZ
-fOP
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -40379,21 +37038,21 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-oIX
-rvZ
-rvZ
-rvZ
-rvZ
-rvZ
-oIX
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 oez
 oez
@@ -40636,21 +37295,21 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-wWE
-vZd
-wWE
-dcJ
-wWE
-vZd
-wWE
-dcJ
-sTs
-rvM
-rvM
-rvM
-sTs
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 oez
 oez
@@ -40893,21 +37552,21 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-pRS
-rvM
-nfW
-wzc
-nfW
-rvM
-gku
-dcJ
-aCB
-gku
-rvM
-gku
-kgX
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 oez
 oez
@@ -41150,21 +37809,21 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-siJ
-rvM
-rvM
-rvM
-rvM
-rvM
-hNa
-dcJ
-uRh
-uRh
-rvM
-uRh
-uRh
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 oez
 oez
@@ -41407,21 +38066,21 @@ vLb
 vLb
 vLb
 vLb
-szw
-tiw
-rvM
-rvM
-rvM
-rvM
-rvM
-lJT
-szw
-etV
-rvM
-rvM
-rvM
-etV
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 oez
@@ -41664,21 +38323,21 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-gLC
-gLC
-wUG
-phu
-svo
-gLC
-gLC
-dcJ
-sTs
-rvM
-rvM
-rvM
-sTs
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 oez
@@ -41921,21 +38580,21 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-hun
-hun
-xCW
-hun
-oed
-hun
-hun
-dcJ
-aCB
-gku
-rvM
-gku
-kgX
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -42178,21 +38837,21 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-hun
-gKQ
-gKQ
-gKQ
-gKQ
-gKQ
-hun
-dcJ
-uRh
-uRh
-rvM
-uRh
-uRh
-dcJ
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -42435,24 +39094,24 @@ vLb
 vLb
 vLb
 vLb
-szw
-hun
-gKQ
-gKQ
-gKQ
-gKQ
-gKQ
-hun
-szw
-etV
-sjz
-rvM
-sjz
-etV
-dcJ
 vLb
-txY
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 oez
@@ -42692,25 +39351,25 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-tWi
-gKQ
-gKQ
-gKQ
-gKQ
-gKQ
-gec
-dcJ
-dcJ
-wTR
-pmz
-wTR
-dcJ
-dcJ
-txY
-fFp
-fFp
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 oez
@@ -42949,26 +39608,26 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-hun
-gKQ
-gKQ
-gKQ
-gKQ
-gKQ
-hun
-dcJ
-mue
-rvM
-rvM
-rvM
-yfH
-dcJ
-txY
-oTn
-kWA
-txY
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -43206,27 +39865,27 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-hun
-hun
-hun
-hun
-hun
-hun
-hun
-xLe
-rvM
-rvM
-rvM
-rvM
-rvM
-xLe
-kWA
-kWA
-kWA
-kWA
-fFp
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -43463,27 +40122,27 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-hun
-dvH
-jpY
-tUX
-hun
-hun
-hun
-xLe
-rvM
-rvM
-rvM
-rvM
-rvM
-xLe
-kWA
-kWA
-kWA
-ves
-fFp
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -43720,32 +40379,32 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-pmz
-dcJ
-dcJ
-aSY
-rfr
-rfr
-rVr
-dcJ
-izT
-rvM
-tTV
-cFU
-qgv
-dcJ
-txY
-kWA
-kWA
-txY
-txY
-txY
-txY
-txY
-txY
-txY
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -43977,33 +40636,33 @@ vLb
 vLb
 vLb
 vLb
-dcJ
-rvM
-rvM
-dcJ
-cny
-cny
-cny
-cny
-dcJ
-dcJ
-pmz
-txY
-txY
-txY
-txY
-pYl
-kWA
-kWA
-hgR
-txY
-uzT
-dTZ
-uiI
-dTZ
-egE
-txY
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -44226,41 +40885,41 @@ laB
 "}
 (123,1,1) = {"
 laB
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-szw
-tiw
-sTs
-dcJ
-rAK
-cny
-cny
-hue
-dcJ
-tiw
-rvM
-dYl
-oQh
-icG
-rvT
-sxr
-kWA
-kWA
-jnb
-txY
-bPp
-fWx
-bPp
-fWx
-bPp
-kbk
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -44483,41 +41142,41 @@ laB
 "}
 (124,1,1) = {"
 laB
-dcJ
-ydg
-hun
-hun
-pDF
-ojG
-qyB
-wwZ
-dcJ
-bcw
-lUq
-dcJ
-uMO
-nat
-mGG
-wLN
-dcJ
-pgf
-rvM
-txY
-ahp
-efJ
-lxH
-kWA
-kWA
-kWA
-kWA
-fGW
-bPp
-bPp
-oNt
-bPp
-bPp
-wDM
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -44740,41 +41399,41 @@ laB
 "}
 (125,1,1) = {"
 laB
-dcJ
-noz
-sUQ
-pwD
-xve
-pDF
-pDF
-pDF
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-txY
-txY
-txY
-txY
-tuI
-kWA
-kWA
-bxe
-txY
-bPp
-fWx
-bPp
-fWx
-bPp
-kbk
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -44997,41 +41656,41 @@ laB
 "}
 (126,1,1) = {"
 laB
-dcJ
-wPf
-hqC
-faR
-jfi
-pDF
-xve
-nrf
-dEA
-dYq
-bcw
-rvM
-rvM
-spz
-rvM
-lmj
-cxa
-vwg
-lmj
-uBZ
-oQh
-cgW
-rvT
-sxr
-kWA
-kWA
-olZ
-txY
-lat
-xSG
-iqT
-xSG
-nYe
-txY
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -45254,40 +41913,40 @@ laB
 "}
 (127,1,1) = {"
 laB
-dcJ
-wPf
-lsE
-oEf
-xve
-pDF
-xve
-pDF
-pDF
-jIR
-rvM
-rvM
-rvM
-rvM
-rvM
-gRI
-xCy
-hun
-klH
-txY
-ahp
-xcW
-nmN
-kWA
-kWA
-kWA
-ycq
-rvT
-txY
-txY
-txY
-txY
-txY
-txY
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -45511,40 +42170,40 @@ laB
 "}
 (128,1,1) = {"
 laB
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-nfy
-dcJ
-dEN
-dEA
-dYq
-bcw
-qfx
-rvM
-sHR
-rvM
-cCc
-hun
-hun
-jxS
-txY
-txY
-txY
-txY
-rGb
-kWA
-kWA
-wEn
-qJn
-rvE
-eDW
-kvH
-gfo
-usy
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -45768,40 +42427,40 @@ laB
 "}
 (129,1,1) = {"
 laB
-dcJ
-gXj
-tOZ
-goc
-hmp
-sUQ
-dcJ
-dpm
-lit
-dYq
-awI
-jJp
-gLC
-gai
-gLC
-jcD
-nqH
-nqH
-nqH
-fDR
-oQh
-pMT
-rvT
-sxr
-kWA
-kWA
-oZu
-btn
-nYW
-wOT
-wOT
-wOT
-ndW
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -46025,40 +42684,40 @@ laB
 "}
 (130,1,1) = {"
 laB
-dcJ
-rng
-tOZ
-dcJ
-eXH
-pUI
-dcJ
-ccy
-pAP
-dcJ
-sGM
-btg
-rJu
-cYB
-rJu
-amh
-rJu
-amh
-iqf
-txY
-ahp
-jDD
-hFM
-kWA
-kWA
-kWA
-kWA
-oAO
-wOT
-wOT
-axN
-wOT
-usy
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -46282,40 +42941,40 @@ laB
 "}
 (131,1,1) = {"
 laB
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-eGT
-btg
-rJu
-dBt
-rJu
-iqf
-iqf
-iqf
-iqf
-txY
-txY
-txY
-txY
-whK
-kWA
-kWA
-wrx
-qJn
-vYa
-wOT
-cde
-wOT
-tjA
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -46539,40 +43198,40 @@ laB
 "}
 (132,1,1) = {"
 laB
-dcJ
-rvM
-mAf
-rvM
-eba
-rvM
-ntv
-pGS
-iAb
-dcJ
-hbd
-btg
-rJu
-dBt
-rJu
-amh
-rJu
-amh
-iqf
-xjO
-oQh
-icG
-rvT
-sxr
-kWA
-kWA
-oLf
-qJn
-pVc
-wOT
-eiT
-wOT
-xLD
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -46796,40 +43455,40 @@ laB
 "}
 (133,1,1) = {"
 laB
-dcJ
-rvM
-rvM
-rvM
-nDo
-rvM
-dcJ
-rng
-wEZ
-dcJ
-vLK
-rBF
-rJu
-aaj
-rJu
-iqf
-iqf
-iqf
-iqf
-txY
-ahp
-iNt
-eaz
-kWA
-kWA
-kWA
-ycq
-kmZ
-wUe
-wOT
-wOT
-wOT
-iKV
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -47053,40 +43712,40 @@ laB
 "}
 (134,1,1) = {"
 laB
-dcJ
-ekl
-dcJ
-pCz
-ceD
-tLX
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-raf
-dcJ
-raf
-dcJ
-dcJ
-dcJ
-dcJ
-txY
-txY
-txY
-txY
-xXN
-kWA
-kWA
-fKQ
-qJn
-qJn
-rss
-qhk
-qhk
-qJn
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -47310,40 +43969,40 @@ laB
 "}
 (135,1,1) = {"
 laB
-dcJ
-lcT
-rRu
-rvZ
-eBz
-eBz
-rvM
-rgw
-eJY
-dcJ
-rRe
-uxL
-rvM
-spz
-rvM
-mLh
-wiS
-dcJ
-oEC
-oEC
-oEC
-oEC
-lPi
-hbQ
-hbQ
-hbQ
-xkQ
-msY
-mOu
-hqH
-hqH
-hqH
-rOk
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -47567,40 +44226,40 @@ laB
 "}
 (136,1,1) = {"
 laB
-dcJ
-xJo
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-ayH
-dcJ
-uxL
-vGo
-rvM
-rvM
-rvM
-vGo
-mLh
-dcJ
-cRP
-oEC
-oEC
-oEC
-ryC
-hbQ
-hbQ
-hbQ
-nbF
-oYS
-mOu
-hqH
-hqH
-hqH
-scQ
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -47824,40 +44483,40 @@ laB
 "}
 (137,1,1) = {"
 laB
-dcJ
-wfp
-upI
-qlS
-rvM
-rvM
-rvM
-ayH
-dcJ
-dcJ
-rbY
-rvM
-rvM
-rbY
-rvM
-rvM
-rbY
-dcJ
-oEC
-oEC
-oEC
-oEC
-jml
-hbQ
-hbQ
-hbQ
-vDs
-oYS
-mOu
-mGj
-hqH
-hqH
-lVs
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -48081,40 +44740,40 @@ laB
 "}
 (138,1,1) = {"
 laB
-dcJ
-dcJ
-ePZ
-ePZ
-ePZ
-dcJ
-eTz
-dcJ
-dcJ
-dJa
-dtv
-rvM
-rvM
-kMs
-rvM
-rvM
-rTi
-dcJ
-oEC
-oEC
-oEC
-oEC
-aGS
-hbQ
-hbQ
-hbQ
-vDs
-oYS
-mOu
-hqH
-hqH
-hqH
-odt
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -48338,40 +44997,40 @@ laB
 "}
 (139,1,1) = {"
 laB
-dcJ
-hLt
-nfW
-nfW
-nfW
-uNk
-rvM
-rCE
-dcJ
-uxL
-wTJ
-rvM
-rvM
-wTJ
-rvM
-rvM
-wTJ
-dcJ
-cSW
-ykU
-ykU
-qkw
-hbQ
-hbQ
-hbQ
-hbQ
-nbF
-oYS
-mOu
-hqH
-hqH
-tXK
-qJn
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -48595,39 +45254,39 @@ laB
 "}
 (140,1,1) = {"
 laB
-icQ
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-xLe
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-xLe
-hbQ
-hbQ
-hbQ
-hbQ
-hbQ
-hbQ
-hbQ
-hbQ
-qzp
-cWs
-mOu
-hqH
-hqH
-qKZ
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -48852,39 +45511,39 @@ laB
 "}
 (141,1,1) = {"
 laB
-icQ
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-xLe
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-dvH
-dcJ
-vDH
-bHg
-lpf
-hbQ
-hbQ
-hbQ
-lpf
-mhb
-xNP
-kmZ
-qJn
-qJn
-idx
-qJn
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -49109,39 +45768,39 @@ laB
 "}
 (142,1,1) = {"
 laB
-dcJ
-jqM
-uRh
-uRh
-uRh
-bcH
-rvM
-eRN
-dcJ
-wUO
-pZs
-baQ
-rvM
-rvM
-rvM
-pgI
-ofy
-dcJ
-qJn
-nAN
-cMd
-ibC
-ibC
-ibC
-tdB
-oSA
-qJn
-qJn
-qJn
-cvH
-hqH
-qoO
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -49366,39 +46025,39 @@ laB
 "}
 (143,1,1) = {"
 laB
-dcJ
-dcJ
-tUy
-tUy
-tUy
-dcJ
-wHz
-dcJ
-dcJ
-mOp
-qJn
-kmZ
-iMF
-xjt
-liA
-qJn
-qJn
-qJn
-uvM
-jfO
-rKI
-kCf
-kCf
-kCf
-gOS
-ohK
-eHC
-qJn
-qJn
-giY
-hqH
-qoO
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 oez
 oez
@@ -49623,39 +46282,39 @@ laB
 "}
 (144,1,1) = {"
 laB
-dcJ
-thi
-djM
-oCS
-rvM
-rvM
-rvM
-ayH
-dcJ
-dcJ
-qJn
-blF
-vCK
-pvZ
-pvZ
-qcQ
-qJn
-tni
-kCf
-kCf
-kCf
-kCf
-kCf
-kCf
-kCf
-kCf
-kCf
-tni
-qJn
-wfK
-wfK
-qJn
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 oez
 oez
@@ -49880,38 +46539,38 @@ laB
 "}
 (145,1,1) = {"
 laB
-dcJ
-hZs
-rvM
-rvM
-rvM
-rvM
-rvM
-rvM
-ayH
-dcJ
-qJn
-cFm
-pvZ
-pvZ
-pvZ
-dDU
-qJn
-oBO
-kCf
-kCf
-kCf
-qtP
-qtP
-qtP
-kCf
-kCf
-kCf
-nfG
-qJn
-qJn
-qJn
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 oez
 oez
@@ -50137,36 +46796,36 @@ laB
 "}
 (146,1,1) = {"
 laB
-dcJ
-rvM
-bne
-rvZ
-dQO
-dQO
-rvM
-ayV
-eJY
-dcJ
-qJn
-ubN
-pvZ
-pvZ
-pvZ
-bYm
-qJn
-vci
-kCf
-wzT
-qth
-wes
-wes
-wes
-pUs
-wzT
-kCf
-vci
-qJn
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 oez
@@ -50394,35 +47053,35 @@ laB
 "}
 (147,1,1) = {"
 laB
-dcJ
-ekl
-dcJ
-pCz
-tLX
-pAO
-dcJ
-dcJ
-dcJ
-dcJ
-qJn
-tdd
-pvZ
-pvZ
-pvZ
-qBr
-qJn
-qJn
-hva
-uNn
-twz
-twz
-twz
-twz
-twz
-uNn
-kmZ
-qJn
-qJn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 vLb
 vLb
 oez
@@ -50651,34 +47310,34 @@ laB
 "}
 (148,1,1) = {"
 laB
-dcJ
-rvM
-rvM
-rvM
-qFz
-rvM
-dcJ
-rng
-dBJ
-dcJ
-qJn
-sox
-pvZ
-pvZ
-pvZ
-sox
-xrX
-aeX
-wvQ
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-tot
-gPv
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+vLb
+vLb
 vLb
 vLb
 vLb
@@ -50908,33 +47567,33 @@ laB
 "}
 (149,1,1) = {"
 laB
-dcJ
-rvM
-skE
-rvM
-baQ
-rvM
-ntv
-whT
-tap
-dcJ
-qJn
-sox
-pvZ
-pvZ
-pvZ
-sox
-xrX
-wvQ
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-gPv
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+vLb
 vLb
 vLb
 vLb
@@ -51165,32 +47824,32 @@ laB
 "}
 (150,1,1) = {"
 laB
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-dcJ
-qJn
-sox
-pvZ
-pvZ
-pvZ
-sox
-xrX
-rwf
-uKh
-uKh
-xuv
-nRx
-nRx
-nRx
-nRx
-nRx
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
 vLb
 vLb
 vLb
@@ -51424,25 +48083,25 @@ laB
 laB
 vLb
 vLb
-uNn
-xRb
-eWH
-pJx
-uJt
-tDP
-pJx
-uNn
-qJn
-sox
-pvZ
-pvZ
-pvZ
-sox
-xrX
-uKh
-uKh
-xuv
-hzU
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+oez
+oez
+oez
+oez
 oez
 oez
 oez
@@ -51681,24 +48340,24 @@ laB
 laB
 vLb
 vLb
-uNn
-tDP
-ncO
-aCK
-oac
-ncO
-ncO
-uNn
-uNn
-cwT
-sox
-sox
-sox
-wVy
-uNn
-uKh
-uKh
-jxl
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+oez
+oez
+oez
 oez
 oez
 oez
@@ -51938,24 +48597,24 @@ laB
 laB
 vLb
 vLb
-uNn
-pJx
-ncO
-ncO
-gSi
-ncO
-lHa
-uNn
-uNn
-uNn
-smK
-smK
-smK
-uNn
-uNn
-uKh
-uKh
-jxl
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+oez
+oez
+oez
 oez
 oez
 oez
@@ -52195,24 +48854,24 @@ laB
 laB
 vLb
 vLb
-uNn
-bBd
-ncO
-jHu
-ncO
-gSi
-ncO
-npu
-kgE
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-jxl
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
 oez
 oez
 oez
@@ -52452,24 +49111,24 @@ laB
 laB
 vLb
 vLb
-uNn
-mhP
-gSi
-ncO
-fiP
-ncO
-wKk
-uNn
-iAA
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-uKh
-xuv
-hzU
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
 mbu
 mbu
 mbu
@@ -52709,23 +49368,23 @@ laB
 laB
 vLb
 vLb
-uNn
-hFw
-mgK
-xhY
-ncO
-izg
-ncO
-uNn
-uNn
-nRx
-nRx
-nRx
-nRx
-nRx
-nRx
-nRx
-hzU
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
 oez
 mbu
 mbu
@@ -52966,14 +49625,14 @@ laB
 laB
 vLb
 vLb
-uNn
-cuy
-nZK
-wRO
-gSi
-jHu
-ncO
-uNn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 mbu
 uyt
 mbu
@@ -53223,14 +49882,14 @@ laB
 laB
 vLb
 vLb
-gPv
-uEE
-rGO
-ezJ
-ncO
-dxB
-qRR
-uNn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 mbu
 mbu
 uyt
@@ -53481,13 +50140,13 @@ laB
 vLb
 vLb
 vLb
-gPv
-gPv
-uNn
-uNn
-uNn
-uNn
-uNn
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
+vLb
 mbu
 mbu
 mbu

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -157,9 +157,9 @@
 /area/f13/building)
 "aaK" = (
 /obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/seeds/cannabis,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aaL" = (
@@ -284,11 +284,6 @@
 /obj/effect/overlay/rockfloor_side,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
-"abh" = (
-/obj/effect/decal/remains/human,
-/obj/effect/spawner/bundle/f13/armor/combat,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "abj" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -318,10 +313,6 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "abp" = (
-/obj/machinery/camera{
-	dir = 4;
-	network = list("BoS")
-	},
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -447,26 +438,28 @@
 /obj/item/reagent_containers/food/drinks/bottle/blazaam,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/khanfort)
-"abU" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/light/tribal,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "abV" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "abW" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"abX" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
+"abX" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "abY" = (
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
@@ -558,13 +551,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "acs" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	pixel_y = 3;
-	termtag = "Security"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "acu" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -583,10 +576,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/ncr)
-"acC" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "acD" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -616,9 +605,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "acJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/spider/stickyweb,
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "acK" = (
 /obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -742,9 +738,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "adk" = (
-/obj/structure/car/rubbish4,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/radio/off,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "adl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -802,12 +803,15 @@
 	},
 /area/f13/building/massfusion)
 "adz" = (
-/obj/structure/table,
-/obj/item/kirbyplants{
-	pixel_y = 10
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "adA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/timeddoor,
@@ -850,9 +854,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/khanfort)
 "adO" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "adP" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced,
@@ -957,9 +964,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/khans)
 "aek" = (
-/obj/structure/junk/locker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "indmine"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aem" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/cigarette,
@@ -1016,9 +1026,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "aex" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "aez" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_south"
@@ -1049,8 +1063,13 @@
 	},
 /area/f13/building)
 "aeF" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
+/obj/structure/simple_door/bunker,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "aeG" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 4
@@ -1131,17 +1150,22 @@
 	},
 /area/f13/building/massfusion)
 "afb" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/beer,
-/obj/item/reagent_containers/food/drinks/beer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"afc" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/item/stock_parts/cell,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"afc" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "afd" = (
 /obj/structure/flora/stump,
 /obj/effect/decal/cleanable/dirt,
@@ -1254,20 +1278,20 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "afu" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor2"
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "afv" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "afy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2top"
@@ -1330,16 +1354,20 @@
 	},
 /area/f13/building/hospital)
 "afJ" = (
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"afK" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
+"afK" = (
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "afL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -1481,36 +1509,22 @@
 	},
 /area/f13/building/massfusion)
 "agr" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "ags" = (
-/obj/machinery/workbench,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/obj/item/circuitboard/machine/colormate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "agt" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/item/pen{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/obj/item/paper_bin{
-	pixel_x = -6
-	},
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "agv" = (
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/rust,
@@ -2041,15 +2055,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"aiL" = (
-/obj/machinery/button/door{
-	id = "bosgarage";
-	pixel_y = 30
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "aiM" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/barber{
@@ -2236,20 +2241,13 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "ajr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/auto,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "twindowold"
-	},
-/obj/machinery/computer/shuttle/bosentryelevator{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "ajs" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker,
@@ -2323,10 +2321,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
 "ajF" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "ajG" = (
 /obj/item/ammo_casing/caseless{
 	dir = 10;
@@ -6182,10 +6182,13 @@
 	},
 /area/f13/wasteland)
 "ayk" = (
-/obj/structure/barricade/bars,
 /obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/item/storage/belt/medical,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "ayl" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
@@ -6302,11 +6305,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ayG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "ayH" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -7181,12 +7186,6 @@
 /area/f13/village)
 "aBC" = (
 /obj/structure/table/wood,
-/obj/structure/junk/small/tv{
-	desc = "Advertisements would've played on this tv before the bombs dropped.";
-	icon = 'icons/fallout/objects/decorations.dmi';
-	icon_state = "television";
-	name = "pre-war advertising television"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -14653,13 +14652,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bcG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/reinforced{
-	icon_state = "twindowold"
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "bcI" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/tree/jungle{
@@ -16108,9 +16109,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "biK" = (
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "biL" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -18802,9 +18807,9 @@
 	},
 /area/f13/city)
 "bHu" = (
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/flora/wasteplant/wild_agave,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "bHJ" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/decal/cleanable/dirt,
@@ -18816,20 +18821,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building/mall)
 "bIS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/effect/turf_decal/stripes/white/box,
-/obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "twindowold"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "BoSLadder"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "bIW" = (
 /obj/structure/fence{
 	dir = 4
@@ -18867,9 +18865,15 @@
 	},
 /area/f13/building)
 "bJx" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "bJy" = (
 /obj/machinery/light{
 	dir = 4
@@ -19870,21 +19874,14 @@
 	},
 /area/f13/building/mall)
 "cgV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/table,
+/obj/item/kitchen/fork,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
-/obj/effect/turf_decal/stripes/white/box,
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "bos_upper"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "cgY" = (
 /obj/machinery/button/door{
 	pixel_x = -26;
@@ -21630,12 +21627,12 @@
 	},
 /area/f13/wasteland)
 "cxd" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "cxj" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -21788,11 +21785,14 @@
 	},
 /area/f13/building)
 "cAi" = (
-/obj/structure/statue/bos/ladyright{
-	pixel_y = -16
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "cAn" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -23638,9 +23638,16 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/village)
 "dvo" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/flashlight{
+	icon_state = "seclite"
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "dvs" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -23765,12 +23772,15 @@
 	},
 /area/f13/wasteland)
 "dxP" = (
-/obj/structure/reagent_dispensers/barrel/three{
-	pixel_x = -4;
-	pixel_y = -2
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	output_dir = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "dxY" = (
 /obj/item/reagent_containers/pill/patch/turbo,
 /obj/item/storage/trash_stack,
@@ -24230,17 +24240,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"dJw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/camera{
-	dir = 4;
-	network = list("BoS")
-	},
-/obj/structure/chair/f13foldupchair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "dJE" = (
 /obj/structure/debris/v1{
 	pixel_x = -16
@@ -25569,9 +25568,13 @@
 /turf/open/transparent/openspace,
 /area/f13/caves)
 "etR" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/closet/crate/bin,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "euv" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/chem_tin/radx,
@@ -25675,9 +25678,13 @@
 	},
 /area/f13/city)
 "evK" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/rack,
+/obj/item/pickaxe,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "evU" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -26152,12 +26159,6 @@
 	color = "000000"
 	},
 /obj/structure/table,
-/obj/structure/junk/small/tv{
-	desc = "Advertisements would've played on this tv before the bombs dropped.";
-	icon = 'icons/fallout/objects/decorations.dmi';
-	icon_state = "television";
-	name = "pre-war advertising television"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
 "eIb" = (
@@ -27228,13 +27229,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fdW" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosgarage"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "fdY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -27458,11 +27452,15 @@
 	},
 /area/f13/village)
 "fjo" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "fjq" = (
 /obj/item/electropack/shockcollar,
 /obj/item/electropack/shockcollar,
@@ -27579,11 +27577,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
 "fmK" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/structure/table,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "fmU" = (
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28576,14 +28575,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fJJ" = (
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = 28
+/obj/machinery/mineral/processing_unit{
+	input_dir = 8;
+	output_dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "fJO" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
@@ -29905,11 +29905,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/city)
-"guT" = (
-/obj/structure/rack,
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "guU" = (
 /obj/structure/curtain,
 /obj/structure/decoration/vent/rusty{
@@ -29994,14 +29989,6 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gvN" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "gvO" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -30766,8 +30753,7 @@
 /area/f13/caves)
 "gLF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder";
-	tag = 
+	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
 "gLN" = (
@@ -31014,8 +31000,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "gQy" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood)
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/clothing/head/hardhat,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "gQA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -31199,13 +31191,12 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "gWg" = (
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = -28
+/obj/machinery/mineral/unloading_machine,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "gWi" = (
 /obj/effect/decal/cleanable/oil/slippery{
 	pixel_x = -10
@@ -32430,13 +32421,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/khans)
 "hBx" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/chair/stool,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "hBy" = (
 /obj/structure/rack,
 /obj/item/stack/ore/blackpowder/twenty,
@@ -32688,11 +32679,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/khans)
-"hJI" = (
-/obj/item/kirbyplants,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "hJP" = (
 /obj/structure/table/optable,
 /obj/machinery/light{
@@ -33070,15 +33056,12 @@
 	},
 /area/f13/wasteland)
 "hSy" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "hSD" = (
 /obj/structure/table,
 /obj/item/stock_parts/matter_bin/super,
@@ -33352,17 +33335,15 @@
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "hZy" = (
-/obj/structure/statue/bos/ladyleft{
-	pixel_y = -16
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"hZD" = (
-/obj/structure/chair{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "hZK" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -33512,13 +33493,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/city)
-"icY" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "idk" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -33798,12 +33772,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
 /area/f13/legion)
-"ikC" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "ikI" = (
 /obj/structure/flora/tallgrass6,
 /obj/structure/flora/wasteplant/wild_broc,
@@ -33847,12 +33815,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"ilS" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "imm" = (
 /obj/machinery/computer/terminal{
 	pixel_y = 5
@@ -34077,17 +34039,13 @@
 	},
 /area/f13/wasteland)
 "iqB" = (
-/obj/docking_port/stationary{
-	area_type = /area/f13;
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_1";
-	name = "Level 1: Operations";
-	width = 4
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood)
+/area/f13/building)
 "iqD" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -34119,12 +34077,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"irT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "irW" = (
 /obj/machinery/light{
 	dir = 4
@@ -35764,13 +35716,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
 "iYZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosgarage"
+/obj/structure/spider/stickyweb,
+/obj/structure/table,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "iZb" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet,
@@ -36570,14 +36522,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
-"jsp" = (
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = 28
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "jst" = (
 /mob/living/simple_animal/hostile/cazador/young,
 /obj/structure/flora/ausbushes/grassybush,
@@ -36645,9 +36589,13 @@
 /area/f13/wasteland)
 "juz" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/weapon_parts,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "juB" = (
 /obj/effect/turf_decal/arrows{
 	pixel_y = 7
@@ -37627,12 +37575,14 @@
 	},
 /area/f13/wasteland)
 "jUQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/window/reinforced{
-	icon_state = "twindowold"
+/obj/machinery/conveyor/auto{
+	dir = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "jUU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38454,8 +38404,15 @@
 	},
 /area/f13/city)
 "krf" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "krg" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -38741,9 +38698,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/khans)
 "kym" = (
-/obj/machinery/vending/cola/starkist,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/rack,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "kyu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/unpowered/securedoor/legion,
@@ -38824,12 +38786,6 @@
 /obj/structure/flora/grass/coyote/one,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/caves)
-"kAQ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "kBd" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -39479,12 +39435,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kPd" = (
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "kPi" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -39506,11 +39461,6 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
-"kPN" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "kQF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -40232,8 +40182,14 @@
 	},
 /area/f13/building/museum)
 "lhb" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "lhf" = (
 /obj/structure/flora/twig2,
 /obj/structure/flora/twig3,
@@ -40881,13 +40837,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "lyN" = (
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = 23
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/closed/wall/f13/tunnel,
+/area/f13/building)
 "lyR" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -41271,12 +41222,14 @@
 	},
 /area/f13/wasteland)
 "lGu" = (
-/obj/machinery/camera{
-	dir = 4;
-	network = list("BoS")
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/storage/backpack/satchel/leather,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "lGG" = (
 /obj/structure/tires/two,
 /obj/effect/decal/cleanable/dirt,
@@ -42458,9 +42411,13 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "meG" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/effect/decal/remains/human,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "meL" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
@@ -42821,9 +42778,15 @@
 	},
 /area/f13/wasteland)
 "mmP" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "mmU" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -44904,21 +44867,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/khanfort)
 "niq" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"niv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "niB" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -45456,13 +45407,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nwe" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "nwn" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -45625,12 +45569,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ncr)
 "nzE" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/building)
 "nzP" = (
 /obj/structure/flora/burnedtree1,
 /turf/open/indestructible/ground/outside/desert,
@@ -46202,10 +46148,14 @@
 	},
 /area/f13/wasteland)
 "nPz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "nQb" = (
 /obj/structure/simple_door/metal/fence/wooden,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -46991,11 +46941,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"ojt" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder"
-	},
 /area/f13/wasteland)
 "ojE" = (
 /obj/effect/decal/waste{
@@ -48212,12 +48157,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"oNl" = (
-/obj/structure/barricade/bars,
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "oNm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48254,16 +48193,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oNQ" = (
-/obj/structure/table/wood,
-/obj/structure/junk/small/tv{
-	desc = "Advertisements would've played on this tv before the bombs dropped.";
-	icon = 'icons/fallout/objects/decorations.dmi';
-	icon_state = "television";
-	name = "pre-war advertising television"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building/mall)
 "oNY" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13,
@@ -50847,11 +50776,14 @@
 	},
 /area/f13/building/massfusion)
 "pXC" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/weapon_parts,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "pXX" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -51201,9 +51133,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qhg" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -51644,11 +51573,12 @@
 	},
 /area/f13/building)
 "qsP" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "qsS" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -51733,10 +51663,14 @@
 	},
 /area/f13/building)
 "quL" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/vomit,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "quQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -53025,9 +52959,14 @@
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
 "raI" = (
-/obj/structure/ore_box,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/table,
+/obj/item/kitchen/fork,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "rbg" = (
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
@@ -54033,10 +53972,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
-"rDP" = (
-/obj/structure/weightmachine/stacklifter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "rEa" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -54595,15 +54530,12 @@
 /turf/open/floor/wood_common,
 /area/f13/village)
 "rRH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "twindowold"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "rSd" = (
 /mob/living/simple_animal/hostile/gecko,
 /obj/effect/decal/cleanable/dirt,
@@ -55479,11 +55411,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "smW" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor2"
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "smX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -55698,12 +55632,6 @@
 /obj/structure/junk/small/tv,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
-"sqZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "srb" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -55716,12 +55644,6 @@
 /obj/machinery/smartfridge/chemistry,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"srd" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "srN" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain3"
@@ -57438,9 +57360,11 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
 "tnl" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/machinery/mineral/processing_unit_console{
+	machinedir = 1
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "tny" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -58196,15 +58120,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
-"tCS" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = -33
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "tCT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -59691,9 +59606,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ulT" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "ulY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -61375,11 +61294,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "van" = (
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/table,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "vao" = (
 /obj/structure/dresser,
 /turf/open/floor/wood_common,
@@ -61879,11 +61801,13 @@
 	},
 /area/f13/wasteland)
 "vnE" = (
-/obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "vnN" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -61992,15 +61916,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "vpZ" = (
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = -33
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 5
 	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "vqb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/railing,
@@ -62067,12 +61987,6 @@
 /area/f13/wasteland)
 "vrq" = (
 /obj/structure/table/wood,
-/obj/structure/junk/small/tv{
-	desc = "Advertisements would've played on this tv before the bombs dropped.";
-	icon = 'icons/fallout/objects/decorations.dmi';
-	icon_state = "television";
-	name = "pre-war advertising television"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
 "vrG" = (
@@ -62616,11 +62530,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"vHf" = (
-/obj/structure/table,
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "vHB" = (
 /turf/open/floor/wood_wide{
 	icon_state = "wide-broken1"
@@ -63701,11 +63610,15 @@
 	},
 /area/f13/building)
 "whS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/storage/bag/ore,
+/obj/item/flashlight,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "whT" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -63992,10 +63905,6 @@
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/legion)
-"wpd" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "wph" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/fridge,
@@ -64798,14 +64707,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/building/museum)
-"wJM" = (
-/obj/machinery/button/door{
-	id = "bosgarage";
-	pixel_y = 30;
-	req_access_txt = "120"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "wKb" = (
 /obj/structure/shuttle/engine/router,
 /obj/structure/lattice/catwalk,
@@ -64995,15 +64896,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wOt" = (
-/obj/structure/toilet{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/effect/decal/cleanable/vomit,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/building)
 "wOA" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -67374,12 +67273,6 @@
 	},
 /area/f13/building)
 "xTd" = (
-/obj/structure/junk/small/tv{
-	desc = "Advertisements would've played on this tv before the bombs dropped.";
-	icon = 'icons/fallout/objects/decorations.dmi';
-	icon_state = "television";
-	name = "pre-war advertising television"
-	},
 /obj/item/toy/cards/deck{
 	pixel_x = 5;
 	pixel_y = 20
@@ -72799,7 +72692,7 @@ kTq
 eEW
 eEW
 eBv
-ojt
+gLF
 mHp
 nvn
 wDX
@@ -74855,7 +74748,7 @@ aXy
 skm
 hoM
 eEW
-ojt
+gLF
 mHp
 mGE
 ayn
@@ -76098,7 +75991,7 @@ bMM
 bMM
 ftl
 skm
-ojt
+gLF
 mHp
 uNJ
 evq
@@ -84364,7 +84257,7 @@ nIQ
 mGZ
 kax
 kax
-ojt
+gLF
 mHp
 aer
 ayn
@@ -87056,7 +86949,7 @@ skm
 hoM
 eEW
 eEW
-ojt
+gLF
 mHp
 sXv
 igF
@@ -91817,7 +91710,7 @@ iIp
 bqR
 skm
 skm
-ojt
+gLF
 mHp
 aye
 ovw
@@ -97668,25 +97561,25 @@ aaB
 aaB
 aae
 aae
-aae
-abV
-aae
-aae
-aak
-aak
-aae
-aae
-aaB
-aaB
-aaB
+aaa
 aaB
 aae
-aak
-aak
-aak
 aae
 aae
 aae
+aae
+aaa
+aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+aak
+aak
+aak
 aae
 xYE
 ean
@@ -97922,28 +97815,28 @@ aae
 aae
 aae
 aaB
-aae
-aae
-aae
-aae
-abV
+aaa
+aaa
+aaa
+aaa
+aaB
 aaA
 aae
 aae
 aae
 aae
-aaB
-aak
 aae
-aaB
-aaY
-aaB
+aaa
 aae
-vGl
+aae
+aae
+aae
 aae
 aae
 aak
-aae
+aak
+aak
+aak
 aae
 vGl
 xYE
@@ -98036,7 +97929,7 @@ azn
 aaQ
 aaQ
 kTq
-ojt
+gLF
 tAk
 cBn
 tir
@@ -98179,8 +98072,8 @@ aae
 aae
 aae
 aaB
-aae
-aae
+aaa
+aaa
 aaA
 aaB
 aaB
@@ -98188,17 +98081,17 @@ aaB
 aae
 aae
 aae
-aaB
-aaB
 aae
 aae
-aaB
-aae
-aaB
-aaB
-aaB
+aaa
 aae
 aae
+aae
+aae
+aae
+aae
+aak
+aak
 aae
 aae
 aae
@@ -98242,7 +98135,7 @@ paJ
 skm
 skm
 eEW
-ojt
+gLF
 pCf
 pBa
 igF
@@ -98292,7 +98185,7 @@ aRb
 bqR
 fvU
 skm
-ojt
+gLF
 tAk
 apJ
 pdm
@@ -98313,7 +98206,7 @@ skm
 nIQ
 bqR
 bqR
-ojt
+gLF
 mHp
 sXv
 sXv
@@ -98436,13 +98329,18 @@ aae
 aae
 aaB
 aaB
+aaa
+aaa
+aaB
+aaB
+rNB
+aaB
+aaC
 aae
 aae
-aaB
-aaB
-abh
-aaB
-abU
+aae
+aae
+aaa
 aae
 aae
 aae
@@ -98450,12 +98348,7 @@ aae
 aae
 aae
 aak
-aae
-aaB
-aaB
-aaB
 aak
-aae
 aae
 aae
 aak
@@ -98693,26 +98586,26 @@ aae
 aaB
 aaB
 aae
-aae
+aaa
 aaA
 aaB
 aaB
-aaB
-aaB
-aaB
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aae
-aae
-aae
 aaY
 aaB
-vGl
+aaB
+aaA
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+aak
 aae
 aae
 aak
@@ -98950,19 +98843,17 @@ aae
 aaB
 aae
 aae
-aae
+aaa
 aaB
 aaK
-bjo
-bjo
+aaB
+aaB
+aaB
+aaB
+aaB
 aae
 aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aae
 aaa
 aaa
 aaa
@@ -98970,6 +98861,8 @@ aaa
 aae
 aae
 aae
+aak
+aak
 aae
 aae
 aae
@@ -99207,28 +99100,28 @@ aae
 aaB
 aae
 aae
-aae
+aaa
 aaB
-bjo
+aaB
+aaB
+aek
+aaB
+aaB
+acr
+aaB
+aae
+aae
+aae
 aae
 aae
 aaa
-aaa
-lhb
-lhb
-lhb
-lhb
 aae
-aae
-lhb
-lhb
-lhb
-lhb
 aaa
-aaa
-aae
 aae
 aak
+aak
+aae
+aae
 aak
 aae
 aae
@@ -99464,27 +99357,27 @@ aae
 asA
 aae
 aae
-aae
+aaa
 aaC
-bjo
+aaB
+aaY
+aaB
+aaB
+abV
+abV
+abV
+aaA
+aae
+aae
+aae
 aae
 aaa
-lhb
-lhb
-aeF
-aeF
-aeF
-aeF
-lhb
-lhb
-aeF
-aeF
-aeF
-aeF
-lhb
-lhb
+aae
 aaa
 aae
+aak
+aak
+aak
 aae
 aae
 aae
@@ -99721,27 +99614,27 @@ aae
 aae
 aae
 aak
-aae
-raI
+aaa
 aaB
+aaB
+aaB
+aaB
+aaB
+abV
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
 aaa
-lhb
-aeF
-aeF
-aeF
-adz
-acJ
-adO
-aeF
-aeF
-adO
-acJ
-acJ
-aeF
-aeF
-aeF
-lhb
+aae
 aaa
+aae
+aak
+aak
+aak
 aae
 aae
 aae
@@ -99978,27 +99871,27 @@ aae
 aae
 aae
 aak
-aae
-aaA
+aaa
 akS
+aaB
+aaB
+aaB
+aaB
+aaA
+aaB
+aaB
+abV
+abV
+abV
+aaA
+aae
 aaa
-lhb
-aeF
-rDP
-krf
-krf
-krf
-kPd
-dJw
-abX
-srd
-krf
-krf
-acJ
-hZD
-aeF
-lhb
-aaa
+aae
+aae
+aae
+aak
+aak
+aak
 aae
 aae
 aak
@@ -100235,28 +100128,28 @@ aae
 aak
 aak
 aae
-aae
 aaa
 aaA
-lhb
-lhb
-aeF
-krf
-krf
-krf
-krf
-krf
-krf
-krf
-krf
-krf
-krf
-krf
-aek
-aeF
-lhb
-lhb
+aaB
+aaB
+rNB
+aaB
+aae
+aae
+aae
+aaA
+aaB
+aaB
+aaA
+aae
 aaa
+aae
+aae
+aae
+aak
+aak
+aak
+aae
 aae
 aaB
 aae
@@ -100495,25 +100388,25 @@ aaa
 aaa
 aae
 aae
-lhb
-lhb
-aeF
-bJx
-acJ
-acJ
-krf
-krf
-krf
-krf
-krf
-krf
-krf
-krf
-krf
-aeF
-lhb
-lhb
+aae
+aaA
+aae
+aae
+aae
+aae
+aaA
+niq
+aaB
+aaA
+aae
 aaa
+aaa
+aaa
+aaa
+aak
+aak
+aak
+aae
 aak
 aaB
 acr
@@ -100749,28 +100642,28 @@ aak
 aae
 aak
 aak
-aae
-aae
-aae
-lhb
-lhb
-aeF
-aeF
-hSy
-krf
-dvo
-bIS
-irT
-irT
-ajr
-fmK
-krf
-niq
-adO
-aeF
-lhb
-lhb
 aaa
+aaa
+aaa
+aaa
+aaa
+aae
+aae
+ags
+ags
+ags
+bIS
+qsP
+ags
+ags
+ags
+aae
+aae
+aaa
+aak
+aak
+aak
+aae
 aae
 aaB
 aaB
@@ -101008,26 +100901,26 @@ aae
 aae
 aae
 aae
+aaa
+aaa
+aaa
 aae
 aae
-lhb
-aeF
-acC
-acJ
-krf
-jUQ
-gQy
-gQy
-gQy
-gQy
-cgV
-krf
-krf
-dxP
-aeF
-lhb
+ags
+bJx
+kPd
+kPd
+adO
+kPd
+agt
+ags
+aae
 aae
 aaa
+aaa
+aaa
+aak
+aak
 aae
 aae
 aaB
@@ -101265,26 +101158,26 @@ aae
 aae
 aae
 aae
-aae
-aae
-lhb
-aeF
-wpd
-krf
-krf
-evK
-gQy
-gQy
-gQy
-gQy
-ayG
-krf
-acJ
-krf
-aeF
-lhb
-aae
 aaa
+ags
+ags
+ags
+ags
+ags
+kPd
+evK
+kPd
+adO
+nzE
+adO
+ags
+ags
+ags
+ags
+ags
+aaa
+aae
+aae
 aak
 aae
 aae
@@ -101522,26 +101415,26 @@ aae
 aae
 aae
 aae
-aae
-aae
-lhb
-aeF
-abW
-acJ
-krf
-evK
-iqB
-gQy
-gQy
-gQy
-ayG
-krf
-krf
-bHu
-aeF
-lhb
-aae
 aaa
+ags
+abX
+kPd
+abW
+ags
+adO
+adk
+iqB
+afJ
+gQy
+adO
+ags
+quL
+kPd
+rRH
+ags
+aaa
+aae
+aae
 aae
 aae
 aae
@@ -101779,26 +101672,26 @@ aae
 aak
 aae
 aae
-aae
-aae
-lhb
-aeF
+aaa
+ags
+van
+adO
 adO
 qsP
-acJ
-bcG
-gQy
-gQy
-gQy
-gQy
-niv
-krf
-aex
+afu
+kPd
 adO
-aeF
-lhb
-aae
+kPd
+adO
+kPd
+qsP
+kPd
+kPd
+dvo
+ags
 aaa
+aae
+aae
 aak
 aae
 aae
@@ -102034,27 +101927,27 @@ aae
 aae
 aak
 aak
-aae
-aae
-aae
-aae
+aaa
+aaa
+aaa
+ags
+ayk
+adz
+afc
+ags
 lhb
-aeF
-ikC
-krf
-krf
-kAQ
+gQy
 rRH
+kPd
 whS
-whS
-rRH
-sqZ
-krf
-krf
+agt
+ags
+juz
+bcG
 biK
-aeF
-lhb
-aae
+ags
+aaa
+aaa
 aaa
 aae
 aae
@@ -102291,27 +102184,27 @@ aae
 aak
 aae
 aae
-aae
-aae
-aae
-aae
-lhb
-aeF
-ajF
-krf
-krf
-acJ
-acJ
-acJ
-acJ
-krf
-acJ
-krf
-krf
-etR
-aeF
-lhb
-fYQ
+aaa
+ags
+ags
+ags
+ags
+ags
+ags
+ags
+ags
+ags
+agr
+agr
+ags
+ags
+ags
+ags
+ags
+ags
+ags
+ags
+ags
 aaa
 aae
 aae
@@ -102548,27 +102441,27 @@ aak
 aae
 aae
 aae
-aae
-aae
-aae
-lhb
-lhb
-aeF
-aeF
-nwe
+aaa
+ags
+kPd
+adO
+ayG
+hSy
+ags
+adO
 krf
-krf
-afv
-acJ
-krf
-aex
-aeF
-krf
-krf
-aeF
-aeF
-lhb
-lhb
+kPd
+kPd
+adO
+adO
+hZy
+adO
+ags
+etR
+adO
+cxd
+cxd
+ags
 aaa
 aae
 aaB
@@ -102805,27 +102698,27 @@ aae
 aae
 aae
 aae
-aae
-aak
-aae
+aaa
+ags
+gWg
+ags
 lhb
-lhb
-lhb
-aeF
+kPd
+ags
+adO
 adO
 meG
-meG
+kPd
 adO
-meG
-meG
 adO
-aeF
+adO
+fmK
+ags
 afc
-afc
-aeF
-aeF
-lhb
-lhb
+adO
+cgV
+raI
+ags
 aaa
 aaB
 ahC
@@ -103062,27 +102955,27 @@ aae
 aae
 aae
 aae
-aak
-aae
-aae
-lhb
-lhb
-aeF
-aeF
-acJ
-krf
-krf
+aaa
+ags
+pXC
+afv
+adO
+adO
+agr
+afJ
+ajF
 kPd
-krf
-krf
+kPd
+kPd
+afJ
 lGu
-aeF
-krf
-krf
-aeF
-aeF
-lhb
-lhb
+vnE
+agr
+kPd
+afJ
+cxd
+hBx
+ags
 aaa
 gca
 aaB
@@ -103319,27 +103212,27 @@ aae
 aae
 aak
 aae
-aae
-aae
-aae
-aae
-lhb
-aeF
+aaa
+ags
+fJJ
+tnl
+kPd
+adO
 agr
-krf
+kPd
 vnE
-krf
-kPN
-krf
-juz
+kPd
+adO
+afu
+adO
 aex
-aeF
-acJ
+adO
+agr
 afu
 afJ
-aeF
-lhb
-aae
+adO
+adO
+ags
 aaa
 aae
 ahD
@@ -103576,28 +103469,28 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-lhb
-aeF
+aaa
+ags
+pXC
+afv
+vpZ
+mmP
 ags
 acJ
-pXC
-krf
-kPN
-krf
-ilS
-krf
-afc
-acJ
-krf
-adk
-aeF
-lhb
-aae
-aae
+adO
+adO
+kPd
+kPd
+adO
+abW
+iYZ
+ags
+adO
+meG
+adO
+smW
+ags
+aaa
 aak
 aae
 aae
@@ -103833,27 +103726,27 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-lhb
-aeF
-afb
-acJ
-krf
-krf
-afv
-krf
-krf
-acJ
-aeF
-krf
-krf
-krf
-aeF
-lhb
-aae
+aaa
+ags
+jUQ
+dxP
+ajr
+afJ
+ags
+adO
+iqB
+cAi
+adO
+adO
+bcG
+adO
+kPd
+ags
+afJ
+nPz
+fjo
+wOt
+ags
 aaa
 aak
 aae
@@ -104090,27 +103983,27 @@ aae
 aae
 aae
 aae
-aae
-aak
-aae
-aae
-lhb
+aaa
+ags
+ags
+ags
+ags
+qsP
+ags
+ags
+lyN
+lyN
 aeF
 aeF
-vHf
-vHf
-aeF
-aeF
-afc
-aeF
-aeF
-aeF
-krf
-krf
-vpZ
-aeF
-lhb
-aae
+lyN
+lyN
+ags
+ags
+qsP
+ags
+ags
+ags
+ags
 aaa
 aae
 aae
@@ -104347,28 +104240,28 @@ aae
 aae
 aae
 aae
-aak
-aae
-aae
-lhb
-lhb
-aeF
+aaa
+aaa
+aaa
+ags
 acs
-fjo
-acJ
-oNl
-srd
-krf
-tnl
-aeF
-adk
-krf
-acJ
+adO
+acs
+ags
+lyN
+aOk
+aOk
+aOk
+aOk
+lyN
+ags
+afc
+adO
 ulT
-aeF
-lhb
-lhb
-aae
+ags
+aaa
+aaa
+aaa
 aaa
 aae
 aae
@@ -104606,26 +104499,26 @@ aak
 aak
 aae
 aae
-aae
-lhb
-lhb
-lhb
-agt
-acJ
-nPz
-ayk
-acJ
-krf
-hJI
-lhb
-krf
-cxd
-krf
+aaa
+ags
+afb
+adO
+ags
+ags
+lyN
+aOk
+aOk
+aOk
+aOk
+lyN
+ags
+ags
+adO
 afK
-aeF
-lhb
-lhb
-aae
+ags
+aaa
+aaa
+aaa
 aae
 aaa
 aae
@@ -104863,25 +104756,25 @@ aae
 aae
 aae
 aae
-aae
-lhb
-lhb
-lhb
-adz
-krf
-acJ
-ayk
-krf
-krf
-gWg
-lhb
+aaa
+ags
+kym
+ags
+ags
 lyN
-krf
-acJ
-afJ
-lhb
-lhb
-lhb
+lyN
+aOk
+aOk
+aOk
+aOk
+lyN
+lyN
+ags
+ags
+ulT
+ags
+aaa
+aae
 aae
 aaa
 aae
@@ -105121,25 +105014,25 @@ aae
 aae
 aae
 aae
-aak
-lhb
-lhb
-lhb
-jsp
-krf
-quL
-afv
-krf
-kym
-lhb
-aiL
-krf
-krf
-smW
-lhb
-lhb
+ags
+ags
+ags
+aae
+aae
+xOD
+aOk
+sYR
+aOk
+aOk
+eBH
+aae
+aae
+ags
+ags
+ags
 aaa
-aaa
+aae
+aae
 aae
 aae
 aae
@@ -105322,7 +105215,7 @@ skm
 skm
 skm
 skm
-ojt
+gLF
 mHp
 sXv
 wLX
@@ -105381,20 +105274,20 @@ aak
 aae
 kOC
 pzs
-lhb
-lhb
-mmP
-lhb
-lhb
-afc
-lhb
-lhb
-lhb
-fdW
-iYZ
-fdW
-lhb
-lhb
+xLC
+xLC
+eEQ
+oiD
+lRa
+aOk
+nWp
+iXx
+xOD
+aOk
+aOk
+aOk
+eBH
+hEu
 aae
 aae
 aaa
@@ -105638,20 +105531,20 @@ aae
 aae
 xLC
 xLC
-lhb
-icY
-krf
-lhb
+xLC
+xLC
+xLC
+hEu
 abp
 boC
-tCS
-lhb
-lhb
-wJM
+eBH
+xLC
+xOD
 aOk
 aOk
-lhb
-lhb
+aOk
+eBH
+xLC
 aae
 aae
 aae
@@ -105895,15 +105788,15 @@ aae
 aae
 xLC
 pzs
-lhb
-van
-guT
-lhb
-gvN
+xLC
+hEu
+xLC
+xLC
+xOD
 aOk
 eBH
 naO
-hBx
+xOD
 aOk
 aOk
 aOk
@@ -106152,11 +106045,11 @@ aae
 vGl
 xLC
 qLb
-lhb
-wOt
-lhb
-lhb
-fJJ
+xLC
+xLC
+xLC
+xLC
+xOD
 aOk
 fyR
 eNJ
@@ -106350,7 +106243,7 @@ skm
 skm
 skm
 skm
-ojt
+gLF
 mHp
 pWU
 nvn
@@ -106409,9 +106302,9 @@ aae
 vGl
 jxM
 jxM
-lhb
-lhb
-lhb
+xLC
+xLC
+xLC
 uwh
 xOD
 aOk
@@ -106667,7 +106560,7 @@ aae
 xLC
 odm
 tGh
-nzE
+xLC
 xLC
 xLC
 eLQ
@@ -109763,8 +109656,8 @@ hzN
 lQR
 aOk
 oJW
-cAi
 aOk
+bHu
 aae
 aae
 aae
@@ -109829,7 +109722,7 @@ skm
 skm
 skm
 skm
-ojt
+gLF
 rzV
 cfT
 igF
@@ -109858,7 +109751,7 @@ paJ
 aRb
 aRb
 skm
-ojt
+gLF
 mHp
 rlf
 kxH
@@ -111305,7 +111198,7 @@ vGl
 vGl
 aae
 aae
-hZy
+bac
 aOk
 vGl
 hTq
@@ -117774,7 +117667,7 @@ skm
 skm
 dWS
 skm
-ojt
+gLF
 mHp
 nvn
 igF
@@ -119881,7 +119774,7 @@ imF
 eEC
 npO
 bqR
-ojt
+gLF
 tws
 nvn
 aer
@@ -123486,7 +123379,7 @@ wVA
 pKY
 skm
 afz
-ojt
+gLF
 rFj
 ppw
 evq
@@ -124215,7 +124108,7 @@ ybY
 uSc
 sVR
 dhi
-oNQ
+fsg
 qmO
 qmO
 qmO
@@ -125083,7 +124976,7 @@ imF
 sXv
 sXv
 pKY
-ojt
+gLF
 mHp
 nvn
 nvn
@@ -126811,7 +126704,7 @@ skm
 skm
 skm
 skm
-ojt
+gLF
 mTD
 afs
 nqK

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -14,6 +14,13 @@
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
 	var/puzzle_id = null
 
+//PLA Crashsite Ruin
+/obj/item/keycard/chinese
+	name = "rusted keycard"
+	desc = "It bears the sigil of the People's Liberation Army."
+	color = "#ff0000"
+	puzzle_id = "chinese"
+
 //Two test keys for use alongside the two test doors.
 /obj/item/keycard/cheese
 	name = "cheese keycard"

--- a/code/modules/fallout/areas/area.dm
+++ b/code/modules/fallout/areas/area.dm
@@ -453,6 +453,9 @@
 	environment = 19
 	grow_chance = 5
 
+/area/f13/radiation/crashsite
+	name = "Qianjin Yingdi Crashsite"
+
 //Faction related areas
 
 /area/f13/raiders

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -107,8 +107,8 @@ Head Paladin
 	flag = F13HEADPALADIN
 	display_order = JOB_DISPLAY_ORDER_HEADPALADIN
 	head_announce = list("Security")
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the acting field commander until the Brotherhood regains its strength enough to place an Elder for the bunker. You are a veteran of many battles and sorties in pursuit of Brotherhood goals; your only weakness may just be your hubris. Your main goals are defense of the Chapter and surveillance of the surrounding region for technology."
 	supervisors = "the Elder"
 	selection_color = "#7f8c8d"
@@ -203,8 +203,8 @@ Head Scribe
 	flag = F13HEADSCRIBE
 	display_order = JOB_DISPLAY_ORDER_HEADSCRIBE
 	head_announce = list("Security")
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the foremost experienced scribe remaining in this bunker. Your role is to ensure the safekeeping and proper usage of technology within the Brotherhood. You are also the lead medical expert in this Chapter. Delegate your tasks to your Scribes."
 	supervisors = "the Elder"
 	selection_color = "#7f8c8d"
@@ -269,8 +269,8 @@ Knight-Captain
 	flag = F13KNIGHTCAPTAIN
 	display_order = JOB_DISPLAY_ORDER_KNIGHTCAPTAIN
 	head_announce = list("Security")
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the Knight-Captain, leader of your respective division in the Chapter. Your knowledge of pre-war materials and engineering is almost unparalleled, and you have basic combat training and experience. You are in charge of the Chapter's engineering Corps, and your Knights. Delegate to them as necessary. As Chief Armorer, you are also in charge of the armory."
 	supervisors = "the Elder and Head Paladin in external affairs"
 	selection_color = "#7f8c8d"
@@ -362,8 +362,8 @@ Senior Paladin
 	title = "Senior Paladin"
 	flag = F13SENIORPALADIN
 	display_order = JOB_DISPLAY_ORDER_SENIORPALADIN
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "As the Chapter's senior offensive warrior, you have proven your service and dedication to the Brotherhood over your time as a Paladin. As your skills gained, however, you were deigned to be more useful as a commander and trainer. Your job is to coordinate the Paladins and ensure they work as a team, instilling discipline as you go."
 	supervisors = "the Head Paladin"
 
@@ -448,8 +448,8 @@ Paladin
 	title = "Paladin"
 	flag = F13PALADIN
 	display_order = JOB_DISPLAY_ORDER_PALADIN
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer directly to the Senior Paladin. You are this Chapter's main line of defense and offense; highly trained in combat and weaponry though with little practical field experience, you are eager to prove your worth to the Brotherhood. Your primary duties are defense and surface operations. You may also be assigned a trainee Initiate."
 	supervisors = "the Head Paladin"
 	exp_requirements = 1200
@@ -523,8 +523,8 @@ Senior Scribe
 	title = "Senior Scribe"
 	flag = F13SENIORSCRIBE
 	display_order = JOB_DISPLAY_ORDER_SENIORSCRIBE
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the bunker's seniormost medical and scientific expert in the bunker, sans the Head Scribe themselves. You are trained in both medicine and engineering, while also having extensive studies of the old world to assist in pinpointing what technology would be useful to the Brotherhood and its interests."
 	supervisors = "the Head Scribe"
 
@@ -622,8 +622,8 @@ Scribe
 	title = "Scribe"
 	flag = F13SCRIBE
 	display_order = JOB_DISPLAY_ORDER_SCRIBE
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer directly to the Senior Scribe, tasked with researching and reverse-engineering recovered technologies from the old world, while maintaining the brotherhoods scientific archives. You may also be given a trainee to assign duties to."
 	supervisors = "the Senior Scribe and Head Scribe"
 
@@ -729,8 +729,8 @@ Senior Knight
 	title = "Senior Knight"
 	flag = F13SENIORKNIGHT
 	display_order = JOB_DISPLAY_ORDER_SENIORKNIGHT
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You report directly to the Knight-Captain. You are the Brotherhood Senior Knight. Having served the Knight Caste for some time now, you are versatile and experienced in both basic combat and repairs, and also a primary maintainer of the Bunker's facilities. As your seniormost Knight, you may be assigned initiates or Junior Knights to mentor."
 	supervisors = "the Knight-Captain inside, Paladins outside"
 	exp_requirements = 900
@@ -831,8 +831,8 @@ Knight
 	title = "Knight"
 	flag = F13KNIGHT
 	display_order = JOB_DISPLAY_ORDER_KNIGHT
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	description = " You are the Brotherhood Knight, the veritable lifeblood of your organization. You are a versatile and adaptably trained person: from your primary duties of weapon & armor repair to basic combat, survival and stealth skills, the only thing you lack is proper experience. You are also in charge of Initiates."
 	supervisors = "the Senior Knight and Knight-Captain"
 
@@ -933,8 +933,8 @@ Initiate
 	title = "Initiate"
 	flag = F13INITIATE
 	display_order = JOB_DISPLAY_ORDER_INITIATE
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	description = "Either recently inducted or born into the Brotherhood, you have since proven yourself worthy of assignment to the Chapter. You are to assist your superiors and receive training how they deem fit. You are NEVER allowed to leave the bunker without the direct supervision of a superior; doing so may result in exile or transferrence back the Valley."
 	supervisors = "the Scribes, Knights or Paladins"
 
@@ -1008,8 +1008,8 @@ Off Duty
 	title = "Brotherhood Off-Duty"
 	flag = F13OFFDUTYBOS
 	display_order = JOB_DISPLAY_ORDER_INITIATE
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	description = "Whether operating in disguise or simply enjoying time from the off-shift, you are still a member of the Brotherhood and must abide by the Codex and follow the orders of your superiors. That being said, while off-duty your orders do not take precedence and you should resist issuing them when another of your rank is currently on duty, and if one does not exist, commit to going on-duty. You have a duty to safeguard what equipment you are given, especially your holotags. Ideally, you should be paired with one or more fellow off-duty members; and you would know where the bunker in the region is."
 	supervisors = "your Superior rank"
 


### PR DESCRIPTION
## About The Pull Request
To get things out of the way first, here's the proposed map changes:
![refinery](https://user-images.githubusercontent.com/46099003/203262640-56c6a85c-fd62-4e78-9df8-0844cf052afb.png)
![crashsite](https://user-images.githubusercontent.com/46099003/203260195-f0360048-3671-49ed-b150-af62430b12fb.png)

The specs of the PLA ruin are simple, it's a dungeon that opens at 1:30, so you'll have to dedicate raiding it instead of a faction. This leaves your base open if you're a faction going into it. It has very good loot and an enclosed crashed spacecraft locked behind a 2000 HP abomination, a platoon of chinese remnant soldiers, turrets and radiation. Better pack some rad-away. There are about 5 high-tier gun spawners, dedicated chinese assault rifle spawns, one hightier energy gun inside the abomination's nest, a superhigh energy gun behind the varedited Colonel who should shoot 12 rounds a burst every 3 seconds. He also blocks off a majority of the other loot.

This is my first attempt at mapping in Byond so please be constructive. And if you think my bunker is cool but disabling the Brotherhood isn't, keep in mind that this couldn't fit anywhere else in the map. I can't really split up the PR unless I go out of my way to code in an extra z-level for it, which I'm going to say, I have no idea how to do that.

### Explanation
The Brotherhood have been a consistent issue for every FO13 server, they have always consisted of major problems, the most prominent of which was "fun." The Brotherhood as a player faction is problematic because it has stringent rules and beliefs coupled with bad gameplay. This leads to the opposite of fun. This pull request proposes to disable them until they get properly reworked. 

I'll elaborate here, the Brotherhood's purpose on servers has always been tenuous. They usually get high-powered gear, numbers comparable to either faction and the most entrenched base on the map. Alone, that would be fine, but altogether those "features" make it dull. If the argument is that the Brotherhood is a PvE faction, it often does that ineffectively, even with the equipment they're bestowed roundstart. And if there is a PvE faction, it ought to be disabled until PvE is actually fixed, right?

Here's the problem, they have about 22 slots, a fully stocked bunker, four PA roles, R&D and infinite medicine at the time of writing this pull request. This fully stocked bunker has two farms, an armory, a ceremonial room, a conference room, literal ss13 dorms, a bar, kitchen, medical bay, sprawling R&D room, etc., etc.

But what exactly do they do with all these resources? What do they contribute to the round? Often nothing, this massive base, the largest of any faction just goes to waste space on the map. Rarely when they are actually active, it's usually to perform their primary 'roleplay' goal, which is "acquiring technology" or rather energy weapons. Refuse to take our counterfeit caps that we can mass produce? My paladin buddies will crit you, take your shit and leave you to die. The counterargument to this is that "they have very powerful equipment because they're not supposed to fight." This is not satisfying for several reasons, most obviously basic game design. 

Here's a highly hyperbolized example, I'm going to add a faction of five people. We're going to call it Big Mountain, and the highest role, "Think Tanks" are going to have the ability to instantly incapacitate you and kill you by scooping out your brains with vivisectors. But they're not supposed to fight, and you're not supposed to fight them. They're supposed to put their resources towards making the round interesting with their unique niceties, helping everyone. Which is why I gave them the ability to make maxcaps- and forcefields that randomly erase damage values on a coinflip.

Unfortunately that example is flawed because the fictional "Big Mountain" faction would actually have a better chance of making the round interesting than the Brotherhood, because they aren't limited by IC rules and stuck in a bunker all round. Essentially ideology of the Brotherhood isn't fun either, nor is it cohesive to a fun environment for everyone else. 

Let's dissect the Chain that Binds, shall we? The Chain that Binds is the most problematic rule in the roster of the Brotherhood for several reasons, the one that probably already came to your mind is the idea of power dynamic ERP. When you only answer to your direct superior, you can't get around their orders. Your superior thus can act like a psychopath. 
Though, even on servers without ERP it's problematic, if you don't have a direct superior online, with the Chain that Binds as written, you don't answer to anybody. If there's an Elder and he tells you to do something and your Head Paladin isn't there to relay the order, that violates the Chain that Binds. Though technically the Elder could assign a Head Paladin, or make you the Head Paladin to have his orders apply, what happens when the actual Head Paladin joins?

Essentially, were you to enforce the Codex as written for the Brotherhood you would be jobbanned almost immediately. So if portraying the Brotherhood accurately isn't the goal, what is? Is it functionally just a faction for lax gameplay? A hugbox?

### How do we solve this?

The problem with all of this is that you can very easily compare it to how the old Brotherhood was structured, with about 12 slots and only three of those receiving power armor. On Sunnyvale, they had a bunker that was in disrepair and had to be assembled roundstart. The Brotherhood there still turtled, yes, but their influence was limited by ethical restraint on behalf of developers. They were kept relatively ineffective and power armor was much more common [and often a detriment if you wore it.]

Reflecting its status on Bad Deathclaw we can see that it was merely there to diversify the wastes. It was by all means a side faction, not a main one. The Brotherhood was less influential than the town, rightfully so. Should it return to this state? Maybe not. Here's what I think the ideal rework for the BoS would be: 

They are going to have to be outcasts in some way, there is no way we can get an interesting Brotherhood if they have the Codex that makes their roleplay into a robotic input:output scenario. People already play them like Outcasts because they rarely if ever follow the Chain that Binds, and if they did the faction wouldn't work because there's no Elder.

They need something that sets them apart from the other factions that isn't just cool armor and better weapons. For example, Scribe gameplay is abysmal and pretty much only exists for "roleplay" reasons. Instead of this, put R&D nodes into VR sims that they have to break into to unlock new technologies. Scribes should have a trait that makes it so only they can do this. Make it so these technologies (like chem dispensers) aren't in their base roundstart, they have to build them and make sure they're functioning.

Essentially, they need less support roles and more support content. The entire faction can be distilled down to being support roles to the members who actually get to have fun (the Paladins). This wouldn't be a problem if there wasn't literally nothing else to do in the faction. It needs to change.

Maybe we could lower slots overall so the population of the Wasteland meant that more Paladin slots open. i.e. there are 60 people in the wastes so all the paladin slots are able to be taken, giving them a ratio of being outnumbered 15 to 1.

But, ideally all side factions can have some sort of unique gameplay loop like the VRsim Research Node unlocks I proposed.

I think a surface base would go a long way here, hell we could turn Mass Fusion into their own FOB when we do add them back because by no means is this permanent. I'm submitting this PR so we can get the faction in the right direction. It's the first step of many that will be taken by myself and others who care for the faction.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Old World ghouls have taken up residence in the sewers, creating a compound nearby.
del: The local Brotherhood of Steel chapter has migrated West. Their bunker has fallen into disrepair, a perfect fixer-upper for any aspiring waster.
/:cl: