### PR TITLE
adds LAER to unique pool

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -796,7 +796,8 @@
 	name = "unique tier energy gun"
 	lootcount = 1
 
-	loot = list(/obj/item/gun/energy/laser/solar
+	loot = list(/obj/item/gun/energy/laser/solar,
+				/obj/item/gun/energy/laser/laer
 				)
 
 //Ballistic Weapon Spawners


### PR DESCRIPTION
## About The Pull Request
unused content is bad and the unique pool for energy weapons had a single gun before.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Some unique pools were diversified.
/:cl:
