### PR TITLE
legion bailout program

### DIFF
--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -51,10 +51,14 @@
 	STR.cant_hold = typecacheof(list(/obj/item/screwdriver/power))
 	STR.can_hold = GLOB.storage_wallet_can_hold
 
-// Legion reserves. Spawns with the Centurion.
+// Legion reserves. Spawns with the Centurion and a camp follower loadout (or auxillia)
 /obj/item/storage/bag/money/small/legion/PopulateContents()
-	// ~450ish worth of legion money
+	// 500 caps + change
 	new /obj/item/stack/f13Cash/random/low(src)
+	new /obj/item/stack/f13Cash/caps/onezerozero(src)
+	new /obj/item/stack/f13Cash/caps/onezerozero(src)
+	new /obj/item/stack/f13Cash/caps/onezerozero(src)
+	new /obj/item/stack/f13Cash/caps/onezerozero(src)
 	
 // Legion enlisted. Spawns with the Legionnaires. Average 12 caps.
 /obj/item/storage/bag/money/small/legenlisted/PopulateContents()


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
gold reserves ran dry, no moe aureus
emergency cap infusion to stimulate legion economy
here with the legion, we only use caps harvested from dead NCR

starting caps were bugged, aureus was removed without replacement
value in aureus replaced roughly with caps
also adds a gold bar to treaurer loadout for RP purposes
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: no cash on legion 
add: gold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
