### PR TITLE
Allows users with Berserker Rites to bandage

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -535,7 +535,7 @@
 	. = 1 // Default to returning true.
 	if(user && !target_zone)
 		target_zone = user.zone_selected
-	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE) && !bypass_immunity)
+	if((HAS_TRAIT(src, TRAIT_PIERCEIMMUNE) && !HAS_TRAIT_FROM(src, TRAIT_PIERCEIMMUNE, BERSERKER_TRAIT)) && !bypass_immunity) // have to include special chec for beserker
 		. = 0
 	// If targeting the head, see if the head item is thin enough.
 	// If targeting anything else, see if the wear suit is thin enough.


### PR DESCRIPTION
## About The Pull Request
Fixes a bug where if you read Berserker Rites you couldn't bandage or use syringes.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
Fix: Besker's Rites now allows you to bandage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
