### PR TITLE
BUGFIX - Renegades fix

### DIFF
--- a/modular_sunset/code/mob/renegade.dm
+++ b/modular_sunset/code/mob/renegade.dm
@@ -17,7 +17,7 @@
 	health = 140
 	healable = 1
 	speed = 1.2
-	stat_attack = 1
+	stat_attack = 2
 	obj_damage = 150
 	melee_damage_lower = 25
 	melee_damage_upper = 40


### PR DESCRIPTION
## About The Pull Request
Renegades were accidentally reset back to stat_attack 1 in VEGA's PR, this gets them back to stat_attack 2.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Renegades get stat_attack 2
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
