### PR TITLE
Adjusts sonic jackhammer time and adds a sound

### DIFF
--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -52,7 +52,8 @@
 /turf/closed/wall/r_wall/try_destroy(obj/item/I, mob/user, turf/T)
 	if(istype(I, /obj/item/pickaxe/drill/jackhammer))
 		to_chat(user, span_notice("You begin to smash though [src]..."))
-		if(do_after(user, 150, target = src))
+		I.play_tool_sound(src)
+		if(do_after(user, 600, target = src))
 			if(!istype(src, /turf/closed/wall/r_wall))
 				return TRUE
 			I.play_tool_sound(src)


### PR DESCRIPTION
## About The Pull Request
Adjusts the sonic jackhammers time to drill through an R-wall to 1 minute and it now plays a sound upon starting the drilling. Still really, really good because it's only 1 sound at the start of the drilling instead of the usual sounds of deconstruction. 

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
