### PR TITLE
Lore drop (Changed the year and time)

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(ticker)
 
 	/// Deciseconds to add to world.time for station time.
 	var/gametime_offset = OFFSET_INGAME_TIMER
-	var/station_time_rate_multiplier = 12		//factor of station time progressal vs real time.
+	var/station_time_rate_multiplier = 1		//factor of station time progressal vs real time.
 
 	var/totalPlayers = 0					//used for pregame stats on statpanel
 	var/totalPlayersReady = 0				//used for pregame stats on statpanel

--- a/code/modules/mapping/map_config.dm
+++ b/code/modules/mapping/map_config.dm
@@ -48,7 +48,7 @@
 		"ferry" = "ferry_fancy",
 		"emergency" = "emergency_pahrump")
 
-	var/year_offset = 540 //The offset of ingame year from the actual IRL year. You know you want to make a map that takes place in the 90's. Don't lie.
+	var/year_offset = 258 //The offset of ingame year from the actual IRL year. You know you want to make a map that takes place in the 90's. Don't lie.
 
 	// "fun things"
 	/// Orientation to load in by default.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -616,7 +616,7 @@ NIGHTSHIFT_TOGGLE_PUBLIC_REQUIRES_AUTH
 #RANDOMIZE_SHIFT_TIME
 
 ## Sets shift time to server time at roundstart. Overridden by RANDOMIZE_SHIFT_TIME ##
-#SHIFT_TIME_REALTIME
+SHIFT_TIME_REALTIME
 
 ## A cap on how many monkeys may be created via monkey cubes
 MONKEYCAP 64


### PR DESCRIPTION
## About The Pull Request
Changes the year to the NV Start-date and the time's now almost 1:1

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: fixed the year from 2562 to 2280 (Soon 2281 due to the New Year)
config: changed the time config setting that is now almost 1:1 with current time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
