### PR TITLE
Letpassthrow update

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -96,15 +96,15 @@
 	for(var/obj/O in src)
 		if((mover && O.CanPass(mover, target_dir)) || (!mover && !O.density))
 			continue
-		if(O == target || O == mover || (O.pass_flags & LETPASSTHROW)) //check if there's a dense object present on the turf
+		if(O == target || O == mover || (O.pass_flags_self & LETPASSTHROW)) //check if there's a dense object present on the turf
 			continue // LETPASSTHROW is used for anything you can click through (or the firedoor special case, see above)
 
 		if( O.flags_1&ON_BORDER_1) // windows are on border, check them first
 			if( O.dir & target_dir || O.dir & (O.dir-1) ) // full tile windows are just diagonals mechanically
-				return 0								  //O.dir&(O.dir-1) is false for any cardinal direction, but true for diagonal ones
+				return FALSE   //O.dir&(O.dir-1) is false for any cardinal direction, but true for diagonal ones
 		else if( !border_only ) // dense, not on border, cannot pass over
-			return 0
-	return 1
+			return FALSE
+	return TRUE
 
 
 /**

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -229,12 +229,3 @@ SUBSYSTEM_DEF(throwing)
 
 /datum/thrownthing/proc/hit_atom(atom/A)
 	finalize(hit=TRUE, target=A)
-
-/datum/thrownthing/proc/hitcheck()
-	for (var/thing in get_turf(thrownthing))
-		var/atom/movable/AM = thing
-		if (AM == thrownthing || (AM == thrower && !ismob(thrownthing)))
-			continue
-		if (AM.density && !(AM.pass_flags & LETPASSTHROW) && !(AM.flags_1 & ON_BORDER_1))
-			finalize(hit=TRUE, target=AM)
-			return TRUE

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -108,7 +108,6 @@
 	icon_state = "sandbags"
 	max_integrity = 280
 	proj_pass_rate = 20
-	pass_flags = LETPASSTHROW
 	pass_flags_self = LETPASSTHROW
 	bar_material = SAND
 	climbable = TRUE

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -109,6 +109,7 @@
 	max_integrity = 280
 	proj_pass_rate = 20
 	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	bar_material = SAND
 	climbable = TRUE
 	smooth = SMOOTH_TRUE

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -134,7 +134,7 @@
 	assemblytype = /obj/item/stack/rods
 	visible = FALSE
 	explosion_block = FALSE
-	pass_flags = LETPASSTHROW  // would be great but the var is not functional for some reason.
+	pass_flags_self = LETPASSTHROW
 	proj_pass_rate = 95
 
 /obj/machinery/door/unpowered/celldoor/update_icon()

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_INIT(rod_recipes, list ( \
 	new/datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 10, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("metal bars", /obj/structure/barricade/bars, 4, time = 20, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("metal bars", /obj/structure/barricade/bars, 6, time = 20, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("barred door", /obj/structure/simple_door/metal/barred, 30, time = 40, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("railing", /obj/structure/railing, 3, time = 18, window_checks = TRUE), \
 	new/datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = 1, on_floor = 1), \

--- a/code/game/objects/structures/loot_pile.dm
+++ b/code/game/objects/structures/loot_pile.dm
@@ -46,7 +46,7 @@
 	density = TRUE
 	layer = TABLE_LAYER
 	climbable = TRUE
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	loot = list(
 		SCAVENGING_FOUND_NOTHING = 50,
 		SCAVENGING_SPAWN_MOUSE = 10,

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -300,7 +300,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	layer = TRAY_LAYER
 	var/obj/structure/bodycontainer/connected = null
 	anchored = TRUE
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	max_integrity = 350
 
 /obj/structure/tray/Destroy()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -22,8 +22,7 @@
 	layer = TABLE_LAYER
 	climbable = TRUE
 	obj_flags = CAN_BE_HIT|SHOVABLE_ONTO
-	pass_flags = LETPASSTHROW //You can throw objects over this, despite it's density.")
-	pass_flags_self = PASSTABLE
+	pass_flags_self = PASSTABLE | LETPASSTHROW
 	attack_hand_speed = CLICK_CD_MELEE
 	attack_hand_is_action = TRUE
 	var/frame = /obj/structure/table_frame

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -693,8 +693,7 @@
 	layer = TABLE_LAYER
 	density = TRUE
 	anchored = TRUE
-	pass_flags = LETPASSTHROW
-	pass_flags_self = PASSTABLE
+	pass_flags_self = PASSTABLE | LETPASSTHROW
 	max_integrity = 30
 	attack_hand_speed = CLICK_CD_MELEE
 	attack_hand_is_action = TRUE
@@ -707,8 +706,7 @@
 	layer = TABLE_LAYER
 	density = TRUE
 	anchored = TRUE
-	pass_flags = LETPASSTHROW //You can throw objects over this, despite it's density.
-	pass_flags_self = PASSTABLE
+	pass_flags_self = PASSTABLE | LETPASSTHROW
 	max_integrity = 20
 	attack_hand_speed = CLICK_CD_MELEE
 	attack_hand_is_action = TRUE

--- a/code/game/turfs/f13concrete.dm
+++ b/code/game/turfs/f13concrete.dm
@@ -209,6 +209,7 @@ GLOBAL_LIST_INIT(concrete_recipes, list ( \
 	max_integrity = 450 //170 integ stronger than sandbags.
 	proj_pass_rate = 20
 	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	climbable = TRUE
 	smooth = SMOOTH_TRUE
 

--- a/code/game/turfs/f13concrete.dm
+++ b/code/game/turfs/f13concrete.dm
@@ -208,7 +208,6 @@ GLOBAL_LIST_INIT(concrete_recipes, list ( \
 	obj_integrity = 450
 	max_integrity = 450 //170 integ stronger than sandbags.
 	proj_pass_rate = 20
-	pass_flags = LETPASSTHROW
 	pass_flags_self = LETPASSTHROW
 	climbable = TRUE
 	smooth = SMOOTH_TRUE

--- a/code/modules/fallout/obj/structures/obstacle.dm
+++ b/code/modules/fallout/obj/structures/obstacle.dm
@@ -429,7 +429,7 @@
 	obj_integrity = 400
 	max_integrity = 400
 	proj_pass_rate = 90
-	pass_flags_self = LETPASSTHROW
+	//pass_flags_self = LETPASSTHROW
 
 /*
 /obj/structure/barricade/sandbags

--- a/code/modules/fallout/obj/structures/obstacle.dm
+++ b/code/modules/fallout/obj/structures/obstacle.dm
@@ -28,7 +28,7 @@
 	obj_integrity = 500
 	max_integrity = 500
 	proj_pass_rate = 90
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	climbable = TRUE
 
 /obj/structure/obstacle/old_locked_door
@@ -58,7 +58,7 @@
 	var/slowdown = 40
 	var/buildstacktype = /obj/item/stack/rods
 	var/buildstackamount = 5
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 
 /obj/structure/obstacle/barbedwire/end
 	icon_state = "barbed_end"
@@ -429,7 +429,7 @@
 	obj_integrity = 400
 	max_integrity = 400
 	proj_pass_rate = 90
-	pass_flags = LETPASSTHROW //Feed the prisoners, or not.
+	pass_flags_self = LETPASSTHROW
 
 /*
 /obj/structure/barricade/sandbags

--- a/code/modules/fallout/obj/structures/simple_door.dm
+++ b/code/modules/fallout/obj/structures/simple_door.dm
@@ -360,7 +360,7 @@
 	base_opacity = FALSE
 	can_hold_padlock = TRUE
 	proj_pass_rate = 95
-	pass_flags = LETPASSTHROW 
+	pass_flags_self = LETPASSTHROW 
 
 /obj/structure/simple_door/dirtyglass
 	desc = "The glass is dirty, you can't see a thing behind it."

--- a/code/modules/farming/farming_structures.dm
+++ b/code/modules/farming/farming_structures.dm
@@ -17,7 +17,6 @@
 	pressure_resistance = 2 * ONE_ATMOSPHERE
 	max_integrity = 300
 	proj_pass_rate = 70
-	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 	climbable = TRUE
 	var/open = FALSE
@@ -113,7 +112,6 @@
 	density = TRUE
 	anchored = TRUE
 	proj_pass_rate = 90
-	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 
 /obj/structure/loom/attackby(obj/item/I, mob/user)
@@ -160,7 +158,6 @@
 	reagent_id = /datum/reagent/compost
 	proj_pass_rate = 50
 	obj_integrity = 150
-	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 	climbable = TRUE
 	var/seed_default_value = 4
@@ -248,7 +245,6 @@
 	density = FALSE
 	anchored = TRUE
 	proj_pass_rate = 95
-	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 
 /obj/structure/legion_extractor/proc/seedify(obj/item/O, t_max, mob/living/user)
@@ -326,7 +322,6 @@
 	pressure_resistance = 2 * ONE_ATMOSPHERE
 	max_integrity = 160
 	proj_pass_rate = 80
-	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 	climbable = TRUE
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -244,7 +244,6 @@
 	active_power_usage = 600
 	visible_contents = FALSE
 	proj_pass_rate = 30
-	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 	var/drying = FALSE
 
@@ -640,7 +639,6 @@
 	icon_state = "seedbin"
 	max_n_of_items = 400
 	proj_pass_rate = 70
-	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 	var/climbable = TRUE
 
@@ -669,7 +667,6 @@
 	icon_state = "grownbin"
 	max_n_of_items = 1000
 	proj_pass_rate = 70
-	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 
 /obj/machinery/smartfridge/bottlerack/grownbin/accept_check(obj/item/O)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -153,7 +153,6 @@
 	density = FALSE
 	anchored = TRUE
 	buckle_lying = 0
-	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE
 	var/burning = 0
 	var/burn_icon = "bonfire_on_fire" //for a softer more burning embers icon, use "bonfire_warm"


### PR DESCRIPTION
## About The Pull Request
So some items had LETPASSTHROW (which lets thrown items pass over them) incorrectly assigned. This correctly assigns them, however this has the effect of allowing items to be thrown over sandbags, concrete, etc. 

This will have a big effect on defense balance. Additionally, tables no longer stop items being thrown over them.

Increases the cost of metal bars from 4 to 6 to compensate for their inability to be thrown over.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
