### PR TITLE
Ranger role rebalance + maps in AMR to veteran ranger office

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -19603,6 +19603,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
+"lVD" = (
+/obj/structure/displaycase{
+	req_access = list(253);
+	start_showpiece_type = /obj/item/gun/ballistic/rifle/mag/antimateriel
+	},
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "lVM" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -46207,7 +46214,7 @@ rJB
 uxw
 bzD
 vaz
-bzD
+lVD
 rJB
 aae
 aak

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -551,8 +551,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13ranger
 	title = "NCR Ranger"
 	flag = F13RANGER
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	description = "As an NCR Ranger, you are the premier special forces unit of the NCR. You are the forward observations and support the Army in it's campaigns, as well as continuing the tradition of stopping slavery in it's tracks."
 	supervisors = "Veteran Ranger"
 	selection_color = "#fff5cc"


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin. Changes the base ranger from 3 to 2. There is now a display case in the veteran ranger office that he can swipe to get his AMR from, either for emergencies or general use. A myriad of people have suggested the veteran ranger getting an AMR, the display case is mainly to stop matrix abuse with loadouts.


This pull request will be ready for review whenever one of the 7.62 nerfs gets merged, as this hampers the ability of snipers indirectly. Several roles (Rangers prolifically but also the El Capitan loadout) use these, which will impede the combat ability of the NCR slightly.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
rebalance: The Rangers have been moved back down from 4>3. As a result, the budget office of the Camp Miller has freed up enough for one anti-materiel rifle. Make it count.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
