### PR TITLE
adjusts "static PA gone" by adding unused [snowflake] armors to the pool

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -390,10 +390,8 @@
 				/obj/effect/spawner/bundle/f13/armor/t51b = 6,
 				/obj/effect/spawner/bundle/f13/armor/t45d = 8,
 				/obj/effect/spawner/bundle/f13/armor/t45b = 10,
-				/obj/effect/spawner/bundle/f13/armor/eliteriot = 20,
-				/obj/effect/spawner/bundle/f13/armor/desertriot = 20,
-				/obj/effect/spawner/bundle/f13/armor/policeriot = 20,
-				/obj/effect/spawner/bundle/f13/armor/environmental = 20
+				/obj/effect/spawner/bundle/f13/armor/eliteriot = 30,
+				/obj/effect/spawner/bundle/f13/armor/desertriot = 40,
 				)
 
 /obj/effect/spawner/bundle/f13/armor/environmental

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -383,15 +383,47 @@
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2/dark
 				)
 
-/obj/effect/spawner/lootdrop/f13/armor/tier4PA // TIER 4 ARMOR WITH PA
-	name = "tier 4 armor with possible PA"
+/obj/effect/spawner/lootdrop/f13/armor/tier4PA // Not actually tier4 but too lazy to rename/repath and remap. Use this very sparingly as it has PA.
+	name = "tier between 4 and 5 armor with possible PA"
 	loot = list(
-				/obj/effect/spawner/bundle/f13/armor/t45d,
-				/obj/effect/spawner/bundle/f13/armor/riot,
-				/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-				/obj/effect/spawner/bundle/f13/armor/combat/mk2/dark
+				/obj/effect/spawner/bundle/f13/armor/advanced = 4,
+				/obj/effect/spawner/bundle/f13/armor/t51b = 6,
+				/obj/effect/spawner/bundle/f13/armor/t45d = 8,
+				/obj/effect/spawner/bundle/f13/armor/t45b = 10,
+				/obj/effect/spawner/bundle/f13/armor/eliteriot = 20,
+				/obj/effect/spawner/bundle/f13/armor/desertriot = 20,
+				/obj/effect/spawner/bundle/f13/armor/policeriot = 20,
+				/obj/effect/spawner/bundle/f13/armor/environmental = 20
 				)
 
+/obj/effect/spawner/bundle/f13/armor/environmental
+	name = "environmental armor spawner"
+	items = list(
+				/obj/item/clothing/suit/armor/medium/combat/environmental,
+				/obj/item/clothing/head/helmet/f13/combat/environmental
+				)
+
+/obj/effect/spawner/bundle/f13/armor/eliteriot
+	name = "elite riot armor spawner"
+	items = list(
+				/obj/item/clothing/suit/armor/heavy/riot/elite,
+				/obj/item/clothing/head/helmet/f13/ncr/rangercombat/degancustom
+				) // whoever made the helmet into their donor item deserves death
+
+/obj/effect/spawner/bundle/f13/armor/desertriot
+	name = "desert ranger riot armor spawner"
+	items = list(
+				/obj/item/clothing/suit/armor/heavy/riot/marine,
+				/obj/item/clothing/head/helmet/f13/herbertranger
+				) // you too
+
+/obj/effect/spawner/bundle/f13/armor/policeriot
+	name = "police riot armor spawner"
+	items = list(
+				/obj/item/clothing/suit/armor/heavy/riot/police,
+				/obj/item/clothing/head/helmet/f13/combat/rangerbroken
+				)
+				
 /obj/effect/spawner/bundle/f13/armor/t45b_salvaged
 	name = "salvaged t45b power armor spawner"
 	items = list(
@@ -449,6 +481,13 @@
 				/obj/effect/spawner/bundle/f13/armor/t51b,
 				)
 
+/obj/effect/spawner/bundle/f13/armor/t45b
+	name = "t45b power armor spawner"
+	items = list(
+				/obj/item/clothing/suit/armor/power_armor/t45b,
+				/obj/item/clothing/head/helmet/f13/power_armor/t45b,
+				)
+
 /obj/effect/spawner/bundle/f13/armor/t45d
 	name = "t45d power armor spawner"
 	items = list(
@@ -463,6 +502,12 @@
 				/obj/item/clothing/head/helmet/f13/power_armor/t51b,
 				)
 
+/obj/effect/spawner/bundle/f13/armor/advanced
+	name = "advanced power armor spawner"
+	items = list(
+				/obj/item/clothing/suit/armor/power_armor/advanced,
+				/obj/item/clothing/head/helmet/f13/power_armor/advanced,
+				)
 
 /obj/effect/spawner/lootdrop/f13/armor/random
 	name = "random armor loot"
@@ -607,10 +652,8 @@
 		/obj/item/reagent_containers/glass/beaker/meta = 5,
 		/obj/item/stack/sheet/mineral/abductor/ten = 5,
 		/obj/item/scalpel/advanced = 5,
-		/obj/item/surgical_drapes/advanced = 5,
 		/obj/effect/spawner/bundle/f13/needler = 5,
 		/obj/item/clothing/glasses/night = 5,
-		/obj/item/circuitboard/machine/chem_dispenser/apothecary = 5,
 		/obj/item/storage/box/stockparts/deluxe = 5,
 		/obj/item/storage/box/emps = 5,
 		/obj/item/organ/cyberimp/arm/janitor = 5,


### PR DESCRIPTION
## About The Pull Request
Essentially adds several gimmick/unique armors to the "tier4PA" pool, most of which are "ranger" riot armors. 

I'm unsure how the weight system works but if it's just an average of all the defined weights, PA keeps its 25~ish% likelihood of appearing (though you're most likely getting t45b).

Suggest adjustments in the comments.

Specifically: Advanced Power Armor with a weight of 4 (less than Guns & Bullets, Part Five.)
T51b with a weight of 6 (50% more likely to appear than APA),
T45d with a weight of 8 (100% more likely to appear than APA)
T45b with a weight of 10 (150% more likely to appear than APA)
Elite Riot Armor [stats unchanged, equal to regular riot armor] (400% more likely to appear than APA)
Desert Ranger Armor (600% more likely to appear than APA)

Statistically, there are only two of these spawns on the map. Assuming the average round is 3 hours, mathematically that means you'll only see a set of APA or T51b outside of brotherhood hands in 36 hour intervals. (Since getting it is about a 1/12 round chance, IF you clear both bunkers. You'd only see it once every 72 hours assuming someone was clearing the same bunker every single round, around the clock.)

Mob AI was recently fixed and there are plans to have dungeon mobs execute you in crit. Since this doesn't actually change the statistics of getting PA, this shouldn't be a problem.

I also removed the apothecary board and smart surgical drapes from the "good science loot" because they don't work.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: tier4PA has been diversified.
fix: broken items were removed from the science pool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
