### PR TITLE
en-khan-cements

### DIFF
--- a/code/modules/clothing/suits/heavy_armor.dm
+++ b/code/modules/clothing/suits/heavy_armor.dm
@@ -401,3 +401,25 @@
 	desc = " Made by the most skilled blacksmiths in Arizona, the bronzed steel of this rare armor offers good protection, and the scars on its metal proves it has seen use on the field."
 	icon_state = "leg_legate"
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 15) // Wouldn't it be hilarious if we just tore apart Legate's armor?
+
+//////////////////
+// Great Khans //
+////////////////
+
+//khan heavy armor, metal armor with less slowdown
+//slowdown of 0.5 compared to 0.25 of medium armor and 0.75 of regular heavy armor
+/obj/item/clothing/suit/toggle/labcoat/khan_jacket/coat
+	name = "Great Khan battle coat"
+	desc = "Heavy leather coat lined with a patchwork of metal plates on the inside. On the back the symbol of the Great Khans is displayed proudly."
+	icon_state = "khan_heavy"
+	item_state = "khan_heavy"
+	cold_protection = CHEST|GROIN|LEGS|ARMS
+	heat_protection = CHEST|GROIN|LEGS|ARMS
+	strip_delay = 80
+	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	equip_delay_other = 50
+	max_integrity = 200
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/duster/armored
+	armor_tier_desc = ARMOR_CLOTHING_HEAVY
+	armor = ARMOR_VALUE_DUSTER_ARMOR
+	slowdown = ARMOR_SLOWDOWN_HEAVY * ARMOR_SLOWDOWN_LESS_T2 * ARMOR_SLOWDOWN_GLOBAL_MULT

--- a/code/modules/clothing/suits/heavy_armor.dm
+++ b/code/modules/clothing/suits/heavy_armor.dm
@@ -406,8 +406,8 @@
 // Great Khans //
 ////////////////
 
-//khan heavy armor, metal armor with less slowdown
-//slowdown of 0.5 compared to 0.25 of medium armor and 0.75 of regular heavy armor
+//khan heavy armor, reinforced metal armor with less slowdown
+//slowdown of 0.6 compared to 0.25 of medium armor and 0.75 of regular heavy armor
 /obj/item/clothing/suit/toggle/labcoat/khan_jacket/coat
 	name = "Great Khan battle coat"
 	desc = "Heavy leather coat lined with a patchwork of metal plates on the inside. On the back the symbol of the Great Khans is displayed proudly."
@@ -421,5 +421,5 @@
 	max_integrity = 200
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/duster/armored
 	armor_tier_desc = ARMOR_CLOTHING_HEAVY
-	armor = ARMOR_VALUE_DUSTER_ARMOR
+	armor = ARMOR_VALUE_REINFORCED_METAL_ARMOR
 	slowdown = ARMOR_SLOWDOWN_HEAVY * ARMOR_SLOWDOWN_LESS_T2 * ARMOR_SLOWDOWN_GLOBAL_MULT

--- a/code/modules/clothing/suits/light_armor.dm
+++ b/code/modules/clothing/suits/light_armor.dm
@@ -928,7 +928,7 @@
 // Great Khans //
 ////////////////
 
-//These are from light jackets 
+//very good resistances for light armor, very bad threshold
 /obj/item/clothing/suit/toggle/labcoat/khan_jacket
 	name = "Great Khan jacket"
 	desc = "A black leather jacket. <br>There is an illustration on the back - an aggressive, red-eyed skull wearing a fur hat with horns.<br>The skull has a mongoloid moustache - it's obviously a Great Khans emblem."
@@ -945,7 +945,8 @@
 	max_integrity = 100
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/armor
 	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
-	armor = ARMOR_VALUE_REINFORCED_LEATHER_JACKET
+	armor = ARMOR_VALUE_LIGHT
+	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1)
 	armor_tier_desc = ARMOR_CLOTHING_LIGHT
 	stiffness = LIGHT_STIFFNESS
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets

