### PR TITLE
The statattackening, or how I learned to stop worrying and love the mob execution

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -21,7 +21,7 @@
 	robust_searching = TRUE
 	maxHealth = 120
 	health = 120
-	stat_attack = 1
+	stat_attack = 2
 	blood_volume = 0
 	del_on_death = TRUE
 	healable = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -21,6 +21,7 @@
 	robust_searching = TRUE
 	maxHealth = 120
 	health = 120
+	stat_attack = 1
 	blood_volume = 0
 	del_on_death = TRUE
 	healable = FALSE
@@ -127,11 +128,11 @@
 	health = 400 //13~ hits of 5.56
 	maxHealth = 400
 	del_on_death = FALSE
-	melee_damage_lower = 28
+	melee_damage_lower = 40
 	melee_damage_upper = 65
 	extra_projectiles = 4 //5 projectiles
 	ranged_cooldown_time = 12 //brrrrrrrrrrrrt
-	retreat_distance = 0
+	retreat_distance = 2
 	minimum_distance = 2
 	attack_verb_simple = "pulverizes"
 	attack_sound = 'sound/weapons/punch1.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
@@ -33,7 +33,7 @@
 	attack_verb_simple = "whipped"
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 20
-	stat_attack = 1
+	stat_attack = 2
 	gold_core_spawnable = HOSTILE_SPAWN
 	faction = list("hostile", "supermutant")
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/human/centaur = 3,
@@ -84,6 +84,7 @@
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	robust_searching = TRUE
+	stat_attack = 2
 	attack_verb_simple = "eviscerates"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	speak_emote = list("screams", "clicks", "chitters", "barks", "moans", "growls", "meows", "reverberates", "roars", "squeaks", "rattles", "exclaims", "yells", "remarks", "mumbles", "jabbers", "stutters", "seethes")
@@ -142,6 +143,7 @@
 	speed = -0.5
 	maxHealth = 700
 	health = 700
+	stat_attack = 2
 	harm_intent_damage = 8
 	melee_damage_lower = 50
 	melee_damage_upper = 50

--- a/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
@@ -33,7 +33,7 @@
 	attack_verb_simple = "whipped"
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 20
-	stat_attack = CONSCIOUS
+	stat_attack = 1
 	gold_core_spawnable = HOSTILE_SPAWN
 	faction = list("hostile", "supermutant")
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/human/centaur = 3,

--- a/code/modules/mob/living/simple_animal/hostile/f13/chinese.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/chinese.dm
@@ -23,7 +23,7 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/chineseremnant, /obj/item/melee/onehanded/knife/survival)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 15
-	stat_attack = 1
+	stat_attack = 2
 	faction = list("china")
 	check_friendly_fire = 1
 	status_flags = CANPUSH

--- a/code/modules/mob/living/simple_animal/hostile/f13/chinese.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/chinese.dm
@@ -23,6 +23,7 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/chineseremnant, /obj/item/melee/onehanded/knife/survival)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 15
+	stat_attack = 1
 	faction = list("china")
 	check_friendly_fire = 1
 	status_flags = CANPUSH

--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -24,7 +24,7 @@
 	a_intent = INTENT_HARM //So we can not move past them.
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	robust_searching = TRUE
-	stat_attack = 1
+	stat_attack = 2
 	speak = list("ROAR!","Rawr!","GRRAAGH!","Growl!")
 	speak_emote = list("growls", "roars")
 	emote_hear = list("grumbles.","grawls.")

--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -24,6 +24,7 @@
 	a_intent = INTENT_HARM //So we can not move past them.
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	robust_searching = TRUE
+	stat_attack = 1
 	speak = list("ROAR!","Rawr!","GRRAAGH!","Growl!")
 	speak_emote = list("growls", "roars")
 	emote_hear = list("grumbles.","grawls.")
@@ -60,7 +61,6 @@
 	gender = FEMALE
 	maxHealth = 800
 	health = 800
-	stat_attack = CONSCIOUS
 	melee_damage_lower = 50
 	melee_damage_upper = 55
 	footstep_type = FOOTSTEP_MOB_HEAVY
@@ -75,7 +75,6 @@
 	maxHealth = 1200
 	health = 1200
 	color = "#FFFF00"
