### PR TITLE
Gives the Head Knight a command headset

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -335,6 +335,7 @@ Head Knight
 	belt =			/obj/item/storage/belt/military/army
 	neck =			/obj/item/storage/belt/holster
 	mask =			/obj/item/clothing/mask/gas/sechailer
+	ears =			/obj/item/radio/headset/headset_bos/command
 	head =			/obj/item/clothing/head/helmet/f13/combat/brotherhood/head
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/pistol14 = 1,


### PR DESCRIPTION
## About The Pull Request
Head Knight now spawns with a BoS Command Headset, rather than a normal one. I'm fairly sure head roles that are active in combat should have a big voice. Also I'm being held at gunpoint by Beady20k please I fucking need help call the police oh God oh fuck

(QoL change)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Head Knight has a command headset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
