### PR TITLE
Alternative to #293

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -1048,8 +1048,8 @@ Off Duty
 	title = "Brotherhood Off-Duty"
 	flag = F13OFFDUTYBOS
 	display_order = JOB_DISPLAY_ORDER_INITIATE
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 4
+	spawn_positions = 4
 	description = "Whether operating in disguise or simply enjoying time from the off-shift, you are still a member of the Brotherhood and must abide by the Codex and follow the orders of your superiors. That being said, while off-duty your orders do not take precedence and you should resist issuing them when another of your rank is currently on duty, and if one does not exist, commit to going on-duty. You have a duty to safeguard what equipment you are given, especially your holotags. Ideally, you should be paired with one or more fellow off-duty members; and you would know where the bunker in the region is."
 	supervisors = "your Superior rank"
 

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -135,7 +135,7 @@ Head Paladin
 
 	loadout_options = list(
 	/datum/outfit/loadout/hpstand, //Tribeam laser + Hardened T-51
-	//datum/outfit/loadout/hpheavy, //Gauss + Glock + Hardened T-51
+	/datum/outfit/loadout/hpheavy, //DKS + Glock + Hardened T-51
 	/datum/outfit/loadout/hpgat		//Gatling + Hardened T-51
 	)
 
@@ -196,16 +196,16 @@ Head Paladin
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/mfc = 3
 	)
