### PR TITLE
Guns eject casings on the same tile they were fired from.

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -63,7 +63,6 @@
 	if(istype(AC)) //there's a chambered round
 		if(casing_ejector)
 			AC.forceMove(drop_location()) //Eject casing onto ground.
-			AC.bounce_away(TRUE, toss_direction = get_ejector_direction(user))
 			chambered = null
 		else if(empty_chamber)
 			chambered = null
@@ -342,14 +341,3 @@
 	if(istype(magazine,/obj/item/ammo_box/magazine/internal))
 		magazine?.max_ammo = initial(magazine?.max_ammo)
 	..()
-
-obj/item/gun/ballistic/proc/get_ejector_direction(mob/user)
-	if(user?.dir)
-		switch(handedness)
-			if(GUN_EJECTOR_RIGHT)
-				return turn(user.dir, -90)
-			if(GUN_EJECTOR_LEFT)
-				return turn(user.dir, -90)
-			if(GUN_EJECTOR_ANY)
-				return turn(user.dir, pick(-90, 90))
-	return angle2dir_cardinal(rand(0,360)) // something fucked up, just send a direction


### PR DESCRIPTION
## About The Pull Request
Guns now eject any ammo they shot on the tile they fired from. Prevents a lot of client-side lag, specifically sound and processing lag, might reduce server lag, prevents weird bugs such as people catching bullet casings and overall should be a good QoL change. I get it might not be great for muh immersion, but it'll help the server to run better.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Can no longer catch bullet casings.
code: Casings land on the same tile they were fired from.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
