### PR TITLE
Adds an alert to players respawning after matrix'ing

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -532,6 +532,9 @@
 
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 
+	if(job == src.previous_job)
+		log_and_message_admins("[ADMIN_TPMONTY(character)] has spawned as a job they've previously matrix'd as ([character.job])!")
+
 /mob/dead/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
 	//TODO:  figure out a way to exclude wizards/nukeops/demons from this.
 	for(var/C in GLOB.employmentCabinets)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -269,7 +269,7 @@ Transfer_mind is there to check if mob is being deleted/not going to have a body
 Works together with spawning an observer, noted above.
 */
 
-/mob/proc/ghostize(can_reenter_corpse = TRUE, special = FALSE, penalize = FALSE, voluntary = FALSE)
+/mob/proc/ghostize(can_reenter_corpse = TRUE, special = FALSE, penalize = FALSE, voluntary = FALSE, memorize_job = null)
 	var/sig_flags = SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, can_reenter_corpse, special, penalize)
 	penalize = !(sig_flags & COMPONENT_DO_NOT_PENALIZE_GHOSTING) && (suiciding || penalize) // suicide squad.
 	voluntary_ghosted = voluntary
@@ -285,6 +285,8 @@ Works together with spawning an observer, noted above.
 	transfer_ckey(ghost, FALSE)
 	if(!QDELETED(ghost))
 		ghost.client.init_verbs()
+	if(memorize_job)
+		ghost.previous_job = memorize_job
 	if(penalize)
 		var/penalty = CONFIG_GET(number/suicide_reenter_round_timer) MINUTES
 		var/roundstart_quit_limit = CONFIG_GET(number/roundstart_suicide_time_limit) MINUTES

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -226,7 +226,8 @@
 		var/atom/movable/content = i
 		dat += " [content.type]"
 	log_game(dat)
-	ghostize(memorize_job = job_to_free)
+	if(job_to_free)
+		ghostize(memorize_job = job_to_free)
 	qdel(src)
 
 /mob/living/carbon/human/Topic(href, href_list)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -226,7 +226,7 @@
 		var/atom/movable/content = i
 		dat += " [content.type]"
 	log_game(dat)
-	ghostize()
+	ghostize(memorize_job = job_to_free)
 	qdel(src)
 
 /mob/living/carbon/human/Topic(href, href_list)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -515,6 +515,10 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 		return
 
 	var/mob/dead/new_player/M = new /mob/dead/new_player()
+
+	if(src.previous_job)
+		M.previous_job = src.previous_job
+
 	if(!client)
 		log_game("[key_name(usr)] AM failed due to disconnect.")
 		qdel(M)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -182,3 +182,4 @@
 	/// How much DT does the mob ignore?
 	var/damage_threshold_penetration_mob = 0
 
+	var/previous_job // Used for tracking what a ghost's last job was


### PR DESCRIPTION
## About The Pull Request
Adds an alert to players respawning as the same job after matrix'ing to help catch people respawning for gear.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Admins will now get an alert when a player respawns as the same job they've most recently matrix'd as.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
