### PR TITLE
Removes Ranger Takedown.

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -511,8 +511,8 @@ Access
 	ADD_TRAIT(H, TRAIT_SILENT_STEP, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_FAST_PUMP, src)
-	var/datum/martial_art/rangertakedown/RT = new
-	RT.teach(H)
+/*	var/datum/martial_art/rangertakedown/RT = new
+	RT.teach(H) */
 
 /datum/outfit/job/ncr/f13vetranger
 	name = "NCR Veteran Ranger"
@@ -597,8 +597,8 @@ Access
 	ADD_TRAIT(H, TRAIT_LIGHT_STEP, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_FAST_PUMP, src)
-	var/datum/martial_art/rangertakedown/RT = new
-	RT.teach(H)
+/*	var/datum/martial_art/rangertakedown/RT = new
+	RT.teach(H) */
 
 
 /datum/outfit/job/ncr/f13ranger


### PR DESCRIPTION
## About The Pull Request
It currently ignores the STUNIMMUNE flag, stun combat isn't generally fun and honestly I can't be bothered to recode it to abide to standard stun parameters.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: The library of Bearlexandria was burnt to the ground, with it the knowledge of the Ranger Takedown was lost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
