### PR TITLE
Tribal Armor Fix

### DIFF
--- a/code/modules/clothing/suits/medium_armor.dm
+++ b/code/modules/clothing/suits/medium_armor.dm
@@ -55,6 +55,7 @@
 	strip_delay = 30
 	equip_delay_other = 50
 	max_integrity = 200
+	armor = ARMOR_VALUE_REINFORCED_LEATHER_ARMOR
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/duster
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T2 * ARMOR_SLOWDOWN_GLOBAL_MULT // lighter, cus melee focus
 


### PR DESCRIPTION
## About The Pull Request
Adjusts the tribal armor so the heavy armor variant has more protection than the medium armor variant. 
Pictures of the after-change:

![HeavyArmor](https://user-images.githubusercontent.com/20309339/204576878-19d07dc4-45f6-4828-968c-0412686020ee.png)
![mediumarmor](https://user-images.githubusercontent.com/20309339/204576888-81f75b01-82ea-41c6-84d1-0026d8a44c49.png)

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Heavy tribal armor is no longer worse than medium tribal armor, protection value wise.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
