### PR TITLE
various cargo crate additions

### DIFF
--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -97,6 +97,17 @@
 					/obj/item/clothing/gloves/color/latex/nitrile,
 					/obj/item/clothing/gloves/color/latex/nitrile)
 	crate_name = "nitrile gloves crate"
+	
+/datum/supply_pack/science/rndsetup
+	name = "Research and Development Starter Kit"
+	desc = "We took these from an abandoned Vault-Tec warehouse a while back and the OSI is on our ass about it. Could you just take it off our hands? Server not included."
+	cost = 50000
+	contains = list(/obj/item/circuitboard/computer/rdconsole,
+					/obj/item/circuitboard/machine/destructive_analyzer,
+					/obj/item/circuitboard/machine/circuit_imprinter,
+					/obj/item/circuitboard/machine/protolathe,
+					/obj/item/storage/box/stockparts/deluxe)
+	crate_name = "r&d starter kit"
 /*
 /datum/supply_pack/science/plasma
 	name = "Plasma Assembly Crate"

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -97,17 +97,6 @@
 					/obj/item/clothing/gloves/color/latex/nitrile,
 					/obj/item/clothing/gloves/color/latex/nitrile)
 	crate_name = "nitrile gloves crate"
-	
-/datum/supply_pack/science/rndsetup
-	name = "Research and Development Starter Kit"
-	desc = "We took these from an abandoned Vault-Tec warehouse a while back and the OSI is on our ass about it. Could you just take it off our hands? Server not included."
-	cost = 50000
-	contains = list(/obj/item/circuitboard/computer/rdconsole,
-					/obj/item/circuitboard/machine/destructive_analyzer,
-					/obj/item/circuitboard/machine/circuit_imprinter,
-					/obj/item/circuitboard/machine/protolathe,
-					/obj/item/storage/box/stockparts/deluxe)
-	crate_name = "r&d starter kit"
 /*
 /datum/supply_pack/science/plasma
 	name = "Plasma Assembly Crate"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -49,6 +49,14 @@
 					/obj/effect/spawner/lootdrop/f13/armor/tier3)
 	crate_name = "armor crate"
 
+/datum/supply_pack/security/raidersalvaged
+	name = "Armor - Salvaged"
+	desc = "This is the best we can do, we found it on some junkies outside El Paso... after we ran them over with a train. It's not quite salvaged power armor but it'll do the job in a pinch. Not sure why anybody would want it, but maybe you do."
+	cost = 25000
+	contains = list(/obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/raider,
+					/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/raider)
+	crate_name = "armor crate"
+
 /datum/supply_pack/security/ec
 	name = "Ammo - Energy Cell"
 	desc = "Three fully charged energy cells."
@@ -320,6 +328,13 @@
 					/obj/item/gun/energy/disabler,
 					/obj/item/gun/energy/disabler)
 	crate_name = "disabler crate" */
+
+/datum/supply_pack/security/minigunlaser
+	name = "Weapons - Gatling Laser"
+	desc = "An exclusive, it arrived! A refurbished Glastinghouse Inc. X-25 gatling laser taken from the sorry scrap of some RobCo automaton. Uncompact, inconvenient and practically useless against armored targets, maybe you'll find some use for it."
+	cost = 50000
+	contains = list(/obj/item/minigunpack)
+	crate_name = "minigun crate"
 
 /datum/supply_pack/security/minigun5mm
 	name = "Weapons - Minigun"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -332,7 +332,7 @@
 /datum/supply_pack/security/minigunlaser
 	name = "Weapons - Gatling Laser"
 	desc = "An exclusive, it arrived! A refurbished Glastinghouse Inc. X-25 gatling laser taken from the sorry scrap of some RobCo automaton. Uncompact, inconvenient and practically useless against armored targets, maybe you'll find some use for it."
-	cost = 50000
+	cost = 75000
 	contains = list(/obj/item/minigunpack)
 	crate_name = "minigun crate"
 


### PR DESCRIPTION
## About The Pull Request
That title isn't intentionally vague, essentially I added three crates to cargo that boil down to the following:

25k for salvaged raider PA (This is x10 the cost of three sets of combat armor.)

75k for the gatling laser (You can already get the minigun which is better than this. The gatling laser's only redeeming quality is that it's good for PvE and hitscan. If you've ever used it against someone in combat armor you know how truly bad it is.)

~~50k for an R&D setup, why?~~ ~~Because the GLA actually used the one at the hospital A LOT~~, ~~furthermore, if the R&D setup in the town is destroyed this is an avenue to get a new one.~~ Told to remove this one by a green name.

I hope high prices enforce scarcity for all three of these. Suggest any changes you'd like to see or additional crates you want the merchant to have. I am not "dying on the hill" for these crates, I just got a few requests from Maus to add them in some capacity. Will be fine raising the cost if it seems unacceptable.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Some dubiously useful crates for the merchant.
/:cl: