### PR TITLE
buffs the brush gun

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -880,7 +880,6 @@
 				/obj/effect/spawner/bundle/f13/marksman,
 				/obj/effect/spawner/bundle/f13/guns/tommygun,
 				/obj/effect/spawner/bundle/f13/shotgunlever,
-				/obj/effect/spawner/bundle/f13/brushgun,
 				/obj/effect/spawner/bundle/f13/ak112
 				)
 

--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -77,7 +77,7 @@
 	name = "4570 internal tube magazine" //brush gun
 	ammo_type = /obj/item/ammo_casing/c4570
 	caliber = list(CALIBER_4570)
-	max_ammo = 10
+	max_ammo = 8
 	multiload = 1
 
 /obj/item/ammo_box/magazine/internal/shot/lasmusket

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -237,8 +237,8 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	damage_multiplier = GUN_EXTRA_DAMAGE_0
-	init_recoil = RIFLE_RECOIL(3.6)
+	damage_multiplier = GUN_EXTRA_DAMAGE_T3
+	init_recoil = RIFLE_RECOIL(1.9)
 	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	fire_sound = 'sound/f13weapons/brushgunfire.ogg'


### PR DESCRIPTION
## About The Pull Request
It had appallingly bad recoil and mediocre damage in comparison to the sequoia or hunting revolver (both of which had better recoil than it because they use the pistol multipliers for recoil, like literally seven magnitudes lower than the brush gun.)

Also, given that it's one of the Veteran Ranger primaries and a Provost Marshal primary, but almost never used, a buff seemed in order. It's basically an elephant cartridge now, so:

It now has a recoil that is equal to the trail carbine which shoots .44 and not 3x it. 

It does about 69 damage per shot.

It can only hold eight shots and not ten.

To compensate for this "massive boost" in power, it has been made rarer in loot spawns.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: The Gun Runners have offloaded their arsenal, in them, optimized brush guns with modified receivers and gyrostabilized triggers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