-	stat_attack = CONSCIOUS
 	melee_damage_lower = 55
 	melee_damage_upper = 55
 	footstep_type = FOOTSTEP_MOB_HEAVY
@@ -96,7 +95,6 @@
 	icon_dead = "combatclaw_dead"
 	maxHealth = 2500
 	health = 2500
-	stat_attack = CONSCIOUS
 	melee_damage_lower = 70
 	melee_damage_upper = 80
 	footstep_type = FOOTSTEP_MOB_HEAVY

--- a/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
@@ -130,5 +130,6 @@
 	auto_fire_delay = MOB_AUTOFIRE_DELAY_SLOWER
 	melee_damage_lower = 5
 	melee_damage_upper = 10
+	stat_attack = 1
 	minimum_distance = 4
 	retreat_distance = 6

--- a/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
@@ -130,6 +130,6 @@
 	auto_fire_delay = MOB_AUTOFIRE_DELAY_SLOWER
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	stat_attack = 1
+	stat_attack = 2
 	minimum_distance = 4
 	retreat_distance = 6

--- a/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
@@ -15,7 +15,7 @@
 	response_disarm_simple = "shoves"
 	response_harm_simple = "hits"
 	speed = 1
-	stat_attack = 1
+	stat_attack = 2
 	robust_searching = 1
 	maxHealth = 100
 	health = 100
@@ -140,7 +140,7 @@
 	speed = 0
 	ranged_cooldown_time = 22
 	extra_projectiles = 2
-	stat_attack = 1
+	stat_attack = 2
 	ranged = TRUE
 	robust_searching = TRUE
 	healable = TRUE
@@ -278,7 +278,7 @@
 	response_disarm_simple = "shoves"
 	response_harm_simple = "hits"
 	speed = 1
-	stat_attack = 1
+	stat_attack = 2
 	robust_searching = 1
 	maxHealth = 200
 	health = 200
@@ -385,7 +385,7 @@
 	response_disarm_simple = "shoves"
 	response_harm_simple = "hits"
 	speed = 1
-	stat_attack = 1
+	stat_attack = 2
 	robust_searching = 1
 	maxHealth = 120
 	health = 120
@@ -490,7 +490,7 @@
 	response_disarm_simple = "shoves"
 	response_harm_simple = "hits"
 	speed = 1
-	stat_attack = 1
+	stat_attack = 2
 	robust_searching = 1
 	maxHealth = 120
 	health = 120
@@ -597,7 +597,7 @@
 	response_disarm_simple = "shoves"
 	response_harm_simple = "hits"
 	speed = 1
-	stat_attack = 1
+	stat_attack = 2
 	robust_searching = 1
 	maxHealth = 160
 	health = 160

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -166,7 +166,7 @@
 	harm_intent_damage = 8
 	melee_damage_lower = 25
 	melee_damage_upper = 35
-	stat_attack = 1
+	stat_attack = 2
 	mob_size = 5
 	wound_bonus = 0
 	bare_wound_bonus = 0

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -166,6 +166,7 @@
 	harm_intent_damage = 8
 	melee_damage_lower = 25
 	melee_damage_upper = 35
+	stat_attack = 1
 	mob_size = 5
 	wound_bonus = 0
 	bare_wound_bonus = 0

--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -105,6 +105,7 @@
 	maxHealth = 450
 	health = 450
 	speed = 1.2
+	stat_attack = 1
 	obj_damage = 300
 	aggro_vision_range = 15
 	rapid_melee = 1
@@ -118,6 +119,7 @@
 	color = "#FFFF00"
 	maxHealth = 480
 	health = 480
+	stat_attack = 1
 	retreat_distance = 1
 	minimum_distance = 2
 	projectiletype = /obj/item/projectile/bullet/m44
@@ -147,6 +149,7 @@
 	icon_dead = "raiderboss_dead"
 	maxHealth = 137
 	health = 136
+	stat_attack = 1
 	extra_projectiles = 3
 	rapid_melee = 1
 	projectiletype = /obj/item/projectile/bullet/c45/op
@@ -376,6 +379,7 @@
 	icon_dead = "junker_dead"
 	maxHealth = 360
 	health = 360
