### PR TITLE
Re-adds the Knucklegun, Knifegun and Zip gun recipes back

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -461,6 +461,19 @@
 	subcategory = CAT_WEAPON
 
 //Hobo Guns
+
+/datum/crafting_recipe/gun/zipgun
+	name = "Zip gun (9mm)"
+	result = /obj/item/gun/ballistic/automatic/hobo/zipgun
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
+				/obj/item/stack/rods = 1,
+				/obj/item/ammo_casing/c9mm = 5,
+				/obj/item/stack/crafting/metalparts = 1)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/gun/pepperbox
 	name = "Pepperbox gun (10mm)"
 	result = /obj/item/gun/ballistic/revolver/hobo/pepperbox
@@ -491,6 +504,30 @@
 	/obj/item/stack/crafting/metalparts = 2,
 	/obj/item/stack/sheet/cloth = 1,
 	/obj/item/stack/sheet/mineral/wood = 2)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/gun/knifegun
+	name = "Knife gun (.44)"
+	result = /obj/item/gun/ballistic/revolver/hobo/knifegun
+	reqs = list(/obj/item/scalpel = 1,
+				/obj/item/stack/rods = 1,
+				/obj/item/ammo_casing/m44 = 1,
+				/obj/item/restraints/handcuffs/cable = 1)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/gun/knucklegun
+	name = "Knucklegun (.45)"
+	result = /obj/item/gun/ballistic/revolver/hobo/knucklegun
+	reqs = list(/obj/item/stack/sheet/metal = 5,
+				/obj/item/stack/rods = 4,
+				/obj/item/ammo_casing/c45 = 4,
+				/obj/item/stack/crafting/metalparts = 1)
 	tools = list(TOOL_WORKBENCH)
 	time = 120
 	category = CAT_WEAPONRY


### PR DESCRIPTION
## About The Pull Request
Adds back these 3 things from the Hobomat PR that do not relate to the Hobomat and were an OK change

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added the Knucklegun crafting recipe back
add: Added the Zip gun crafting recipe back
add: Added the Knifegun crafting recipe back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
