### PR TITLE
Makes Brahmins not ridable awhile they are dead.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -589,6 +589,9 @@
 /mob/living/simple_animal/cow/brahmin/attackby(obj/item/I, mob/user)
 	. = ..()
 	if(istype(I,/obj/item/brahminbags))
+		if(stat == DEAD)
+			to_chat(user, "<span class='warning'>You cannot add anything to a dead brahmin!</span>")
+			return
 		if(bags)
 			to_chat(user, span_warning("The brahmin already has bags attached!"))
 			return
@@ -602,6 +605,9 @@
 		return
 
 	if(istype(I,/obj/item/brahmincollar))
+		if(stat == DEAD)
+			to_chat(user, "<span class='warning'>You cannot add anything to a dead brahmin!</span>")
+			return
 		if(user != owner)
 			to_chat(user, span_warning("You need to claim the brahmin with a bridle before you can rename it!"))
 			return
@@ -618,6 +624,9 @@
 		return
 
 	if(istype(I,/obj/item/brahminbridle))
+		if(stat == DEAD)
+			to_chat(user, "<span class='warning'>You cannot add anything to a dead brahmin!</span>")
+			return
 		if(bridle)
 			to_chat(user, span_warning("This brahmin already has a bridle!"))
 			return
@@ -630,6 +639,9 @@
 		return
 
 	if(istype(I,/obj/item/brahminsaddle))
+		if(stat == DEAD)
+			to_chat(user, "<span class='warning'>You cannot add anything to a dead brahmin!</span>")
+			return
 		if(saddle)
 			to_chat(user, span_warning("This brahmin already has a saddle!"))
 			return
@@ -657,6 +669,14 @@
 
 		if(!brand)
 			return
+
+/mob/living/simple_animal/cow/brahmin/death(gibbed)
+	. = ..()
+	if(can_buckle)
+		can_buckle = FALSE
+	if(buckled_mobs)
+		for(var/mob/living/M in buckled_mobs)
+			unbuckle_mob(M)
 
 /datum/component/storage/concrete/brahminbag
 	max_w_class = WEIGHT_CLASS_HUGE //Allows the storage of shotguns and other two handed items.


### PR DESCRIPTION
## About The Pull Request
Makes brahmins not living dead brahmin ridable when they are dead.
https://github.com/fortune13-ss13/thewasteland/pull/741

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: brahmins to stay dead awhile they arent ridable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
