### PR TITLE
Tweaks faction loadout items and fixes most of the unused job names in job

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -51,38 +51,20 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 			heirloom_type = /obj/item/gun/ballistic/automatic/toy/pistol
 		if("BoS Off-Duty")
 			heirloom_type = /obj/item/toy/figure/borg
-		if("Marshal")
+		if("Provost Marshal")
 			heirloom_type = /obj/item/clothing/accessory/medal/silver
-		if("Deputy")
+		if("Deputy Marshal")
 			heirloom_type = /obj/item/clothing/accessory/medal/bronze_heart
-		if("Shopkeeper")
+		if("Merchant")
 			heirloom_type = /obj/item/coin/plasma
-		if("Followers Doctor")
-			heirloom_type = pick(/obj/item/clothing/neck/stethoscope,/obj/item/toy/tragicthegarnering)
-		if("Followers Administrator")
+		if("Director")
 			heirloom_type = pick(/obj/item/toy/nuke, /obj/item/wrench/medical, /obj/item/clothing/neck/tie/horrible)
 		if("Prime Legionnaire")
 			heirloom_type = pick(/obj/item/melee/onehanded/machete, /obj/item/melee/onehanded/club/warclub, /obj/item/clothing/accessory/talisman, /obj/item/toy/plush/mr_buckety)
 		if("Recruit Legionnaire")
 			heirloom_type = pick(/obj/item/melee/onehanded/machete, /obj/item/melee/onehanded/club/warclub, /obj/item/clothing/accessory/talisman,/obj/item/clothing/accessory/skullcodpiece/fake)
-		if("Den Mob Boss")
+		if("Desperado Leader")
 			heirloom_type = /obj/item/lighter/gold
-		if("Den Doctor")
-			heirloom_type = /obj/item/card/id/dogtag/MDfakepermit
-		if("Farmer")
-			heirloom_type = pick(/obj/item/hatchet, /obj/item/shovel/spade)
-		if("Janitor")
-			heirloom_type = /obj/item/mop
-		if("Security Officer")
-			heirloom_type = /obj/item/clothing/accessory/medal/silver/valor
-		if("Scientist")
-			heirloom_type = /obj/item/toy/plush/slimeplushie
-		if("Assistant")
-			heirloom_type = /obj/item/clothing/gloves/cut/family
-		if("Chaplain")
-			heirloom_type = /obj/item/camera/spooky/family
-		if("Captain")
-			heirloom_type = /obj/item/clothing/accessory/medal/gold/captain/family
 		if("Great Khan")
 			heirloom_type = pick(/obj/item/melee/onehanded/knife/switchblade, /obj/item/melee/onehanded/machete, /obj/item/clothing/mask/bandana/red)
 		if("Far-Lands Tribals")

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -886,14 +886,6 @@
 	item_state = "silver_id"
 	desc = "A rewritable card that allows you to put your name and assignment on it."
 
-/obj/item/card/id/dogtag/vigilante
-	name = "vigilante's badge"
-	desc = "An old silver badge."
-	assignment = "Vigilante"
-	icon_state = "deputy"
-	item_state = "badge-deputy"
-
-
 /obj/item/card/id/dogtag/deputy
 	name = "deputy's badge"
 	desc = "A silver badge which shows honour and dedication."
@@ -934,11 +926,6 @@
 	assignment = "citizenship permit"
 	access = list(ACCESS_BAR)
 
-/obj/item/card/id/dogtag/MDfakepermit
-	name = "faded medical license"
-	desc = "a revoked medical license. This is why we do not remove people's skeletons "
-	access = list()
-
 /obj/item/card/id/dogtag/town/ncr
 	name = "NCR citizenship permit"
 	desc = "A permit identifying the holder as a citizen of the New California Republic."
@@ -975,16 +962,9 @@
 			update_label()
 	return ..()
 
-/obj/item/card/id/dogtag/ncrambassador
-	name = "ambassador's permit"
-	desc = "An silver encrusted ambassador's permit in a plastic holder."
-	icon_state = "silver"
-	item_state = "silver"
-	assignment = "ambassador's permit"
-
-/obj/item/card/id/dogtag/ncradmin
-	name = "administrators ID"
-	desc = "An silver encrusted admins ID in a plastic holder."
+/obj/item/card/id/dogtag/ncrrep
+	name = "representative's ID"
+	desc = "An silver encrusted representatives ID in a plastic holder."
 	icon_state = "silver"
 	item_state = "silver"
 
@@ -995,23 +975,13 @@
 
 /obj/item/card/id/dogtag/ncrmp
 	name = "military police tags"
