### PR TITLE
fixes senior paladin loadout

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -462,7 +462,7 @@ Senior Paladin
 /datum/outfit/loadout/spaladinc
 	name = "Senior Frontline Paladin"
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/aer12 = 1,
+		/obj/item/gun/energy/laser/aer14 = 1,
 		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/stock_parts/cell/ammo/mfc = 2,
 		/obj/item/stock_parts/cell/ammo/ec = 2


### PR DESCRIPTION
## About The Pull Request
bob intended to give the senior paladin an AER14 in #293 but forgor
![image](https://user-images.githubusercontent.com/46099003/208272108-cc51747d-17c6-4499-bdaf-5eb9bdcf1f58.png)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Senior Paladin loadout has been restored.
/:cl:
