### PR TITLE
Renames NCR's "off-duty" to "rear echelon"

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -1177,7 +1177,7 @@ Access
 // Basically off-duty and civilian-tier roles. May removed civilian-tier roles at a later date. Allows RP value for now. - Rebel0
 
 /datum/job/ncr/f13offdutyncr
-	title = "NCR Off-Duty"
+	title = "NCR Rear Echelon"
 	flag = F13OFFDUTYNCR
 	total_positions = 4
 	spawn_positions = 4
@@ -1192,7 +1192,7 @@ Access
 	exp_requirements = 60
 
 /datum/outfit/job/ncr/f13offdutyncr
-	name = "NCR Off-Duty"
+	name = "NCR Rear Echelon"
 	jobtype	= /datum/job/ncr/f13offdutyncr
 	id = /obj/item/card/id/dogtag/ncrtrooper
 	head = null


### PR DESCRIPTION
## About The Pull Request
I got asked to. Title's simple.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: NCR Off-Duty is called Rear Echelon.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
