### PR TITLE
Removes extra damage when you equip melee weapons

### DIFF
--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -647,8 +647,6 @@
 	if(ishuman(user) && slot == SLOT_GLOVES)
 		ADD_TRAIT(user, TRAIT_UNARMED_WEAPON, "glove")
 		if(HAS_TRAIT(user, TRAIT_UNARMED_WEAPON))
-			H.dna.species.punchdamagehigh = force + 8 //The +8 damage is what brings up your punch damage to the unarmed weapon's force fully
-			H.dna.species.punchdamagelow = force + 8
 			H.dna.species.attack_sound = hitsound
 			if(sharpness == SHARP_POINTY || sharpness ==  SHARP_EDGED)
 				H.dna.species.attack_verb = pick("slash","slice","rip","tear","cut","dice")

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -647,6 +647,8 @@
 	if(ishuman(user) && slot == SLOT_GLOVES)
 		ADD_TRAIT(user, TRAIT_UNARMED_WEAPON, "glove")
 		if(HAS_TRAIT(user, TRAIT_UNARMED_WEAPON))
+			H.dna.species.punchdamagehigh = force
+			H.dna.species.punchdamagelow = force
 			H.dna.species.attack_sound = hitsound
 			if(sharpness == SHARP_POINTY || sharpness ==  SHARP_EDGED)
 				H.dna.species.attack_verb = pick("slash","slice","rip","tear","cut","dice")


### PR DESCRIPTION
## About The Pull Request
You get 8 bonus melee damage when you wear items on your glove slots. This removes that extra damage as those items were not balanced with that in mind and are currently out performing most other melee weapons. Nerfs things like the mace glove, sappers, etc.

EDIT:
I understand that the "8" damage is accounting for your normal punch damage on top of the items damage, but these items simply weren't balanced with that extra 8 damage in mind.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