--- a/code/modules/clothing/suits/light_armor.dm
+++ b/code/modules/clothing/suits/light_armor.dm
@@ -946,7 +946,7 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/armor
 	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_LIGHT
-	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1)
+	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T1)
 	armor_tier_desc = ARMOR_CLOTHING_LIGHT
 	stiffness = LIGHT_STIFFNESS
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets

--- a/code/modules/clothing/suits/medium_armor.dm
+++ b/code/modules/clothing/suits/medium_armor.dm
@@ -878,18 +878,4 @@
 	armor_tier_desc = ARMOR_CLOTHING_MEDIUM
 	stiffness = MEDIUM_STIFFNESS
 
-//takes from duster
-/obj/item/clothing/suit/toggle/labcoat/khan_jacket/coat
-	name = "Great Khan battle coat"
-	desc = "Heavy leather coat lined with a patchwork of metal plates on the inside. On the back the symbol of the Great Khans is displayed proudly."
-	icon_state = "khan_heavy"
-	item_state = "khan_heavy"
-	cold_protection = CHEST|GROIN|LEGS|ARMS
-	heat_protection = CHEST|GROIN|LEGS|ARMS
-	strip_delay = 80
-	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
-	equip_delay_other = 50
-	max_integrity = 200
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets/duster/armored
-	armor = ARMOR_VALUE_DUSTER_ARMOR
-	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T3 * ARMOR_SLOWDOWN_GLOBAL_MULT
+

--- a/code/modules/clothing/suits/medium_armor.dm
+++ b/code/modules/clothing/suits/medium_armor.dm
@@ -878,4 +878,18 @@
 	armor_tier_desc = ARMOR_CLOTHING_MEDIUM
 	stiffness = MEDIUM_STIFFNESS
 
-
+//takes from duster
+/obj/item/clothing/suit/toggle/labcoat/khan_jacket/coat
+	name = "Great Khan battle coat"
+	desc = "Heavy leather coat lined with a patchwork of metal plates on the inside. On the back the symbol of the Great Khans is displayed proudly."
+	icon_state = "khan_heavy"
+	item_state = "khan_heavy"
+	cold_protection = CHEST|GROIN|LEGS|ARMS
+	heat_protection = CHEST|GROIN|LEGS|ARMS
+	strip_delay = 80
+	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	equip_delay_other = 50
+	max_integrity = 200
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/duster/armored
+	armor = ARMOR_VALUE_DUSTER_ARMOR
+	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T3 * ARMOR_SLOWDOWN_GLOBAL_MULT

--- a/code/modules/clothing/suits/medium_armor.dm
+++ b/code/modules/clothing/suits/medium_armor.dm
@@ -858,7 +858,7 @@
 // Great Khans //
 /////////////////
 
-//takes from medium armor
+//has slowdown, good resistances and bad threshold
 /obj/item/clothing/suit/toggle/labcoat/khan_jacket/armored
 	name = "Great Khan armored jacket"
 	desc = "A black leather jacket with ballistic plates and a big Great Khan logo on the back. Some prefer to wear a leather vest (alt-click)."
@@ -874,22 +874,8 @@
 	max_integrity = 200
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/armor
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_GLOBAL_MULT
-	armor = ARMOR_VALUE_REINFORCED_LEATHER_JACKET
+	armor =  ARMOR_VALUE_MEDIUM
+	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T1)
 	armor_tier_desc = ARMOR_CLOTHING_MEDIUM
 	stiffness = MEDIUM_STIFFNESS
 
-//takes from duster
-/obj/item/clothing/suit/toggle/labcoat/khan_jacket/coat
-	name = "Great Khan battle coat"
-	desc = "Heavy leather coat lined with a patchwork of metal plates on the inside. On the back the symbol of the Great Khans is displayed proudly."
-	icon_state = "khan_heavy"
-	item_state = "khan_heavy"
-	cold_protection = CHEST|GROIN|LEGS|ARMS
-	heat_protection = CHEST|GROIN|LEGS|ARMS
-	strip_delay = 80
-	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
-	equip_delay_other = 50
-	max_integrity = 200
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets/duster/armored
-	armor = ARMOR_VALUE_DUSTER_ARMOR
-	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T3 * ARMOR_SLOWDOWN_GLOBAL_MULT

