### PR TITLE
GnB 1 + 4 knowledge to knights on roundstart + Removed Booster from knight and gave it to scribes + more

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -717,6 +717,21 @@
 	subcategory = CAT_WEAPON
 	always_available = FALSE
 
+//trench shotgun
+
+/datum/crafting_recipe/trench
+	name = "Trench Shotgun"
+	result = /obj/item/gun/ballistic/shotgun/trench
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
+				/obj/item/stack/crafting/metalparts = 5,
+				/obj/item/stack/sheet/metal = 3,
+	)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_available = FALSE
+
 //marksman carbine
 /datum/crafting_recipe/marksmancarbine
 	name = "Marksman Carbine"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -615,7 +615,7 @@
 	icon_state = "gab2"
 	oneuse = TRUE
 	remarks = list("Always keep your gun well lubricated...", "Keep your barrel free of grime...", "Perfect fitment is the key to a good firearm...", "Maintain a proper trigger pull length...", "Keep your sights zeroed to proper range...")
-	crafting_recipe_types = list(/datum/crafting_recipe/smg10mm, /datum/crafting_recipe/verminkiller, /obj/item/gun/ballistic/shotgun/trench, /datum/crafting_recipe/huntingrifle)
+	crafting_recipe_types = list(/datum/crafting_recipe/smg10mm, /datum/crafting_recipe/verminkiller, /datum/crafting_recipe/trench, /datum/crafting_recipe/huntingrifle)
 
 /obj/item/book/granter/crafting_recipe/gunsmith_three
 	name = "Guns and Bullets, Part 3"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -27,7 +27,6 @@ GLOBAL_LIST_INIT(knight_gunsmith_recipes, list(
 	/datum/crafting_recipe/ergonomic_grip,
 	/datum/crafting_recipe/metal_guard,
 	/datum/crafting_recipe/forged_barrel,
-	/datum/crafting_recipe/booster,
 	/datum/crafting_recipe/sniperscope,
 	/datum/crafting_recipe/suppressor,
 	/datum/crafting_recipe/recoilcomp,
@@ -252,9 +251,11 @@ Head Scribe
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/superstimpak5)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/buffout)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/steady)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/lightplasmapistol)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/wattz2k)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/AER9)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/AEP7)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/booster)
 	ADD_TRAIT(H, TRAIT_MEDICALEXPERT, src)
 	ADD_TRAIT(H, TRAIT_CYBERNETICIST_EXPERT, src)
 	ADD_TRAIT(H, TRAIT_CYBERNETICIST, src)
@@ -324,10 +325,10 @@ Knight-Captain
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/superstimpak5)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/buffout)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/steady)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/lightplasmapistol)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/dks)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m1carbine)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/n99)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m2405) // temporary as head scribe taken plasma pistol as they are more plasma / laser and knight is ballistic. Actually accurate?! for BOS?
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
 	ADD_TRAIT(H, TRAIT_GUNSMITH_ONE, src)
@@ -593,6 +594,7 @@ Senior Scribe
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/wattz2k)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/AER9)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/AEP7)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/booster)
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 	ADD_TRAIT(H, TRAIT_CYBERNETICIST, src)
@@ -704,6 +706,7 @@ Scribe
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/buffout)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/steady)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/AER9)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/booster)
 	ADD_TRAIT(H, TRAIT_SURGERY_MID, src)
 	ADD_TRAIT(H, TRAIT_MEDICALGRADUATE, src)
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -15,6 +15,25 @@
 		"Leadership recommends the following goal for this week: Acquire or confiscate dangerous tech by any means necessary."
 		)
 
+GLOBAL_LIST_INIT(knight_gunsmith_recipes, list(
+	/datum/crafting_recipe/n99,
+	/datum/crafting_recipe/varmintrifle,
+	/datum/crafting_recipe/huntingshotgun,
+	/datum/crafting_recipe/smg10mm,
+	/datum/crafting_recipe/verminkiller, 
+	/datum/crafting_recipe/trench, 
+	/datum/crafting_recipe/huntingrifle,
+	/datum/crafting_recipe/scope,
+	/datum/crafting_recipe/ergonomic_grip,
+	/datum/crafting_recipe/metal_guard,
+	/datum/crafting_recipe/forged_barrel,
+	/datum/crafting_recipe/booster,
+	/datum/crafting_recipe/sniperscope,
+	/datum/crafting_recipe/suppressor,
+	/datum/crafting_recipe/recoilcomp,
+	/datum/crafting_recipe/laserguide,
+	/datum/crafting_recipe/fullauto))
+
 /datum/outfit/job/bos
 	name = "bosdatums"
 	jobtype = 	/datum/job/bos
@@ -315,6 +334,8 @@ Knight-Captain
 	ADD_TRAIT(H, TRAIT_GUNSMITH_TWO, src)
 	ADD_TRAIT(H, TRAIT_GUNSMITH_THREE, src)
 	ADD_TRAIT(H, TRAIT_GUNSMITH_FOUR, src)
+	for(var/datum/crafting_recipe/recipe as() in GLOB.knight_gunsmith_recipes)
+		H.mind.teach_crafting_recipe(recipe)
 
 /datum/outfit/job/bos/f13knightcap
 	name = "Knight-Captain"
@@ -769,6 +790,9 @@ Senior Knight
 	ADD_TRAIT(H, TRAIT_GUNSMITH_TWO, src)
 	ADD_TRAIT(H, TRAIT_GUNSMITH_THREE, src)
 	ADD_TRAIT(H, TRAIT_GUNSMITH_FOUR, src)
+	for(var/datum/crafting_recipe/recipe as() in GLOB.knight_gunsmith_recipes)
+		H.mind.teach_crafting_recipe(recipe)
+
 
 /datum/outfit/job/bos/f13seniorknight
 	name = "Senior Knight"
@@ -872,6 +896,9 @@ Knight
 	ADD_TRAIT(H, TRAIT_GUNSMITH_TWO, src)
 	ADD_TRAIT(H, TRAIT_GUNSMITH_THREE, src)
 	ADD_TRAIT(H, TRAIT_GUNSMITH_FOUR, src)
+	for(var/datum/crafting_recipe/recipe as() in GLOB.knight_gunsmith_recipes)
+		H.mind.teach_crafting_recipe(recipe)
+
 
 /datum/outfit/job/bos/f13knight
 	name = "Knight"


### PR DESCRIPTION
## About The Pull Request
Fixes GnB 1 + 4 into knights of BOS because they had a bug.
Removes booster from knights on roundstart, you can read funny gun and bullet books.
Also gives light plasma pistol to Head Knight, since head scribe is more for plasma / lasers, and gives head knight m2405 crafting instead for temporary, plus according to the mod it comes from its slightly lore accurate.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: knight_gunsmith_recipes to bos knights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
