### PR TITLE
PA book from machine gone

### DIFF
--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -813,7 +813,6 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Random manual",					/obj/item/book/manual/random,									40),
 		new /datum/data/wasteland_equipment("Box of ingredients - American",	/obj/item/storage/box/ingredients/american,						20),
 		new /datum/data/wasteland_equipment("Box of ingredients - Wildcard", 	/obj/item/storage/box/ingredients/wildcard, 					20),	/// Goal with these you can do some dicing with it
-		new /datum/data/wasteland_equipment("Advanced Armor and You",			/obj/item/book/granter/trait/pa_wear,							2000),
 		//// new /datum/data/wasteland_equipment("Music box",						/obj/item/holodisk/musicbox,								400),
 		new /datum/data/wasteland_equipment("???",								/obj/item/toy/syndicateballoon,									500)
 		)
@@ -821,7 +820,6 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Random manual",					/obj/item/book/manual/random,									40),
 		new /datum/data/wasteland_equipment("Box of ingredients - American",	/obj/item/storage/box/ingredients/american,						20),
 		new /datum/data/wasteland_equipment("Box of ingredients - Wildcard", 	/obj/item/storage/box/ingredients/wildcard,						 20),	/// Goal with these you can do some dicing with it
-		new /datum/data/wasteland_equipment("Advanced Armor and You",			/obj/item/book/granter/trait/pa_wear,							2000),
 		/// new /datum/data/wasteland_equipment("Music box",						/obj/item/holodisk/musicbox,								400),
 		new /datum/data/wasteland_equipment("???",								/obj/item/toy/syndicateballoon,									500)
 		)


### PR DESCRIPTION
## About The Pull Request
Tribal PA mechanized groups are over, the machine will not sell you the book again. Due to it shouldnt of been readded into the machine.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
remove: PA granter gone from machine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
