### PR TITLE
Moves G&B 2 to low trait book spawner

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2034,7 +2034,6 @@ obj/effect/spawner/bundle/f13/combat_rifle
 				/obj/item/book/granter/trait/explosives = 10,
 				/obj/item/book/granter/trait/explosives_advanced = 5,
 				/obj/item/book/granter/trait/rifleman = 5,
-				/obj/item/book/granter/crafting_recipe/gunsmith_two = 20,
 				/obj/item/book/granter/crafting_recipe/gunsmith_three = 10,
 				/obj/item/book/granter/crafting_recipe/gunsmith_four = 10,
 				/obj/item/book/granter/crafting_recipe/gunsmith_five = 5
@@ -2068,6 +2067,7 @@ obj/effect/spawner/bundle/f13/combat_rifle
 				/obj/item/book/granter/crafting_recipe/ODF = 10,
 				/obj/item/book/granter/action/drink_fling = 10,
 				/obj/item/book/granter/crafting_recipe/gunsmith_one = 10,
+				/obj/item/book/granter/crafting_recipe/gunsmith_two = 10,
 				)
 
 /obj/effect/spawner/lootdrop/f13/blueprintLow


### PR DESCRIPTION
## About The Pull Request
It's not even worth 50 caps, nobody would want this over explosives knowledge or surgery EVER. It's common enough with there being a vendor for it.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Moved Guns and Bullets, Part 2 to low tier spawners.
/:cl:
