### PR TITLE
Rubbery shotgun nerf

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -428,6 +428,7 @@ GLOBAL_LIST_INIT(main_body_parts, list(
 
 /// Rubber wound modifier defines
 /// intended to break bones, dont make beanbags sharp or everyone dies
+// these ammos are usually very over powered unless balanced some other way
 #define RUBBERY_WOUND_PISTOL_LIGHT (BULLET_WOUND_PISTOL_LIGHT)
 #define RUBBERY_WOUND_PISTOL_MEDIUM (BULLET_WOUND_PISTOL_MEDIUM * 1.5)
 #define RUBBERY_WOUND_PISTOL_HEAVY (BULLET_WOUND_PISTOL_HEAVY * 1.5)
@@ -435,7 +436,7 @@ GLOBAL_LIST_INIT(main_body_parts, list(
 #define RUBBERY_WOUND_RIFLE_MEDIUM (BULLET_WOUND_RIFLE_MEDIUM * 2)
 #define RUBBERY_WOUND_RIFLE_HEAVY (BULLET_WOUND_RIFLE_HEAVY * 5) // If this starts ripping off limbs... good~
 #define RUBBERY_WOUND_SHOTGUN_PELLET (-BULLET_WOUND_SHOTGUN_PELLET * 0.1) // cus negative
-#define RUBBERY_WOUND_SHOTGUN_SLUG (BULLET_WOUND_SHOTGUN_SLUG * 3)
+#define RUBBERY_WOUND_SHOTGUN_SLUG (BULLET_WOUND_SHOTGUN_SLUG)
 
 /// Bullet wound falloff defines
 #define BULLET_WOUND_FALLOFF_PISTOL_LIGHT 0

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -172,8 +172,8 @@
  * DAMAGE: 5
  * STAMIN: 100
  * RECOIL: 2
- * WOUNDS: 120
- * WNAKED: 90
+ * WOUNDS: 40
+ * WNAKED: 30
  */
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
@@ -195,7 +195,7 @@
  * DAMAGE: 25
  * STAMIN: 50
  * RECOIL: 2
- * WOUNDS: 120
+ * WOUNDS: 40
  * WNAKED: 0
  */
 /obj/item/projectile/bullet/incendiary/shotgun
@@ -277,8 +277,8 @@
  * DAMAGE: 5
  * STAMIN: 100
  * RECOIL: 2
- * WOUNDS: 120
- * WNAKED: 90
+ * WOUNDS: 40
+ * WNAKED: 30
  */
 /obj/item/projectile/bullet/shotgun_stunslug
 	name = "stunslug"

--- a/modular_atom/blacksmith/additions.dm
+++ b/modular_atom/blacksmith/additions.dm
@@ -10,9 +10,9 @@
 
 #define QUALITY_MODIFIER quality
 
-#define FORCE_SMITH_REACH 15
-#define FORCE_SMITH_LOW 19
-#define FORCE_SMITH_HIGH 24
+#define FORCE_SMITH_REACH 19
+#define FORCE_SMITH_LOW 24
+#define FORCE_SMITH_HIGH 29
 
 
 //////////////////////////////////////

--- a/modular_atom/blacksmith/additions.dm
+++ b/modular_atom/blacksmith/additions.dm
@@ -10,9 +10,9 @@
 
 #define QUALITY_MODIFIER quality
 
-#define FORCE_SMITH_REACH 19
-#define FORCE_SMITH_LOW 24
-#define FORCE_SMITH_HIGH 29
+#define FORCE_SMITH_REACH 15
+#define FORCE_SMITH_LOW 19
+#define FORCE_SMITH_HIGH 24
 
 
 //////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request
Nerfs the wounding from rubbery shotguns from 120 to 40. 120 wounds causes limbs to break in 1 shot, if not completely blow off. They're still strong, just not blow off someone's arm in 1 hit strong.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