--- a/code/modules/fallout/misc/gang_items.dm
+++ b/code/modules/fallout/misc/gang_items.dm
@@ -250,11 +250,6 @@
 	cost = 10 
 	item_path = /obj/item/radio/headset/headset_khans
 
-/datum/gang_item/equipment/greatkhanarmorcoat
-	name = "Great Khan Armored Coat"
-	cost = 200
-	item_path = /obj/item/clothing/suit/toggle/labcoat/khan_jacket/coat
-
 ///////////////////
 //EQUIPMENT
 ///////////////////

--- a/code/modules/fallout/misc/gang_items.dm
+++ b/code/modules/fallout/misc/gang_items.dm
@@ -241,14 +241,19 @@
 	item_path = /obj/item/grenade/f13/stinger
 
 /datum/gang_item/equipment/he
-	name = "High Explosive Grenade"
-	cost = 100
-	item_path = /obj/item/grenade/f13/explosive
+	name = "stick of dynamite"
+	cost = 75
+	item_path = /obj/item/grenade/f13/anarchist/dynamite
 
 /datum/gang_item/equipment/greatkhanheadset
 	name = "Great Khan Headset"
 	cost = 10 
 	item_path = /obj/item/radio/headset/headset_khans
+
+/datum/gang_item/equipment/greatkhanarmorcoat
+	name = "Great Khan Armored Coat"
+	cost = 200
+	item_path = /obj/item/clothing/suit/toggle/labcoat/khan_jacket/coat
 
 ///////////////////
 //EQUIPMENT

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -62,7 +62,7 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/uzi)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/gate_khanate)
-
+	H.mind.teach_crafting_recipe(GLOB.chemwhiz_recipes)
 /datum/job/khan/greatkhan
 	title = "Great Khan"
 	flag = F13GREATKHAN

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -24,7 +24,7 @@
 	box = /obj/item/storage/survivalkit/tribal/chief
 	box_two = /obj/item/storage/survivalkit/medical/raider
 	backpack_contents = list(
-		/obj/item/storage/bag/money/small/khan = 1
+		/obj/item/storage/bag/money/small/khan = 1,
 		/obj/item/melee/unarmed/brass/spiked = 1,
 		)
 

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -25,6 +25,7 @@
 	box_two = /obj/item/storage/survivalkit/medical/raider
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/khan = 1
+		/obj/item/melee/unarmed/brass/spiked = 1,
 		)
 
 /datum/outfit/job/khan/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -45,6 +46,7 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/uzi)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/gate_khanate)
+	H.mind.teach_crafting_recipe(GLOB.chemwhiz_recipes)
 
 /datum/outfit/job/khan/greatkhan
 	jobtype = /datum/job/khan/greatkhan
@@ -91,7 +93,6 @@
 		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/restraints/legcuffs/bola/tactical = 1,
 		/obj/item/book/granter/trait/bigleagues = 1,
-		/obj/item/melee/unarmed/brass/spiked = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2)
 
 /datum/outfit/loadout/khanskirmisher //Mid-range SMG user with an autoloader and a bola

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -16,6 +16,7 @@
 	ears = /obj/item/radio/headset/headset_khans
 	head = /obj/item/clothing/head/helmet/f13/khan/bandana
 	shoes = /obj/item/clothing/shoes/f13/military/khan
+	gloves = /obj/item/melee/unarmed/brass/spiked
 	backpack =	/obj/item/storage/backpack/satchel/explorer
 	satchel = 	/obj/item/storage/backpack/satchel/old
 	uniform = /obj/item/clothing/under/f13/khan