+	stat_attack = 1
 	ranged = TRUE
 	retreat_distance = 4
 	minimum_distance = 6

--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -105,7 +105,7 @@
 	maxHealth = 450
 	health = 450
 	speed = 1.2
-	stat_attack = 1
+	stat_attack = 2
 	obj_damage = 300
 	aggro_vision_range = 15
 	rapid_melee = 1
@@ -119,7 +119,7 @@
 	color = "#FFFF00"
 	maxHealth = 480
 	health = 480
-	stat_attack = 1
+	stat_attack = 2
 	retreat_distance = 1
 	minimum_distance = 2
 	projectiletype = /obj/item/projectile/bullet/m44
@@ -149,7 +149,7 @@
 	icon_dead = "raiderboss_dead"
 	maxHealth = 137
 	health = 136
-	stat_attack = 1
+	stat_attack = 2
 	extra_projectiles = 3
 	rapid_melee = 1
 	projectiletype = /obj/item/projectile/bullet/c45/op
@@ -379,7 +379,7 @@
 	icon_dead = "junker_dead"
 	maxHealth = 360
 	health = 360
-	stat_attack = 1
+	stat_attack = 2
 	ranged = TRUE
 	retreat_distance = 4
 	minimum_distance = 6

--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -12,7 +12,7 @@
 	speak = list("GRRRRRR!", "ARGH!", "NNNNNGH!", "HMPH!", "ARRRRR!")
 	speak_emote = list("shouts", "yells")
 	move_to_delay = 5
-	stat_attack = CONSCIOUS
+	stat_attack = 1
 	robust_searching = 1
 	environment_smash = ENVIRONMENT_SMASH_WALLS
 	emote_taunt_sound = list('sound/f13npc/supermutant/attack1.ogg', 'sound/f13npc/supermutant/attack2.ogg', 'sound/f13npc/supermutant/attack3.ogg')

--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -12,7 +12,7 @@
 	speak = list("GRRRRRR!", "ARGH!", "NNNNNGH!", "HMPH!", "ARRRRR!")
 	speak_emote = list("shouts", "yells")
 	move_to_delay = 5
-	stat_attack = 1
+	stat_attack = 2
 	robust_searching = 1
 	environment_smash = ENVIRONMENT_SMASH_WALLS
 	emote_taunt_sound = list('sound/f13npc/supermutant/attack1.ogg', 'sound/f13npc/supermutant/attack2.ogg', 'sound/f13npc/supermutant/attack3.ogg')

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -67,6 +67,7 @@
 	maxHealth = 140
 	melee_damage_lower = 20
 	melee_damage_upper = 72
+	stat_attack = 1
 	attack_sound = 'sound/items/welder.ogg'
 	attack_verb_simple = "shoots a burst of flame at"
 	projectilesound = 'sound/weapons/laser.ogg'
@@ -340,6 +341,7 @@
 	health = 160
 	mob_biotypes = MOB_ROBOTIC|MOB_INORGANIC
 	maxHealth = 160
+	stat_attack = 1
 	speed = 0
 	melee_damage_lower = 25
 	melee_damage_upper = 60

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -67,7 +67,7 @@
 	maxHealth = 140
 	melee_damage_lower = 20
 	melee_damage_upper = 72
-	stat_attack = 1
+	stat_attack = 2
 	attack_sound = 'sound/items/welder.ogg'
 	attack_verb_simple = "shoots a burst of flame at"
 	projectilesound = 'sound/weapons/laser.ogg'
@@ -341,7 +341,7 @@
 	health = 160
 	mob_biotypes = MOB_ROBOTIC|MOB_INORGANIC
 	maxHealth = 160
-	stat_attack = 1
+	stat_attack = 2
 	speed = 0
 	melee_damage_lower = 25
 	melee_damage_upper = 60


### PR DESCRIPTION
## About The Pull Request
This applies stat_attack 2 to most dungeon mobs, making them execute people in critical condition. Alternative to #346, though that's since been closed. Some legendary mobs, like the legendary ghoul and raider get it too since they're... well, legendary. And also exclusively used inside dungeons.

Also tweaks sentry bots so they aren't cheesable with melee.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Abandon all hope ye who enter here, dungeon mobs will now execute you when you make mistakes. Good luck sleeping out of that.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