-/* Bad
+
 /datum/outfit/loadout/hpheavy
 	name = "Heavy Head Paladin"
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/m72 = 1,
-		/obj/item/ammo_box/magazine/m2mm = 3,
+		/obj/item/gun/ballistic/automatic/sniper = 1,
+		/obj/item/ammo_box/magazine/w308 = 2,
 		/obj/item/gun/energy/laser/plasma/glock = 1,
-		/obj/item/stock_parts/cell/ammo/ec = 2
+		/obj/item/stock_parts/cell/ammo/ec = 2,
 	)
-*/
+
 /datum/outfit/loadout/hpgat
 	name = "Laser Gatling Head Paladin"
 	backpack_contents = list(
@@ -278,7 +278,7 @@ Head Scribe
 		/obj/item/storage/firstaid/tactical/bosheadscribe=1,
 		/obj/item/clothing/mask/gas/adv/gasmask = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 2,
-		/obj/item/gun/energy/laser/wattz = 1,
+		/obj/item/gun/energy/laser/plasma/glock = 1,
 		)
 
 /*
@@ -299,8 +299,8 @@ Knight-Captain
 	exp_requirements = 1500
 
 	loadout_options = list(
-	/datum/outfit/loadout/capstand, //Wattz 2k
-	/datum/outfit/loadout/capsap, //Marksman
+	/datum/outfit/loadout/capstand, //DKS 2 mags
+	/datum/outfit/loadout/capsap, //RCW + 2 mags
 	/datum/outfit/loadout/capalt //Neostead with buck because they don't know slugs are better
 	)
 
@@ -329,7 +329,10 @@ Knight-Captain
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/commando)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m1carbine)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/n99)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m2405) // temporary as head scribe taken plasma pistol as they are more plasma / laser and knight is ballistic. Actually accurate?! for BOS?
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m2405) 
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/thatgun)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/lever_action)// temporary as head scribe taken plasma pistol as they are more plasma / laser and knight is ballistic. Actually accurate?! for BOS?
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
 	ADD_TRAIT(H, TRAIT_GUNSMITH_ONE, src)
@@ -359,8 +362,8 @@ Knight-Captain
 /datum/outfit/loadout/capstand
 	name = "Standard"
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/wattz2k = 1,
-		/obj/item/stock_parts/cell/ammo/mfc = 2
+		/obj/item/gun/ballistic/automatic/sniper = 1,
+		/obj/item/ammo_box/magazine/w308 = 2
 	)
 
 /datum/outfit/loadout/capsap
@@ -394,7 +397,7 @@ Senior Paladin
 
 	loadout_options = list(
 		/datum/outfit/loadout/spaladina, //5mm minigun
-		/datum/outfit/loadout/spaladinc,  //Aer9
+		/datum/outfit/loadout/spaladinc,  //Aer14 + pistol
 		/datum/outfit/loadout/spaladind //Sledge and fist
 		)
 
@@ -460,7 +463,7 @@ Senior Paladin
 		/obj/item/melee/powerfist/f13 = 1,
 		/obj/item/twohanded/sledgehammer/supersledge = 1,
 		/obj/item/gun/energy/laser/pistol = 1,
-		/obj/item/stock_parts/cell/ammo/ec = 2
+		
 		)
 
 
@@ -548,8 +551,8 @@ Senior Scribe
 	title = "Senior Scribe"
 	flag = F13SENIORSCRIBE
 	display_order = JOB_DISPLAY_ORDER_SENIORSCRIBE
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	description = "You are the bunker's seniormost medical and scientific expert in the bunker, sans the Head Scribe themselves. You are trained in both medicine and engineering, while also having extensive studies of the old world to assist in pinpointing what technology would be useful to the Brotherhood and its interests."
 	supervisors = "the Head Scribe"
 
@@ -610,7 +613,7 @@ Senior Scribe
 	glasses =	/obj/item/clothing/glasses/sunglasses/big
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/ec = 2,
-		/obj/item/gun/energy/laser/wattz = 1,
+		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/clothing/mask/gas/adv/gasmask = 1,
@@ -633,7 +636,7 @@ Senior Scribe
 	backpack_contents = list(
 		/obj/item/storage/belt/utility/bos=1,
 		/obj/item/clothing/gloves/color/yellow=1,
-		/obj/item/blueprint/research=2,
+		/obj/item/blueprint/research=6,
 		/obj/item/clothing/gloves/color/yellow=1
 		)
 
@@ -647,8 +650,8 @@ Scribe
 	title = "Scribe"
 	flag = F13SCRIBE
 	display_order = JOB_DISPLAY_ORDER_SCRIBE
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	description = "You answer directly to the Senior Scribe, tasked with researching and reverse-engineering recovered technologies from the old world, while maintaining the brotherhoods scientific archives. You may also be given a trainee to assign duties to."
 	supervisors = "the Senior Scribe and Head Scribe"
 
@@ -686,7 +689,7 @@ Scribe
 	glasses =		/obj/item/clothing/glasses/sunglasses/big
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/ec = 2,
-		/obj/item/gun/energy/laser/wattz = 1,
+		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/storage/firstaid/regular = 1
 		)
@@ -763,8 +766,8 @@ Senior Knight
 	exp_requirements = 900
 
 	loadout_options = list(
-	/datum/outfit/loadout/sknighta, //AER9
-	/datum/outfit/loadout/sknightb, //Browning Auto-5
+	/datum/outfit/loadout/sknighta, //AER12
+	/datum/outfit/loadout/sknightb, //Lever Action
 	/datum/outfit/loadout/sknightc, //R91
 	/datum/outfit/loadout/sknightd	//Ripper and Bulletproof Shield
 	)
@@ -818,7 +821,7 @@ Senior Knight
 	name = "Footknight"
 	suit = /obj/item/clothing/suit/armor/medium/combat/brotherhood/senior
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/aer9 = 1,
+		/obj/item/gun/energy/laser/aer12 = 1,
 		/obj/item/stock_parts/cell/ammo/mfc = 2,
 		/obj/item/gun_upgrade/scope/watchman = 1,
 		/obj/item/gun/ballistic/automatic/pistol/autoloader = 1,
@@ -829,7 +832,7 @@ Senior Knight
 	name = "Knight-Defender"
 	suit = /obj/item/clothing/suit/armor/medium/combat/brotherhood/senior
 	backpack_contents = list(
-		/obj/item/gun/ballistic/shotgun/police = 1,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever = 1,
 		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 2
@@ -840,8 +843,8 @@ Senior Knight
 	suit = /obj/item/clothing/suit/armor/light/combat/brotherhood/scout/senior
 	backpack_contents = list(
 		/obj/item/clothing/suit/armor/light/combat/brotherhood/scout/senior = 1,
-		/obj/item/gun/ballistic/automatic/assault_rifle = 1,
-		/obj/item/ammo_box/magazine/m556/rifle = 2,
+		/obj/item/gun/ballistic/automatic/marksman = 1,
+		/obj/item/ammo_box/magazine/m556/rifle = 3,
 		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 2
 		)
@@ -871,8 +874,8 @@ Knight
 	loadout_options = list(
 	/datum/outfit/loadout/knighta, //AER9 J
 	/datum/outfit/loadout/knightc, //AER9 S
-	/datum/outfit/loadout/knightb, //Ripper J
-	/datum/outfit/loadout/knightd //Ripper S
+	/datum/outfit/loadout/knightb, //Shish J
+	/datum/outfit/loadout/knightd //Shish S
 	)
 
 	outfit = /datum/outfit/job/bos/f13knight
@@ -936,7 +939,7 @@ Knight
 	suit = /obj/item/clothing/suit/armor/light/combat/brotherhood/scout
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/juniorknight = 1,
-		/obj/item/melee/powered/ripper = 1,
+		/obj/item/shishkebabpack = 1,
 		/obj/item/shield/riot/bullet_proof = 1
 		)
 
@@ -957,7 +960,7 @@ Knight
 	suit = /obj/item/clothing/suit/armor/light/combat/brotherhood/scout
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/knight = 1,
-		/obj/item/melee/powered/ripper = 1,
+		/obj/item/shishkebabpack = 1,
 		/obj/item/shield/riot/bullet_proof = 1
 		)
 /*
@@ -1045,8 +1048,8 @@ Off Duty
 	title = "Brotherhood Off-Duty"
 	flag = F13OFFDUTYBOS
 	display_order = JOB_DISPLAY_ORDER_INITIATE
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	description = "Whether operating in disguise or simply enjoying time from the off-shift, you are still a member of the Brotherhood and must abide by the Codex and follow the orders of your superiors. That being said, while off-duty your orders do not take precedence and you should resist issuing them when another of your rank is currently on duty, and if one does not exist, commit to going on-duty. You have a duty to safeguard what equipment you are given, especially your holotags. Ideally, you should be paired with one or more fellow off-duty members; and you would know where the bunker in the region is."
 	supervisors = "your Superior rank"
 
@@ -1062,3 +1065,7 @@ Off Duty
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/survival = 1
 		)
+
+		/* 
+		They're broken so until its fixed, its gone
+		*/

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -187,7 +187,8 @@ Head Paladin
 		/obj/item/melee/powerfist/f13 = 1,
 		/obj/item/gun/ballistic/automatic/pistol/n99/crusader = 1,
 		/obj/item/ammo_box/magazine/pistol10mm = 2,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/flashlight/seclite = 1
 		)
 
 /datum/outfit/loadout/hpstand
