### PR TITLE
THE... Shield Nerf

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -205,13 +205,13 @@
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	var/repair_material = /obj/item/stack/sheet/plastic
-	var/can_shatter = FALSE
+	var/can_shatter = TRUE
 	shield_flags = SHIELD_FLAGS_DEFAULT | SHIELD_TRANSPARENT
-	max_integrity = 2250
+	max_integrity = 1000
 
 /datum/block_parry_data/shield/riot
 	block_damage_multiplier = 0.35
-	block_stamina_efficiency = 5
+	block_stamina_efficiency = 1
 	block_stamina_cost_per_second = 1
 	block_damage_absorption = 7.5
 
@@ -265,7 +265,7 @@ obj/item/shield/riot/bullet_proof
 	item_state = "shield_bulletproof"
 	block_parry_data = /datum/block_parry_data/shield/bulletproof
 	armor = list("melee" = 50, "bullet" = 90, "laser" = 50, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 70)
-	max_integrity = 1750
+	max_integrity = 1000
 	slowdown = 0.2
 	custom_materials = list(/datum/material/plastic=8000, /datum/material/titanium=1000)
 	repair_material = /obj/item/stack/sheet/mineral/titanium
@@ -334,6 +334,7 @@ obj/item/shield/riot/bullet_proof
 	block_damage_multiplier = 0.3
 	block_damage_absorption = 7.5
 	block_damage_limit = 30
+	block_stamina_efficiency = 1.5
 
 //Scrap shield. Somewhat cheaper, simpler and worse than Legion shield but basically similar.
 /obj/item/shield/riot/scrapshield
@@ -428,12 +429,12 @@ obj/item/shield/riot/bullet_proof
 	custom_materials = list(/datum/material/iron = 32000)
 	repair_material = /obj/item/stack/sheet/metal
 	shield_flags = SHIELD_FLAGS_HEAVY
-	max_integrity = 3000
+	max_integrity = 1000
 
 /datum/block_parry_data/shield/tower
 	block_slowdown = 0.75
 	block_damage_multiplier = 0.7
-	block_stamina_efficiency = 10
+	block_stamina_efficiency = 1
 	block_stamina_cost_per_second = 5
 	block_damage_absorption = 20
 	block_damage_limit = 160
@@ -448,11 +449,11 @@ obj/item/shield/riot/bullet_proof
 	shieldbash_stamdmg = 60
 	shield_flags = SHIELD_FLAGS_DEFAULT //no guaranteed kd on bash, sorry
 	block_parry_data = /datum/block_parry_data/shield/tower/scrap
-	max_integrity = 1500
+	max_integrity = 1000
 
 /datum/block_parry_data/shield/tower/scrap
 	block_damage_multiplier = 0.6
-	block_stamina_efficiency = 7.5
+	block_stamina_efficiency = 1
 	block_damage_absorption = 15
 
 /obj/item/shield/riot/tele


### PR DESCRIPTION
## About The Pull Request
Shields, specifically those that had 1000+ durability, have had said durability lowered substantially, generally by half. The stamina efficiency of said shields have also been reduced greatly, meaning most shields have a 1:1 translation of damage into stamina.

Right now, shields are, put bluntly, stupidly powerful. In dungeons, they can be used to negate most of the challenge by simply equipping a melee or handgun whilst using one to out-DPS any mob attacking you - this goes up to legendary deathclaws. In PVP, they're capable of soaking up massive amounts of damage, especially in team fights in which they have support - the scrap tower shield, a shield made with metal and cable coil, is currently capable of absorbing roughly 2000 damage with no risk to the user, due to the flat damage reduction it grants and miniscule amounts of stamina damage. Shields, with this nerf, are still good at what they're intended to do - defend, but not for incredibly long periods. Blocking 3 or 4 bullets is still possible - blocking a 60 round mag? Less so.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Shields across the board have had their stamina efficiency and durability lowered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