-	desc = "A dog tag that associates one with the NCROSI."
-	icon_state = "ncrdogtagrecruit"
-
-/obj/item/card/id/dogtag/ncrht
-	name = "heavy trooper's tags"
-	desc = "A dog tag proving the elite status of the heavy trooper."
+	desc = "A dog tag that associates one with the New California Republic Military Police."
 	icon_state = "ncrdogtagrecruit"
 
 /obj/item/card/id/dogtag/ncrsergeant
 	name = "sergeant's tags"
 	desc = "A chevron decorated dog tag showing NCO-ship."
 	icon_state = "ncrdogtagsergeant"
-
-/obj/item/card/id/dogtag/ncrrep
-	name = "representative's tags"
-	desc = "A special dog tag belonging to the NCR representative."
-	icon_state = "ncrdogtagofficer"
 
 /obj/item/card/id/dogtag/ncrlieutenant
 	name = "lieutenant's tags"
@@ -1037,6 +1007,7 @@
 	name = "colonel's tags"
 	desc = "A dog tag that demands respect from all those subordinate to it. This one belongs to an NCR colonel."
 	icon_state = "ncrdogtagcaptain"
+
 /* Below replaced by the versions in Legio Invicta
 /obj/item/card/id/dogtag/legforgemaster
 	name = "camp follower medallion"
@@ -1107,18 +1078,6 @@
 	item_state = "card-id_leg"
 	assignment = "immune medallion"
 
-
-
-//For PilotBland's frumentarii custom loadout
-/obj/item/card/id/dogtag/legfrumentariiremus
-	name = "Remus Amius' frumentarius medallion"
-	desc = "A golden disc with a string threaded through the top, displaying official markings confirming a frumentarius' status."
-	icon_state = "legionmedallioncent"
-	item_state = "card-id_leg2"
-	assignment = "frumentarius medallion"
-
-
-
 ///OUTLAW TAGS////
 
 /obj/item/card/id/raider
@@ -1157,17 +1116,12 @@
 	item_state = "brokenholodog"
 	uses_overlays = FALSE
 
-/obj/item/card/id/rusted/brokenholodog/enclave
-	name = "malfunctioning holotag"
-	desc = "A would-be advanced holographic dogtag, if it was working. Kept as a reminder to something."
-
 /obj/item/card/id/denid
 	name = "Den Gang Membership Certificate"
 	desc = "A certificate declaring your loyalty to the gang"
 	assignment = "gang tattoo"
 
 	access = list(ACCESS_DEN, ACCESS_PUBLIC)
-
 
 /obj/item/card/id/khantattoo
 	name = "Great Khan tattoo"
@@ -1182,36 +1136,6 @@
 /obj/item/card/id/khantattoo/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_GENERIC)
-
-/obj/item/card/id/khanleadertattoo
-	name = "Great Khan leader tattoo"
-	desc = "A tattoo of the symbol of the Great Khans."
-	icon = 'icons/fallout/clothing/khans.dmi'
-	icon_state = "khan_id"
-	item_state = null
-	assignment = "gang tattoo"
-	uses_overlays = FALSE
-	access = list(ACCESS_KHAN, ACCESS_PUBLIC)
-
-/obj/item/card/id/khanleadertattoo/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_GENERIC)
-
-
-/obj/item/card/id/outcasttattoo
-	name = "faded tribal tattoos"
-	desc = "Tattoos marking the wearer as a tribal, worn and faded colors."
-	icon_state = "skin"
-	item_state = "skin"
-	assignment = "gang tattoo"
-	uses_overlays = FALSE
-
-/obj/item/card/id/outcasttattoo/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_GENERIC)
-
-/* Tribal Tags
-*/
 
 /obj/item/card/id/tribetattoo
 	name = "Tattoo of the machine spirits"
@@ -1257,24 +1181,6 @@
 	icon_state = "doctor"
 	item_state = "card-doctor"
 	assignment = "name badge"
