### PR TITLE
I literally forgot about salvaged PA when we were talking about deflect 

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -9,7 +9,8 @@
 	light_color = "#FFCC66"
 	light_on = FALSE
 	var/hat_type = "yellow" //Determines used sprites: hardhat[light_on]_[hat_type] and hardhat[light_on]_[hat_type]2 (lying down sprite)
-	armor = ARMOR_VALUE_MEDIUM
+	armor = ARMOR_VALUE_KIT
+	armor_tokens = list(ARMOR_MODIFIER_UP_DT_T2)
 	flags_inv = 0
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	resistance_flags = FIRE_PROOF

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -65,6 +65,7 @@
 	icon_state = "hardhat0_purple"
 	item_state = "hardhat0_purple"
 	light_range = 5
+	armor_tokens = list(ARMOR_MODIFIER_UP_DT_T2)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	custom_materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/plastic = 3000, /datum/material/silver = 500)
 	hat_type = "purple"

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -10,7 +10,7 @@
 	light_on = FALSE
 	var/hat_type = "yellow" //Determines used sprites: hardhat[light_on]_[hat_type] and hardhat[light_on]_[hat_type]2 (lying down sprite)
 	armor = ARMOR_VALUE_KIT
-	armor_tokens = list(ARMOR_MODIFIER_UP_DT_T2)
+	armor_tokens = list(ARMOR_MODIFIER_UP_DT_T1)
 	flags_inv = 0
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	resistance_flags = FIRE_PROOF

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -28,7 +28,8 @@
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = FIRE_PROOF
 	mutantrace_variation = STYLE_MUZZLE
-
+	armor_tokens = list(ARMOR_MODIFIER_UP_DT_T2)
+	
 /obj/item/clothing/head/welding/attack_self(mob/user)
 	weldingvisortoggle(user)
 

--- a/code/modules/clothing/suits/heavy_armor.dm
+++ b/code/modules/clothing/suits/heavy_armor.dm
@@ -290,8 +290,8 @@
 	slowdown = ARMOR_SLOWDOWN_SALVAGE * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_SALVAGE
 	armor_tier_desc = ARMOR_CLOTHING_SALVAGE
-	armor_block_chance = 25
-	deflection_chance = 5 //Trash compared to actual PA
+	armor_block_chance = 10
+	deflection_chance = 0 //Trash compared to actual PA
 
 /obj/item/clothing/suit/armor/heavy/salvaged_pa/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
 	if(check_armor_penetration(object) <= 0.05 && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))

--- a/code/modules/clothing/suits/power_armor.dm
+++ b/code/modules/clothing/suits/power_armor.dm
@@ -329,6 +329,7 @@
 	desc = "It's a set of early-model T-45 power armor with a custom air conditioning module and restored servomotors. Bulky, but almost as good as the real thing."
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
 	armor_block_chance = 20 //1-in-5
+	deflection_chance = 1 //to ensure it doesnt inherit deflect chance from anything above it
 
 /obj/item/clothing/suit/armor/power_armor/t45d
 	name = "T-45d power armor"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
exactly what it said on the tin
SPA block chance from 25 - > 10

T-45b has exactly 1 point of ricochet to prevent inheriting a higher value from other templates
slips in 2 DT for welding helmets, a thin sheet of metal for your face should provide a tiny amount of protection
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

balance: block on SPA reduced from 25 to 10
balance: T-45b has a defined ricochet value
balance: +2 threshold for welding helmets 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