@@ -25,7 +26,6 @@
 	box_two = /obj/item/storage/survivalkit/medical/raider
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/khan = 1,
-		/obj/item/melee/unarmed/brass/spiked = 1,
 		)
 
 /datum/outfit/job/khan/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -101,7 +101,7 @@
 // Standard Great Khan money bag. Wealthy by raider standards. 100 + spare change
 /obj/item/storage/bag/money/small/khan/PopulateContents()
 	new /obj/item/stack/f13Cash/random/low(src)
-	new new /obj/item/stack/f13Cash/caps/onezerozero(src)
+	new /obj/item/stack/f13Cash/caps/onezerozero(src)
 	
 // Standard Settler money bag. They are pretty wealthy, with NCR bucks and caps, no Legion money.
 /obj/item/storage/bag/money/small/settler/PopulateContents()

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -87,7 +87,7 @@
 
 // Oasis reserves. Spawns with the Mayor.
 /obj/item/storage/bag/money/small/oasis/PopulateContents()
-	// exactly 1000 caps, and about 200 in foreign reserves
+	// exactly 1000 caps
 	new /obj/item/stack/f13Cash/caps/onezerozerozero(src)
 
 
@@ -98,9 +98,10 @@
 	new /obj/item/stack/f13Cash/random/low(src)
 
 
-// Standard Great Khan money bag. They have a little more caps than common raiders. Average 75.
+// Standard Great Khan money bag. Wealthy by raider standards. 100 + spare change
 /obj/item/storage/bag/money/small/khan/PopulateContents()
 	new /obj/item/stack/f13Cash/random/low(src)
+	new new /obj/item/stack/f13Cash/caps/onezerozero(src)
 	
 // Standard Settler money bag. They are pretty wealthy, with NCR bucks and caps, no Legion money.
 /obj/item/storage/bag/money/small/settler/PopulateContents()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -243,7 +243,7 @@
 	draw_time = GUN_DRAW_LONG
 	damage_multiplier = GUN_LESS_DAMAGE_T2
 	init_firemodes = list(
-		FULL_AUTO_450,
+		FULL_AUTO_600,
 		SEMI_AUTO_SMG
 	)
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -221,7 +221,7 @@
  * Uzi 9mm SMG
  * Light 9mm SMG
  * 9mm
- * Faster firing
+ * Very Fast Firing Rate
  * Less damage
  * One-handed
  * Akimbo!
@@ -243,7 +243,7 @@
 	draw_time = GUN_DRAW_LONG
 	damage_multiplier = GUN_LESS_DAMAGE_T2
 	init_firemodes = list(
-		FULL_AUTO_300,
+		FULL_AUTO_450,
 		SEMI_AUTO_SMG
 	)
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
improvents to the khan loadout

khan starting cash boosted to ~100 caps
they are supposed to start with 75 caps, but someone removed starting cash without altering the comments

all khans start with chemwiz recipes, ie. jet, buffout, stimpaks
though you should still pick drug pusher loadout if you want to operate the fancy machines

uzi is now 600-RPM instead of 300
this indirectly buffs the desperados and most mid-tier drops
the gun already does about 20% less damage per shot, it doesnt need less fire-rate
and the real life mini-uzi fired at 900RPM, so 600 should be fine

 khan armor has been reworked
generally designed with high resist and low threshold, helps absorb large pistol rounds but bad against automatics
-  jacket:
 bullet:15, melee:15, laser:5, threshold:4 ->  bullet: 20, melee:20, laser: 20, threshold:1

- armored jacket
  bullet:20 , melee:20, laser:10, threshold: 5 -> bullet:25, melee:35, laser:35, threshold: 3
 
- battlecoat
no longer medium armor
 bullet:20 , melee:20, laser:10, threshold: 5 -> bullet: 20, melee: 40, laser: 40, threshold: 8
very slight reason to pick jacket over battlecoat for the +5 bullet resist, but the extra threshold should mean bullets do less damage anyways

slowdown is roughly 0.5, metal armor is 0.8 for comparison

HE-grenade is now a stick of dynamite
yee-haw
for immulsions

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
