### PR TITLE
Removes ability to make rubber shot and beanbag rounds for shotguns

### DIFF
--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Lower.dmm
@@ -12161,8 +12161,6 @@
 /obj/item/ammo_box/shotgun/buck,
 /obj/item/ammo_box/shotgun/buck,
 /obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/bean,
-/obj/item/ammo_box/shotgun/bean,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 10
 	},
@@ -15232,9 +15230,6 @@
 /obj/item/ammo_box/shotgun/buck,
 /obj/item/ammo_box/shotgun/buck,
 /obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/rubber,
-/obj/item/ammo_box/shotgun/rubber,
-/obj/item/ammo_box/shotgun/rubber,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "iDw" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -7581,8 +7581,6 @@
 /obj/item/ammo_box/shotgun/buck,
 /obj/item/ammo_box/shotgun/buck,
 /obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/bean,
-/obj/item/ammo_box/shotgun/bean,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 10
 	},

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -13863,7 +13863,6 @@
 /area/f13/wasteland)
 "aZR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_box/shotgun/bean,
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/handcuffs,
@@ -24179,8 +24178,6 @@
 /area/f13/legion)
 "dSW" = (
 /obj/structure/closet,
-/obj/item/ammo_box/shotgun/bean,
-/obj/item/ammo_box/shotgun/bean,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -504,9 +504,7 @@ GLOBAL_LIST_INIT(loot_t5_melee, list(
 ))
 
 GLOBAL_LIST_INIT(loot_t1_range, list(
-	/obj/item/ammo_box/shotgun/bean,
 	/obj/item/gun/ballistic/revolver/caravan_shotgun,
-	/obj/item/ammo_box/shotgun/bean,
 	/obj/item/ammo_box/stripper/a762,
 	/obj/item/gun/ballistic/revolver/police,
 	/obj/item/ammo_box/loader/c38,
@@ -626,7 +624,6 @@ GLOBAL_LIST_INIT(loot_unique_range, list(
 GLOBAL_LIST_INIT(loot_t1_ammo, list(
 	/obj/item/ammo_box/magazine/pistol9mm,
 	/obj/item/ammo_box/shotgun/buck,
-	/obj/item/ammo_box/shotgun/bean,
 	/obj/item/ammo_box/loader/c38,
 	/obj/item/ammo_box/magazine/pistol10mm,
 	/obj/item/ammo_box/magazine/m556/rifle/small

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -674,7 +674,6 @@
 	loot = list("" = 25,
 		/obj/item/ammo_box/magazine/wt550m9 = 1,
 		/obj/item/ammo_casing/shotgun/buckshot = 7,
-		/obj/item/ammo_casing/shotgun/rubbershot = 7,
 		/obj/item/ammo_casing/a762 = 15,
 		/obj/item/ammo_box/stripper/a762 = 15,
 		)
@@ -686,7 +685,6 @@
 	loot = list("" = 50,
 		/obj/item/ammo_box/magazine/wt550m9 = 2,
 		/obj/item/ammo_casing/shotgun/buckshot = 10,
-		/obj/item/ammo_casing/shotgun/rubbershot = 10,
 		/obj/item/ammo_casing/a762 = 7,
 		/obj/item/ammo_box/stripper/a762 = 7,
 		)
@@ -697,10 +695,8 @@
 	spawn_on_turf = FALSE
 	loot = list("" = 50,
 		/obj/item/ammo_box/shotgun/loaded/buckshot = 5,
-		/obj/item/ammo_box/shotgun/loaded/beanbag = 5,
 		/obj/item/ammo_box/shotgun/loaded/incendiary = 5,
 		/obj/item/ammo_casing/shotgun/buckshot = 8,
-		/obj/item/ammo_casing/shotgun/rubbershot = 9,
 		/obj/item/ammo_casing/shotgun = 8,
 		/obj/item/ammo_casing/shotgun/incendiary = 10,
 		)

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -188,7 +188,7 @@
 	build_path = /obj/item/ammo_box/c38box/rubber
 	category = list("initial", "Simple Ammo")
 
-/datum/design/ammolathe/beanbag
+/*/datum/design/ammolathe/beanbag
 	name = "beanbag shotgun box"
 	id = "beanbag"
 	materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 1000)
@@ -200,7 +200,7 @@
 	id = "rubbershot"
 	materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 1000)
 	build_path = /obj/item/ammo_box/shotgun/rubber
-	category = list("initial", "Simple Ammo")
+	category = list("initial", "Simple Ammo")*/
 
 /datum/design/ammolathe/lethalshot
 	name = "buckshot shotgun box"
@@ -838,7 +838,7 @@
 	build_path = /obj/item/ammo_box/shotgun/improvised
 	category = list("initial", "Handloaded Ammo")
 
-/datum/design/ammolathe/improvised/beanbag
+/*/datum/design/ammolathe/improvised/beanbag
 	name = "beanbag shotgun box"
 	id = "handloader_beanbag"
 	materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 1000)
@@ -850,7 +850,7 @@
 	id = "handloader_rubbershot"
 	materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 1000)
 	build_path = /obj/item/ammo_box/shotgun/rubber
-	category = list("initial", "Handloaded Ammo")
+	category = list("initial", "Handloaded Ammo")*/
 
 /datum/design/ammolathe/improvised/a223
 	name = ".223 bag"


### PR DESCRIPTION
## About The Pull Request
The funny ammo is a little too funny and doesn't properly interact with armor. Until that's fixed, this ammo should be disabled. Shotguns only.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Rubber and beanbag rounds have been disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