-	uses_overlays = FALSE
-
-/obj/item/card/id/chief
-	name = "crimson identification card"
-	desc = "A red card which shows dedication and leadership to the Vaults safety and security."
-	icon_state = "chief"
-	item_state = "sec_id"
-	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	uses_overlays = FALSE
-
-/obj/item/card/id/sec
-	name = "red identification card"
-	desc = "A red card which shows dedication to the Security department."
-	icon_state = "sec"
-	item_state = "sec_id"
-	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	uses_overlays = FALSE
 
 //ENCLAVE ID

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1407,8 +1407,8 @@ list(/obj/item/stack/sheet/metal = 20,
 	new /obj/item/weldingtool(src)
 
 /obj/item/storage/box/shopkeeper
-	name = "Shopkeeper's blueprints"
-	desc = "a box of the shopkeeper's blueprints"
+	name = "merchant's blueprints"
+	desc = "a box of the merchant's blueprints"
 
 
 /obj/item/storage/box/shopkeeper/PopulateContents()

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -523,15 +523,14 @@
 			return "Provost Marshal Access"
 
 /proc/get_all_jobs()
-	return list("Centurion", "NCR Captain", "Overseer", "Sheriff",
+	return list("Legion Centurion", "NCR Captain", "Overseer", "Mayor",
 				"Head Paladin", "Senior Paladin", "Paladin", "Head Knight", "Senior Knight", "Knight", "Head Scribe", "Senior Scribe", "Scribe", "Initiate",
-				"Veteran Decanus", "Vexillarius", "Decanus", "Veteran Legionnaire", "Prime Legionnaire",
-				"NCR Lieutenant", "NCR Sergeant", ,"NCR Corporal", "NCR Combat Medic", "NCR Combat Engineer", "NCR Trooper",
-				"NCR Veteran Ranger", "NCR Patrol Ranger", "NCR Recon Ranger",
-				"NCR Scout", "NCR Scout Sergeant", "NCR Scout Lieutenant",
-				"Chief of Security", "Vault-tec Doctor", "Vault-tec Scientist",
-				"Vault-tec Security", "Vault-tec Engineer", "Vault Dweller", "Settler",
-				"Wastelander", "Raider", "Great Khan", "Preacher", "Head Hunter", "Chief", "Shaman", "Villager", "Hunter")
+				"Legion Orator", "Legion Vexillarius", "Legion Veteran Decanus", "Legion Prime Decanus", "Legion Recruit Decanus", "Legion Explorer", "Veteran Legionnaire", "Prime Legionnaire", "Recruit Legionnaire", "Camp Follower", "Legion Off-Duty",
+				"NCR Lieutenant", "NCR Medical Officer", "NCR Representative", "NCR Sergeant", "NCR Corporal", "NCR Combat Medic", "NCR Combat Engineer", "NCR Heavy Trooper", "NCR Trooper", "NCR Military Police", "NCR Off-Duty",
+				"NCR Veteran Ranger", "NCR Ranger",
+				"Provost Marshal", "Director", "Deputy Marshal",
+				"Detective", "Merchant", "Prospector", "Barkeeper", "Town Doctor", "Researcher", "Preacher", "Citizen",
+				"Wastelander", "Far-Lands Tribal", "Raider", "Great Khan", "Desperado Leader", "Desperado Enforcer")
 
 /proc/get_all_job_icons() //For all existing HUD icons
 	return get_all_jobs() + list("Prisoner")

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -95,11 +95,11 @@ GLOBAL_LIST_INIT(faction_whitelist_positions, list(
 "Legion Slave",
 
 "Mayor",
-"Sheriff",
+"Provost Marshal",
 "Director",
-"Deputy",
-"Shopkeeper",
-"Doctor",
+"Deputy Marshal",
+"Merchant",
+"Town Doctor",
 "Prospector",
 "Detective",
 
@@ -147,14 +147,14 @@ GLOBAL_LIST_INIT(eastwood_positions, list(
 	"Town Doctor",
 	"Researcher",
 	"Preacher",
-	"Citizen",
+	"Citizen"
 ))
 
 GLOBAL_LIST_INIT(legion_command_positions, list(
 	"Legate",
 	"Legion Orator",
 	"Legion Centurion",
-	"Legion Veteran Decanus",
+	"Legion Veteran Decanus"
 ))
 
 GLOBAL_LIST_INIT(legion_positions, list(
@@ -169,7 +169,7 @@ GLOBAL_LIST_INIT(legion_positions, list(
 	"Prime Legionnaire",
 	"Recruit Legionnaire",
 	"Camp Follower",
-	"Legion Immune",
+	"Legion Off-Duty",
 	"Legion Slave"
 ))
 
@@ -214,12 +214,12 @@ GLOBAL_LIST_INIT(enclave_positions, list(
 	"Enclave Specialist",
 	"Enclave Scientist",
 	"Enclave Private",
-	"Enclave Bunker Duty",
+	"Enclave Bunker Duty"
 ))
 
 GLOBAL_LIST_INIT(silicon_positions, list(
 	"Mr. Handy",
-	"Cyborg",
+	"Cyborg"
 ))
 
 // job categories for rendering the late join menu
@@ -254,9 +254,9 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 	EXP_TYPE_ENCLAVE = list("titles" = enclave_positions),
 	EXP_TYPE_RANGER = list("titles" = list("NCR Veteran Ranger","NCR Ranger")),
 	EXP_TYPE_SCRIBE = list("titles" = list("Scribe")),
-	EXP_TYPE_DECANUS = list("titles" = list("Legion Decanus")),
+	EXP_TYPE_DECANUS = list("titles" = list("Legion Veteran Decanus","Legion Prime Decanus","Legion Recruit Decanus")),
 
-	EXP_TYPE_NCRCOMMAND = list("titles" = list("NCR Lieutenant","NCR Sergeant First Class","NCR Captain", "NCR Veteran Ranger"))
+	EXP_TYPE_NCRCOMMAND = list("titles" = list("NCR Lieutenant","NCR Captain","NCR Veteran Ranger"))
 ))
 
 GLOBAL_LIST_INIT(exp_specialmap, list(

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -276,12 +276,15 @@
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
 							"NCR Lieutenant",
+							"NCR Medical Officer",
 							"NCR Heavy Trooper",
 							"NCR Sergeant",
 							"NCR Corporal",
 							"NCR Combat Engineer",
 							"NCR Combat Medic",
+							"NCR Military Police",
 							"NCR Trooper",
+							"NCR Off-Duty"
 						)
 
 /datum/gear/head/ncr_fieldcap
@@ -292,11 +295,13 @@
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
 							"NCR Lieutenant",
+							"NCR Medical Officer",
 							"NCR Heavy Trooper",
 							"NCR Sergeant",
 							"NCR Corporal",
 							"NCR Combat Engineer",
 							"NCR Combat Medic",
+							"NCR Military Police",
 							"NCR Trooper",
 							"NCR Off-Duty"
 						)
@@ -309,11 +314,13 @@
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
 							"NCR Lieutenant",
+							"NCR Medical Officer",
 							"NCR Heavy Trooper",
 							"NCR Sergeant",
 							"NCR Corporal",
 							"NCR Combat Engineer",
 							"NCR Combat Medic",
+							"NCR Military Police",
 							"NCR Trooper",
 							"NCR Off-Duty"
 						)						
@@ -326,12 +333,15 @@
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
 							"NCR Lieutenant",
+							"NCR Medical Officer",
 							"NCR Heavy Trooper",
 							"NCR Sergeant",
 							"NCR Corporal",
 							"NCR Combat Engineer",
 							"NCR Combat Medic",
+							"NCR Military Police",
 							"NCR Trooper",
+							"NCR Off-Duty"
 						)
 
 /datum/gear/head/ncr_campaignhat
@@ -340,7 +350,9 @@
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_FACTIONS
 	cost = 2
 	restricted_desc = "NCR"
-	restricted_roles = list("NCR Heavy Trooper",
+	restricted_roles = list("NCR Captain",
+							"NCR Lieutenant",
+							"NCR Heavy Trooper",
 							"NCR Sergeant",
 							"NCR Military Police"
 						)
@@ -363,12 +375,11 @@
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_FACTIONS
 	cost = 3
 	restricted_desc = "Eastwood PD, Eastwood officials"
-	restricted_roles = list("Chief of Police",
+	restricted_roles = list("Provost Marshal",
 							"Deputy Marshal",
 							"Mayor",
 							"Detective",
-							"Secretary",
-							"Shopkeeper"
+							"Merchant"
 						)
 
 /// Khan

--- a/modular_citadel/code/modules/client/loadout/shoes.dm
+++ b/modular_citadel/code/modules/client/loadout/shoes.dm
@@ -130,16 +130,16 @@
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
 							"NCR Lieutenant",
+							"NCR Medical Officer",
 							"NCR Veteran Ranger",
 							"NCR Ranger",
-							"NCR Lieutenant",
 							"NCR Heavy Trooper",
 							"NCR Sergeant",
 							"NCR Corporal",
 							"NCR Combat Engineer",
 							"NCR Combat Medic",
+							"NCR Military Police",
 							"NCR Trooper",
-							"NCR Rear Echelon",
 							"NCR Off-Duty"
 						)
 

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -159,16 +159,17 @@
 	cost = 2
 	restricted_desc = "Eastwood"
 	restricted_roles = list("Mayor",
-							"Secretary",
-							"Sheriff",
-							"Doctor",
+							"Director",
+							"Provost Marshal",
+							"Town Doctor",
 							"Citizen",
 							"Deputy Marshal",
-							"Shopkeeper",
-							"Farmer",
+							"Merchant",
+							"Researcher",
 							"Prospector",
 							"Detective",
 							"Barkeep",
+							"Preacher"
 							)
 
 datum/gear/suit/blueshirt
@@ -178,10 +179,9 @@ datum/gear/suit/blueshirt
 	cost = 3
 	restricted_desc = "Eastwood PD, Eastwood officials"
 	restricted_roles = list("Mayor",
-							"Sheriff",
+							"Provost Marshal",
 							"Deputy Marshal",
-							"Shopkeeper",
-							"Secretary",
+							"Merchant"
 							)
 
 /datum/gear/suit/hazardvest
@@ -190,7 +190,7 @@ datum/gear/suit/blueshirt
 	subcategory = LOADOUT_SUBCATEGORY_SUIT_FACTIONS
 	cost = 2
 	restricted_roles = list("Citizen",
-							"Prospector",
+							"Prospector"
 							)
 
 

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -595,17 +595,17 @@
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
 							"NCR Lieutenant",
+							"NCR Medical Officer",
 							"NCR Veteran Ranger",
-							"NCR Lieutenant",
+							"NCR Ranger",
 							"NCR Heavy Trooper",
 							"NCR Sergeant",
 							"NCR Corporal",
 							"NCR Combat Engineer",
 							"NCR Combat Medic",
+							"NCR Military Police",
 							"NCR Trooper",
-							"NCR Rear Echelon",
-							"NCR Off-Duty",
-							"NCR Ranger"
+							"NCR Off-Duty"
 						)
 
 /datum/gear/uniform/ncr_shorts
@@ -615,17 +615,17 @@
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
 							"NCR Lieutenant",
+							"NCR Medical Officer",
 							"NCR Veteran Ranger",
-							"NCR Lieutenant",
+							"NCR Ranger",
 							"NCR Heavy Trooper",
 							"NCR Sergeant",
 							"NCR Corporal",
 							"NCR Combat Engineer",
 							"NCR Combat Medic",
+							"NCR Military Police",
 							"NCR Trooper",
-							"NCR Rear Echelon",
-							"NCR Off-Duty",
-							"NCR Ranger"
+							"NCR Off-Duty"
 						)
 
 /datum/gear/uniform/ncr_officer_dress
