### PR TITLE
locks supply console to merchant

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -16,6 +16,7 @@
 	/// var that tracks message cooldown
 	var/message_cooldown
 	var/list/loaded_coupons
+	var/list/job_req = list("Merchant")
 
 	light_color = "#E2853D"//orange
 
@@ -69,6 +70,10 @@
 	if(!ui)
 		ui = new(user, src, "Cargo", name)
 		ui.open()
+	if(LAZYLEN(job_req) && !(user.mind?.assigned_role in job_req))
+		to_chat(user, span_warning("You have no idea how to use it..."))
+		return
+	. = ..()
 
 /obj/machinery/computer/cargo/ui_data()
 	var/list/data = list()


### PR DESCRIPTION
## About The Pull Request
The merchant is a separate organization from the town, they should not be breaking in and ordering shit without his ID. it doesn't even make sense why the caravan company would send them stuff if they killed him or got him killed. 

I stole the code from the identification console so it might not work. Gonna test this later when I download an older version of byond.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: You need the merchant's ID to use his console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