@@ -211,7 +212,6 @@ Head Paladin
 	backpack_contents = list(
 		/obj/item/minigunpack = 1
 	)
-
 
 /*
 Head Scribe
@@ -279,6 +279,7 @@ Head Scribe
 		/obj/item/clothing/mask/gas/adv/gasmask = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/gun/energy/laser/plasma/glock = 1,
+		/obj/item/flashlight/seclite = 1
 		)
 
 /*
@@ -356,7 +357,8 @@ Knight-Captain
 		/obj/item/gun/ballistic/automatic/pistol/pistol14 = 1,
 		/obj/item/ammo_box/magazine/pistol14mm = 2,
 		/obj/item/melee/onehanded/knife/hunting = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
+		/obj/item/flashlight/seclite = 1
 		)
 
 /datum/outfit/loadout/capstand
@@ -437,7 +439,8 @@ Senior Paladin
 
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
-		/obj/item/melee/onehanded/knife/hunting = 1
+		/obj/item/melee/onehanded/knife/hunting = 1,
+		/obj/item/flashlight/seclite = 1
 	)
 
 /datum/outfit/loadout/spaladina
@@ -521,7 +524,8 @@ Paladin
 	neck =	/obj/item/clothing/neck/mantle/bos/paladin
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak= 1,
-		/obj/item/melee/onehanded/knife/hunting = 1
+		/obj/item/melee/onehanded/knife/hunting = 1,
+		/obj/item/flashlight/seclite = 1
 	)
 
 /datum/outfit/loadout/paladinc
@@ -617,6 +621,7 @@ Senior Scribe
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/clothing/mask/gas/adv/gasmask = 1,
+		/obj/item/flashlight/seclite = 1
 
 	)
 
@@ -691,7 +696,8 @@ Scribe
 		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/melee/onehanded/knife/survival = 1,
-		/obj/item/storage/firstaid/regular = 1
+		/obj/item/storage/firstaid/regular = 1,
+		/obj/item/flashlight/seclite = 1
 		)
 
 /datum/outfit/job/bos/f13scribe/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -814,7 +820,8 @@ Senior Knight
 	head = 			/obj/item/clothing/head/helmet/f13/combat/brotherhood/senior
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
+		/obj/item/flashlight/seclite = 1
 		)
 
 /datum/outfit/loadout/sknighta
@@ -874,6 +881,8 @@ Knight
 	loadout_options = list(
 	/datum/outfit/loadout/knighta, //AER9 J
 	/datum/outfit/loadout/knightc, //AER9 S
+	/datum/outfit/loadout/knighte, //Engi J
+	/datum/outfit/loadout/knightf, //Engi S
 	/datum/outfit/loadout/knightb, //BF + Shield J
 	/datum/outfit/loadout/knightd //BF + Shield S
 	)
@@ -920,7 +929,8 @@ Knight
 	head = 			/obj/item/clothing/head/helmet/f13/combat/brotherhood
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/survival = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+		/obj/item/flashlight/seclite = 1
 		)
 
 /datum/outfit/loadout/knighta
@@ -965,6 +975,33 @@ Knight
 		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/shield/riot/bullet_proof = 1
 		)
+
+/datum/outfit/loadout/knighte
+	name = "Junior Knight-Engineer"
+	suit = /obj/item/clothing/suit/armor/light/combat/brotherhood/scout
+	backpack_contents = list(
+		/obj/item/clothing/accessory/bos/juniorknight = 1,
+		/obj/item/storage/belt/utility/full = 1,
+		/obj/item/stack/sheet/metal/fifty = 1,
+		/obj/item/stack/sheet/glass/fifty = 1,
+		/obj/item/gun/ballistic/shotgun/police = 1,
+		/obj/item/ammo_box/shotgun/buck = 2,
+		/obj/item/clothing/mask/gas/welding = 1
+		)
+
+/datum/outfit/loadout/knightf
+	name = "Knight-Engineer"
+	suit = /obj/item/clothing/suit/armor/light/combat/brotherhood/scout
+	backpack_contents = list(
+		/obj/item/clothing/accessory/bos/knight = 1,
+		/obj/item/storage/belt/utility/full = 1,
+		/obj/item/stack/sheet/metal/fifty = 1,
+		/obj/item/stack/sheet/glass/fifty = 1,
+		/obj/item/gun/ballistic/shotgun/police = 1,
+		/obj/item/ammo_box/shotgun/buck = 2,
+		/obj/item/clothing/mask/gas/welding = 1
+		)
+
 /*
 Initiate
 */
