### PR TITLE
Makes EMPs debilitating to PA again, brings BD level armor values back.

### DIFF
--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -325,9 +325,9 @@
 		"damage_threshold" = 16)
 
 #define ARMOR_VALUE_PA list(\
-		"melee" = 50, \
-		"bullet" = 50, \
-		"laser" = 50, \
+		"melee" = 80, \
+		"bullet" = 70, \
+		"laser" = 30, \
 		"energy" = 25, \
 		"bomb" = 40, \
 		"bio" = 100, \

--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -314,7 +314,7 @@
 #define ARMOR_VALUE_SALVAGE list(\
 		"melee" = 45, \
 		"bullet" = 45, \
-		"laser" = 45, \
+		"laser" = 25, \
 		"energy" = 25, \
 		"bomb" = 40, \
 		"bio" = 80, \

--- a/code/modules/clothing/suits/power_armor.dm
+++ b/code/modules/clothing/suits/power_armor.dm
@@ -297,8 +297,8 @@
 			else
 				induced_slowdown = 8
 				to_chat(L, span_warning("Warning: light electromagnetic surge detected in armor. Rerouting power to emergency systems."))
-			armor = armor.modifyRating(melee = -40, bullet = -40, laser = -25, energy = -25)
 			emped = TRUE
+			armor = armor.modifyRating(melee = -40, bullet = -40, laser = -25, energy = -25)
 			slowdown += induced_slowdown
 			L.update_equipment_speed_mods()
 			addtimer(CALLBACK(src, .proc/end_emp_effect, induced_slowdown), 100) // this used to last a minute on BD

--- a/code/modules/clothing/suits/power_armor.dm
+++ b/code/modules/clothing/suits/power_armor.dm
@@ -292,20 +292,22 @@
 			var/mob/living/L = loc
 			var/induced_slowdown = 0
 			if(severity >= 41) //heavy emp
-				induced_slowdown = 4
+				induced_slowdown = 16
 				to_chat(L, span_boldwarning("Warning: severe electromagnetic surge detected in armor. Rerouting power to emergency systems."))
 			else
-				induced_slowdown = 2
+				induced_slowdown = 8
 				to_chat(L, span_warning("Warning: light electromagnetic surge detected in armor. Rerouting power to emergency systems."))
+			armor = armor.modifyRating(melee = -40, bullet = -40, laser = -25, energy = -25)
 			emped = TRUE
 			slowdown += induced_slowdown
 			L.update_equipment_speed_mods()
-			addtimer(CALLBACK(src, .proc/end_emp_effect, induced_slowdown), 50)
+			addtimer(CALLBACK(src, .proc/end_emp_effect, induced_slowdown), 100) // this used to last a minute on BD
 	return
 
 /obj/item/clothing/suit/armor/power_armor/proc/end_emp_effect(slowdown_induced)
 	emped = FALSE
 	slowdown -= slowdown_induced // Even if armor is dropped it'll fix slowdown
+	armor = armor.modifyRating(melee = 40, bullet = 40, laser = 25, energy = 25)
 	if(isliving(loc))
 		var/mob/living/L = loc
 		to_chat(L, span_warning("Armor power reroute successful. All systems operational."))


### PR DESCRIPTION
## About The Pull Request
I would prefer to merge this alongside #400 due to the fact that the pulse rifle didn't exist on BD.

Stat changes are the following.

MELEE: 50 > 80
BULLET 50 > 70
LASER 50 > 30
ENERGY 25 > 25

EMP slowdown is much more brutal and twice as long, lowering armor (to combat armor level) as well. Laser armor was nerfed because it was the lowest protection in BD and the preferred method for taking down BoS then. Could raise it if you think its too low given the EMP buffs.


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Kill your local Paladin with uranium and iron.
/:cl:
