### PR TITLE
Un-Bombening - Part One

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -405,6 +405,7 @@
 	name = "desert facewrap"
 	desc = "A facewrap commonly employed by NCR troops in desert environments."
 	icon_state = "ncr_facewrap"
+	clothing_flags = BLOCK_GAS_SMOKE_EFFECT
 	w_class = WEIGHT_CLASS_TINY
 	flags_inv = HIDEFACE
 	flags_cover = MASKCOVERSMOUTH

--- a/modular_atom/legio_invicta/code/legio_invicta.dm
+++ b/modular_atom/legio_invicta/code/legio_invicta.dm
@@ -115,6 +115,7 @@
 	name = "red bandana"
 	desc = "Simple cloth bandana dyed red. Very common in the Legion."
 	icon = 'modular_atom/legio_invicta/icons/icons_legion.dmi'
+	clothing_flags = BLOCK_GAS_SMOKE_EFFECT
 	mob_overlay_icon = 'modular_atom/legio_invicta/icons/onmob_legion.dmi'
 	righthand_file = 'modular_atom/legio_invicta/icons/onmob_legion_righthand.dmi'
 	lefthand_file = 'modular_atom/legio_invicta/icons/onmob_legion_lefthand.dmi'


### PR DESCRIPTION
## About The Pull Request
Common masks, specifically the Desert Facewrap and any bandana capable of being toggled (AKA: Legion Bandanas) inherit the gas mask's gas-blocking trait, indirectly making uncreative gas bombs ineffective. Why? Raptor preferred it to me just axing the smoke reaction, nobody has fun getting instantly round-removed by someone with an FEV/Mutagen gas bomb and it still KEEPS gas as a valid anti-personnel tool if you get a little creative with your mixes. Basically: forces people to either stop crutching on gas, or get creative with their mixes to not rely on ingesting toxins.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Facewrap/Bandanas now have the BLOCK_GAS_SMOKE_EFFECT trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