@@ -1007,7 +1044,8 @@ Initiate
 	name = "Initiate"
 	jobtype = /datum/job/bos/f13initiate
 	backpack_contents = list(
-		/obj/item/melee/onehanded/knife/survival = 1
+		/obj/item/melee/onehanded/knife/survival = 1,
+		/obj/item/flashlight/seclite = 1
 		)
 
 /datum/outfit/job/bos/f13initiate/post_equip(mob/living/carbon/human/H, visualsOnly)

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -874,8 +874,8 @@ Knight
 	loadout_options = list(
 	/datum/outfit/loadout/knighta, //AER9 J
 	/datum/outfit/loadout/knightc, //AER9 S
-	/datum/outfit/loadout/knightb, //Shish J
-	/datum/outfit/loadout/knightd //Shish S
+	/datum/outfit/loadout/knightb, //BF + Shield J
+	/datum/outfit/loadout/knightd //BF + Shield S
 	)
 
 	outfit = /datum/outfit/job/bos/f13knight
@@ -939,7 +939,8 @@ Knight
 	suit = /obj/item/clothing/suit/armor/light/combat/brotherhood/scout
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/juniorknight = 1,
-		/obj/item/shishkebabpack = 1,
+		/obj/item/gun/ballistic/revolver/ballisticfist = 1,
+		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/shield/riot/bullet_proof = 1
 		)
 
@@ -960,7 +961,8 @@ Knight
 	suit = /obj/item/clothing/suit/armor/light/combat/brotherhood/scout
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/knight = 1,
-		/obj/item/shishkebabpack = 1,
+		/obj/item/gun/ballistic/revolver/ballisticfist = 1,
+		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/shield/riot/bullet_proof = 1
 		)
 /*
@@ -971,8 +973,8 @@ Initiate
 	title = "Initiate"
 	flag = F13INITIATE
 	display_order = JOB_DISPLAY_ORDER_INITIATE
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 4
+	spawn_positions = 4
 	description = "Either recently inducted or born into the Brotherhood, you have since proven yourself worthy of assignment to the Chapter. You are to assist your superiors and receive training how they deem fit. You are NEVER allowed to leave the bunker without the direct supervision of a superior; doing so may result in exile or transferrence back the Valley."
 	supervisors = "the Scribes, Knights or Paladins"
 


### PR DESCRIPTION
## About The Pull Request
An alternative suggestion to PR #293 

- Knight and SK slots remain at 3/2.
- Initiate slots buffed to 4.
- Scribe slots nerfed.
- Paladin slots remain at three.
- All loadout changes are still identical, with the following exception.
- Knight, instead of a ripper/shishkebab in their melee loadout, starts with a ballistic fist and two boxes of buckshot.
- Knights have a new loadout: 'Knight-Engineer'. Starts with tools, a welding mask, materials and a police shotgun.

I feel as though encouraging a paladin-heavy BOS isn't the right way to go. This maintains the good changes made by 293 whilst also 'nerfing' the BOS in a way that doesn't cripple them if they don't have paladins on. More knights / initiates is a good thing, they should make up the majority of the bunker - both from a balance and lore viewpoint.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Less scribe slots, loadout changes for senior/head roles in the BOS, loadout changes for Knight-Cavalry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