@@ -634,7 +634,8 @@
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_FACTIONS
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
-							"NCR Lieutenant"
+							"NCR Lieutenant",
+							"NCR Off-Duty"
 						)
 
 /datum/gear/uniform/ncr_sniper_fatigues
@@ -644,17 +645,17 @@
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
 							"NCR Lieutenant",
+							"NCR Medical Officer",
 							"NCR Veteran Ranger",
-							"NCR Lieutenant",
+							"NCR Ranger",
 							"NCR Heavy Trooper",
 							"NCR Sergeant",
 							"NCR Corporal",
 							"NCR Combat Engineer",
 							"NCR Combat Medic",
+							"NCR Military Police",
 							"NCR Trooper",
-							"NCR Rear Echelon",
-							"NCR Off-Duty",
-							"NCR Ranger"
+							"NCR Off-Duty"
 						)
 
 /datum/gear/uniform/ranger
@@ -662,7 +663,10 @@
 	path = /obj/item/clothing/under/f13/ranger
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_FACTIONS
 	restricted_desc = "Rangers"
-	restricted_roles = list("NCR Veteran Ranger", "NCR Ranger")
+	restricted_roles = list("NCR Veteran Ranger", 
+							"NCR Ranger",
+							"NCR Off-Duty"
+						)
 
 /datum/gear/uniform/ranger/trail
 	name = "trail ranger outfit"
@@ -685,16 +689,15 @@
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_FACTIONS
 	restricted_desc = "Eastwood"
 	restricted_roles = list("Mayor",
-							"Secretary",
-							"Chief of Police",
-							"Doctor",
+							"Provost Marshal",
+							"Town Doctor",
 							"Citizen",
-							"Officer",
-							"Shopkeeper",
-							"Farmer",
+							"Deputy Marshal",
+							"Merchant",
 							"Prospector",
 							"Detective",
 							"Barkeep",
+							"Citizen"
 							)
 
 //Khans


### PR DESCRIPTION
## About The Pull Request
It's a shame MO and MP get basically nothing from the NCR Loadout menu so I decided to add them to the list as well, what's the harm

Everything else is in the changelog

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: Removed old useless IDs
tweak: tweaked all NCR loadout items to feature more NCR jobs like MO, MP and Off-Duty
balance: rebalanced the NCR Representatives ID
fix: fixed the Marshal/Deputy/Doctor/Follower Doctor/Administrator/Shopkeeper/Den Mob Boss/Den Doctor and Chief of Police job names used in code that don't exist anymore back to their respective jobs (example: Deputy to Deputy Marshal etc.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
