### PR TITLE
Removes Digitigrade legs from spawning on corpses

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -152,7 +152,7 @@
 		"ears"				= "None",
 		"frills"			= pick(GLOB.frills_list),
 		"spines"			= pick(GLOB.spines_list),
-		"legs"				= pick("Plantigrade","Digitigrade"),
+		"legs"				= "Plantigrade",
 		"caps"				= pick(GLOB.caps_list),
 		"insect_wings"		= pick(GLOB.insect_wings_list),
 		"insect_fluff"		= "None",

--- a/modular_atom/blacksmith/additions.dm
+++ b/modular_atom/blacksmith/additions.dm
@@ -10,9 +10,9 @@
 
 #define QUALITY_MODIFIER quality
 
-#define FORCE_SMITH_REACH 15
-#define FORCE_SMITH_LOW 19
-#define FORCE_SMITH_HIGH 24
+#define FORCE_SMITH_REACH 19
+#define FORCE_SMITH_LOW 24
+#define FORCE_SMITH_HIGH 29
 
 
 //////////////////////////////////////

--- a/modular_atom/blacksmith/additions.dm
+++ b/modular_atom/blacksmith/additions.dm
@@ -10,9 +10,9 @@
 
 #define QUALITY_MODIFIER quality
 
-#define FORCE_SMITH_REACH 19
-#define FORCE_SMITH_LOW 24
-#define FORCE_SMITH_HIGH 29
+#define FORCE_SMITH_REACH 15
+#define FORCE_SMITH_LOW 19
+#define FORCE_SMITH_HIGH 24
 
 
 //////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request
Removes the ability for digitigrade legs to spawn on corpses.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
