### PR TITLE
nerfs bottled patron, changes goldschlager ratio

### DIFF
--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -53,7 +53,7 @@
 								/obj/item/export/bottle/trappist = 10,
 								/obj/item/export/bottle/minikeg = 10,
 								/obj/item/export/bottle/nukashine = 10,
-								/obj/item/export/bottle/patron = 35,
+								/obj/item/export/bottle/patron = 15,
 								/obj/item/export/bottle/goldschlager = 45,
 								)
 

--- a/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
+++ b/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
@@ -3,8 +3,8 @@
 /datum/chemical_reaction/goldschlager
 	name = "Goldschlager"
 	id = /datum/reagent/consumable/ethanol/goldschlager
-	results = list(/datum/reagent/consumable/ethanol/goldschlager = 10)
-	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 10, /datum/reagent/gold = 1)
+	results = list(/datum/reagent/consumable/ethanol/goldschlager = 2)
+	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/gold = 1)
 
 /datum/chemical_reaction/patron
 	name = "Patron"


### PR DESCRIPTION
## About The Pull Request
Goldschlager is a tedious way to turn each gold ~~80%~~ (i fucked up and i'm not recommitting) 160% more profitable on average than selling it in a vendor now, rather than being 1800% more profitable [you could make four bottles with a single ingot of gold.]

Nerfs patron to 15 caps because it is easily mass produceable with a chemistry dispenser, slightly more profitable than nukashine because you need science knowledge to do so..

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: We took bottling out back and shot it in the head.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
