### PR TITLE
Adds 3 new clothes to charselect loadout and changes description of 1 clothing item

### DIFF
--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -1700,7 +1700,7 @@
 
 /obj/item/clothing/under/f13/desert_ranger_scout
 	name = "desert ranger scouting uniform"
-	desc = "A set of clothing worn by desert ranger scouts."
+	desc = "An old set of clothing worn by desert ranger scouts before they were absorbed by the NCR. Durable and comfortable, but rarely seen in the wastes anymore."
 	icon_state = "scoutclothes"
 	can_adjust = FALSE
 	item_state = "scoutclothes"

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -972,6 +972,23 @@
 	path = /obj/item/clothing/under/f13/locust
 	cost = 1
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
+/datum/gear/uniform/wasteland/ncr_exile_fatigues
+    name = "Disheveled NCR fatigues"
+    path = /obj/item/clothing/under/f13/exile
+    cost = 2
+    subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
+
+/datum/gear/uniform/wasteland/desert_ranger_scout
+    name = "Desert ranger scouting uniform"
+    path = /obj/item/clothing/under/f13/desert_ranger_scout
+    cost = 1
+    subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
+
+/datum/gear/uniform/wasteland/legion_exile_fatigues
+    name = "Disheveled legion fatigues"
+    path = /obj/item/clothing/under/f13/exile/legion
+    cost = 2
+    subcategory = LOADOUT_SUBCATEGORY_UNIFORM_WASTELAND
 
 /datum/gear/uniform/wasteland/keksweater
 	name = "Red sweater"


### PR DESCRIPTION
## About The Pull Request
Adds the NCR deserter fatigues, Legion deserter fatigues, and Desert Ranger Scout Clothes (with an updated description to match lore a bit better) to the wasteland section of the character select loadout. Deserter fatigues are 2 points, and DRSC are 1.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added clothes to loadout
tweak: tweaked DRSC description
code: Coded new code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
