### PR TITLE
Gives every NCR a ration + changes to NCR Rep loadout

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -122,15 +122,13 @@
 			return TRUE
 
 /obj/item/storage/lockbox/medal/PopulateContents()
-	new /obj/item/clothing/accessory/medal/gold/heroism(src)
-	new /obj/item/clothing/accessory/medal/silver/valor(src)
-	new /obj/item/clothing/accessory/medal/silver/valor(src)
-	new /obj/item/clothing/accessory/medal/silver/security(src)
-	new /obj/item/clothing/accessory/medal/bronze_heart(src)
-	new /obj/item/clothing/accessory/medal/plasma/nobel_science(src)
-	new /obj/item/clothing/accessory/medal/plasma/nobel_science(src)
-	for(var/i in 1 to 3)
-		new /obj/item/clothing/accessory/medal/conduct(src)
+    new /obj/item/clothing/accessory/medal/silver/valor(src)
+    new /obj/item/clothing/accessory/medal/silver/security(src)
+    new /obj/item/clothing/accessory/medal/bronze_heart(src)
+    for(var/i in 1 to 3)
+        new /obj/item/clothing/accessory/medal/conduct(src)
+    for(var/i in 1 to 3)
+        new /obj/item/clothing/accessory/medal/bronze_heart(src)
 
 /obj/item/storage/lockbox/medal/update_icon_state()
 	var/locked = SEND_SIGNAL(src, COMSIG_IS_STORAGE_LOCKED)

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -94,7 +94,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
-	req_access = list(ACCESS_CAPTAIN)
+	req_access = list(ACCESS_NCR4)
 	icon_locked = "medalbox+l"
 	icon_closed = "medalbox"
 	icon_broken = "medalbox+b"
@@ -122,7 +122,7 @@
 			return TRUE
 
 /obj/item/storage/lockbox/medal/PopulateContents()
-	new /obj/item/clothing/accessory/medal/gold/captain(src)
+	new /obj/item/clothing/accessory/medal/gold/heroism(src)
 	new /obj/item/clothing/accessory/medal/silver/valor(src)
 	new /obj/item/clothing/accessory/medal/silver/valor(src)
 	new /obj/item/clothing/accessory/medal/silver/security(src)

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -122,13 +122,13 @@
 			return TRUE
 
 /obj/item/storage/lockbox/medal/PopulateContents()
-    new /obj/item/clothing/accessory/medal/silver/valor(src)
-    new /obj/item/clothing/accessory/medal/silver/security(src)
-    new /obj/item/clothing/accessory/medal/bronze_heart(src)
-    for(var/i in 1 to 3)
-        new /obj/item/clothing/accessory/medal/conduct(src)
-    for(var/i in 1 to 3)
-        new /obj/item/clothing/accessory/medal/bronze_heart(src)
+	new /obj/item/clothing/accessory/medal/silver/valor(src)
+	new /obj/item/clothing/accessory/medal/silver/security(src)
+	new /obj/item/clothing/accessory/medal/bronze_heart(src)
+	for(var/i in 1 to 3)
+		new /obj/item/clothing/accessory/medal/conduct(src)
+	for(var/i in 1 to 3)
+		new /obj/item/clothing/accessory/medal/bronze_heart(src)
 
 /obj/item/storage/lockbox/medal/update_icon_state()
 	var/locked = SEND_SIGNAL(src, COMSIG_IS_STORAGE_LOCKED)

--- a/code/modules/clothing/head/power_armor.dm
+++ b/code/modules/clothing/head/power_armor.dm
@@ -170,6 +170,13 @@
 	icon_state = "t45dhelmet[light_on]"
 	item_state = "t45dhelmet[light_on]"
 
+/obj/item/clothing/head/helmet/f13/power_armor/t45d/sierra
+	name = "sierra power helmet"
+	desc = "A pre-war power armor helmet, issued to special NCR officers."
+	icon_state = "sierra"
+	item_state = "sierra"
+	actions_types = list()
+
 /obj/item/clothing/head/helmet/f13/power_armor/t51b
 	name = "T-51b power helmet"
 	desc = "It's a T-51b power helmet, typically used by the Brotherhood. It looks somewhat charming."

--- a/code/modules/clothing/suits/power_armor.dm
+++ b/code/modules/clothing/suits/power_armor.dm
@@ -348,6 +348,12 @@
 	icon_state = "t45dpowerarmor_bos"
 	item_state = "t45dpowerarmor_bos"
 
+/obj/item/clothing/suit/armor/f13/power_armor/t45d/sierra
+	name = "sierra power armor"
+	desc = "A captured set of T-45d power armor put into use by the NCR, it's been heavily modified and decorated with the head of a bear and intricate gold trimming. A two headed bear is scorched into the breastplate."
+	icon_state = "sierra"
+	item_state = "sierra"
+
 /obj/item/clothing/suit/armor/power_armor/t51b
 	name = "T-51b power armor"
 	desc = "The pinnacle of pre-war technology. This suit of power armor provides substantial protection to the wearer."

--- a/code/modules/clothing/suits/power_armor.dm
+++ b/code/modules/clothing/suits/power_armor.dm
@@ -348,7 +348,7 @@
 	icon_state = "t45dpowerarmor_bos"
 	item_state = "t45dpowerarmor_bos"
 
-/obj/item/clothing/suit/armor/f13/power_armor/t45d/sierra
+/obj/item/clothing/suit/armor/power_armor/t45d/sierra
 	name = "sierra power armor"
 	desc = "A captured set of T-45d power armor put into use by the NCR, it's been heavily modified and decorated with the head of a bear and intricate gold trimming. A two headed bear is scorched into the breastplate."
 	icon_state = "sierra"

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -159,11 +159,11 @@
 		..()
 
 /obj/item/clothing/accessory/medal/conduct
-	name = "distinguished conduct medal"
-	desc = "A bronze medal awarded for distinguished conduct. Whilst a great honor, this is the most basic award given. It is often awarded by an officer to a member of their staff."
+	name = "distinguished service medal"
+	desc = "A bronze medal awarded for distinguished service. Whilst a great honor, this is the most basic award given. It is often awarded by a commanding officer to a member of their unit."
 
 /obj/item/clothing/accessory/medal/bronze_heart
-	name = "bronze heart medal"
+	name = "purple heart"
 	desc = "A bronze heart-shaped medal awarded for sacrifice. It is often awarded posthumously or for severe injury in the line of duty."
 	icon_state = "bronze_heart"
 
@@ -199,12 +199,12 @@
 	custom_materials = list(/datum/material/silver=1000)
 
 /obj/item/clothing/accessory/medal/silver/valor
-	name = "medal of valor"
-	desc = "A silver medal awarded for acts of exceptional valor."
+	name = "medal of honor"
+	desc = "A silver medal awarded for acts of exceptional honor."
 
 /obj/item/clothing/accessory/medal/silver/security
-	name = "robust security award"
-	desc = "An award for distinguished combat. Often awarded to security staff."
+	name = "silver star medal"
+	desc = "An award for distinguished combat. Often awarded to elite units."
 
 /obj/item/clothing/accessory/medal/gold
 	name = "gold medal"
@@ -214,17 +214,17 @@
 	custom_materials = list(/datum/material/gold=1000)
 
 /obj/item/clothing/accessory/medal/gold/captain
-	name = "medal of competency"
-	desc = "A golden medal awarded exclusively to those promoted to a command role. It signifies the codified responsibilities of the commander to organization, and their undisputable authority over their staff."
+	name = "commendation medal"
+	desc = "A golden medal awarded exclusively to those promoted to commissioned officer. It signifies the codified responsibilities of a CO to organization, and their undisputable authority over their unit."
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/accessory/medal/gold/captain/family
-	name = "old medal"
+	name = "old commendation medal"
 	desc = "A rustic badge pure gold, has been through hell and back by the looks."
 	custom_materials = list(/datum/material/gold=2000)
 
 /obj/item/clothing/accessory/medal/gold/heroism
-	name = "medal of exceptional heroism"
+	name = "star of the Sierra Madre"
 	desc = "An extremely rare golden medal awarded only by as the highest honor and as such, very few exist. This medal is almost never awarded to anybody."
 
 /obj/item/clothing/accessory/medal/plasma
@@ -241,7 +241,7 @@
 		qdel(src)
 
 /obj/item/clothing/accessory/medal/plasma/nobel_science
-	name = "nobel sciences award"
+	name = "medal of science"
 	desc = "A medal which represents significant contributions to the field of science or engineering."
 
 ////////////
@@ -292,14 +292,14 @@
 //////////////
 
 /obj/item/clothing/accessory/lawyers_badge
-	name = "NCR agent's badge"
-	desc = "A polished badge representative of courage, honor, and morally dubious undercover missions."
+	name = "NCR Congressional ID"
+	desc = "A polished badge representing that the owner is a member of the New California Republic House of Congress."
 	icon_state = "lawyerbadge"
 
 /obj/item/clothing/accessory/lawyers_badge/attack_self(mob/user)
 	if(prob(1))
-		user.say("The testimony contradicts the evidence!", forced = "attorney's badge")
-	user.visible_message("[user] shows [user.p_their()] attorney's badge.", span_notice("You show your attorney's badge."))
+		user.say("The testimony contradicts the evidence!", forced = "Congressional ID")
+	user.visible_message("[user] shows [user.p_their()] Congressional ID.", span_notice("You show your Congressional ID."))
 
 /obj/item/clothing/accessory/lawyers_badge/on_uniform_equip(obj/item/clothing/under/U, user)
 	var/mob/living/L = user

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -224,7 +224,7 @@
 	custom_materials = list(/datum/material/gold=2000)
 
 /obj/item/clothing/accessory/medal/gold/heroism
-	name = "star of the Sierra Madre"
+	name = "star of Sierra Madre"
 	desc = "An extremely rare golden medal awarded only by as the highest honor and as such, very few exist. This medal is almost never awarded to anybody."
 
 /obj/item/clothing/accessory/medal/plasma

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -97,7 +97,7 @@ Access
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	accessory = /obj/item/clothing/accessory/ncr
 	head = /obj/item/clothing/head/helmet/f13/power_armor/t45d/sierra
-	suit = /obj/item/clothing/suit/armor/f13/power_armor/t45d/sierra
+	suit = /obj/item/clothing/suit/armor/power_armor/t45d/sierra
 	belt = /obj/item/storage/belt/holster/leg
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	gloves = /obj/item/clothing/gloves/f13/leather

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -302,7 +302,7 @@ Access
 	total_positions = 2
 	spawn_positions = 2
 	description = "You are the direct superior to the enlisted troops, working with the chain of command you echo the orders of your superiors and ensure that the enlisted follow them to the letter. Additionally, you are responsible for the wellbeing of the troops and their ongoing training with the NCR."
-	supervisors = "Sergeant First Class and Above"
+	supervisors = "Lieutenant and Above"
 	selection_color = "#fff5cc"
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY, ACCESS_NCR1, ACCESS_NCR2, ACCESS_NCR_COMMAND, ACCESS_PUBLIC)
 	minimal_access = list(ACCESS_NCR, ACCESS_NCR_ARMORY, ACCESS_NCR1, ACCESS_NCR2, ACCESS_NCR_COMMAND, ACCESS_PUBLIC)
@@ -782,6 +782,7 @@ Access
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m1carbine)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalradio)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/durathread_vest)
+	ADD_TRAIT(H, TRAIT_GUNSMITH_FOUR, src)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -52,6 +52,7 @@ Access
 	..()
 	if(visualsOnly)
 		return
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tailor/ncruniform)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ncrgate)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ncrsalvagedarmorconversion)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ncrsalvagedhelmetconversion)
@@ -95,7 +96,8 @@ Access
 	uniform	= /obj/item/clothing/under/f13/ncr/ncr_officer
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	accessory = /obj/item/clothing/accessory/ncr
-	head = /obj/item/clothing/head/beret/ncr
+	head = /obj/item/clothing/head/helmet/f13/power_armor/t45d/sierra
+	suit = /obj/item/clothing/suit/armor/f13/power_armor/t45d/sierra
 	belt = /obj/item/storage/belt/holster/leg
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	gloves = /obj/item/clothing/gloves/f13/leather
@@ -272,6 +274,7 @@ Access
 	suit_store = /obj/item/gun/ballistic/automatic/assault_rifle/infiltrator
 
 	backpack_contents = list(
+		/obj/item/storage/box/ration/menu_five = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/gun/ballistic/automatic/pistol/m1911/custom = 1,
 		/obj/item/ammo_box/magazine/pistol45 = 3,
@@ -354,7 +357,7 @@ Access
 	suit_store = /obj/item/gun/ballistic/automatic/assault_carbine
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m5mm = 2,
-		/obj/item/storage/box/ration/menu_two = 1,
+		/obj/item/storage/box/ration/menu_seven = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/flashlight/seclite = 1
 		)
@@ -365,7 +368,7 @@ Access
 	suit_store = /obj/item/gun/ballistic/automatic/service/carbine
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556/rifle/extended = 2,
-		/obj/item/storage/box/ration/menu_eight = 1,
+		/obj/item/storage/box/ration/menu_nine = 1,
 		/obj/item/gun_upgrade/scope/watchman = 1,
 		/obj/item/book/granter/trait/trekking = 1
 		)
@@ -375,6 +378,7 @@ Access
 	head = /obj/item/clothing/head/f13/ncr
 	suit_store = /obj/item/gun/ballistic/shotgun/trench //Over thereee over thereeeee spread the spread the word over thereeee
 	backpack_contents = list(
+		/obj/item/storage/box/ration/menu_eleven = 1,
 		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/ammo_box/shotgun/incendiary = 1,
 		/obj/item/clothing/mask/gas = 1,
@@ -388,6 +392,7 @@ Access
 	head = /obj/item/clothing/head/f13/ncr/mp
 	suit_store = /obj/item/gun/ballistic/shotgun/police
 	backpack_contents = list(
+		/obj/item/storage/box/ration/menu_six = 1,
 		/obj/item/ammo_box/shotgun/bean = 2,
 		/obj/item/clothing/accessory/armband/black = 1,
 		/obj/item/melee/classic_baton/militarypolice = 1,
@@ -413,7 +418,7 @@ Access
 
 	loadout_options = list(
 		/datum/outfit/loadout/repsenator,
-		/datum/outfit/loadout/repagent,
+		/datum/outfit/loadout/reposiagent,
 		/datum/outfit/loadout/repambassador
 		)
 
@@ -448,21 +453,18 @@ Access
 	head = /obj/item/clothing/head/helmet/f13/brahmincowboyhat
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/ncr = 1,
-		/obj/item/storage/box/ration/menu_two = 1
+		/obj/item/clothing/accessory/lawyers_badge = 1
 		)
 
-/datum/outfit/loadout/repagent
-	name = "Government Agent"
+/datum/outfit/loadout/reposiagent
+	name = "OSI Agent"
 	glasses = /obj/item/clothing/glasses/sunglasses
-	suit = /obj/item/clothing/under/rank/security/detective/grey
+	suit = /obj/item/clothing/suit/toggle/labcoat
+	accessory = /obj/item/clothing/accessory/pocketprotector/full
 	shoes = /obj/item/clothing/shoes/laceup
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/ncr = 1,
-		/obj/item/storage/box/ration/menu_two = 1,
-		/obj/item/clothing/accessory/waistcoat = 1,
-		/obj/item/clothing/suit/toggle/lawyer/black = 1,
-		/obj/item/storage/briefcase = 1,
-		/obj/item/clothing/accessory/lawyers_badge = 1
+		/obj/item/clothing/accessory/medal/plasma/nobel_science = 1	
 		)
 
 /datum/outfit/loadout/repambassador
@@ -472,7 +474,7 @@ Access
 	head = /obj/item/clothing/head/helmet/f13/rustedcowboyhat
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/ncr = 1,
-		/obj/item/storage/box/ration/menu_two = 1
+		/obj/item/storage/briefcase = 1
 		)
 
 ///////////////
@@ -542,6 +544,7 @@ Access
 	name = "Sniper Veteran Ranger"
 	suit_store = /obj/item/gun/ballistic/automatic/sniper
 	backpack_contents = list(
+		/obj/item/storage/box/ration/ranger_dinner = 1,
 		/obj/item/ammo_box/magazine/w308 = 2,
 		/obj/item/gun/ballistic/revolver/sequoia = 1,
 		/obj/item/ammo_box/c4570box/knockback = 1,
@@ -552,6 +555,7 @@ Access
 	name = "Rifler Veteran Ranger"
 	suit_store = /obj/item/gun/ballistic/rifle/repeater/brush
 	backpack_contents = list(
+		/obj/item/storage/box/ration/ranger_lunch = 1,
 		/obj/item/ammo_box/loader/c4570 = 3,
 		/obj/item/gun/ballistic/revolver/sequoia = 1,
 		/obj/item/book/granter/trait/rifleman = 1
@@ -561,6 +565,7 @@ Access
 	name = "Veteran Ranger Shotgunner"
 	suit_store = /obj/item/gun/ballistic/automatic/shotgun/citykiller
 	backpack_contents = list(
+		/obj/item/storage/box/ration/ranger_breakfast = 1,
 		/obj/item/ammo_box/magazine/city12g = 3,
 		/obj/item/gun/ballistic/revolver/sequoia = 1,
 		/obj/item/ammo_box/c4570box/knockback = 1
@@ -628,6 +633,7 @@ Access
 	neck = /obj/item/storage/belt/holster/leg
 	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
 	backpack_contents = list(
+		/obj/item/storage/box/ration/ranger_lunch = 1,
 		/obj/item/ammo_box/tube/m44 = 2,
 		/obj/item/gun_upgrade/scope/watchman = 1,
 		/obj/item/gun/ballistic/revolver/colt357 = 1,
@@ -642,6 +648,7 @@ Access
 	neck = /obj/item/storage/belt/holster/leg
 	suit_store = /obj/item/gun/ballistic/automatic/marksman
 	backpack_contents = list(
+		/obj/item/storage/box/ration/ranger_dinner = 1,
 		/obj/item/ammo_box/magazine/m556/rifle = 2,
 		/obj/item/gun/ballistic/revolver/revolver44 = 1,
 		/obj/item/ammo_box/loader/m44 = 2,
@@ -655,6 +662,7 @@ Access
 	neck = /obj/item/storage/belt/bandolier/reconbandolier
 	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever
 	backpack_contents = list(
+		/obj/item/storage/box/ration/ranger_breakfast = 1,
 		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/gun/ballistic/revolver/m29/snub = 1,
 		/obj/item/ammo_box/m44box = 1,
@@ -708,22 +716,23 @@ Access
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/autoloader = 1,
 		/obj/item/ammo_box/magazine/pistol45/socom = 2,
-		/obj/item/storage/bag/money/small/ncrenlisted = 1
+		/obj/item/storage/bag/money/small/ncrenlisted = 1,
+		/obj/item/melee/onehanded/knife/bowie = 1
 		) //E
 
 /datum/outfit/loadout/shockht
 	name = "Shock Heavy Trooper"
-	backpack_contents = list(
+	backpack_contents = list(	
 		/obj/item/minigunpackbal5mm = 1,
-		/obj/item/melee/onehanded/knife/bowie = 1
+		/obj/item/storage/box/ration/menu_four = 1
 		)
 
 /datum/outfit/loadout/supportht
 	name = "Support Heavy Trooper"
 	backpack_contents = list(
+		/obj/item/storage/box/ration/menu_one = 1,
 		/obj/item/gun/ballistic/automatic/r84 = 1,
-		/obj/item/ammo_box/magazine/lmg = 1,
-		/obj/item/melee/onehanded/knife/bowie = 1
+		/obj/item/ammo_box/magazine/lmg = 1
 		)
 
 
@@ -798,6 +807,7 @@ Access
 	glasses = /obj/item/clothing/glasses/welding
 	suit_store = /obj/item/gun/ballistic/automatic/assault_carbine/policerifle
 	backpack_contents = list(
+		/obj/item/storage/box/ration/menu_three = 1,
 		/obj/item/ammo_box/magazine/m5mm = 1,
 		/obj/item/grenade/plastic/c4 = 2,
 		/obj/item/stack/sheet/metal/fifty = 1,
@@ -809,6 +819,7 @@ Access
 	name = "Minelayer"
 	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm
 	backpack_contents = list(
+		/obj/item/storage/box/ration/menu_ten = 1,
 		/obj/item/ammo_box/magazine/pistol10mm/extended = 2,
 		/obj/item/book/granter/crafting_recipe/blueprint/trapper = 1,
 		/obj/item/book/granter/trait/explosives = 1,
@@ -846,6 +857,7 @@ Access
 	backpack = /obj/item/storage/backpack/satchel/trekker
 	suit_store = /obj/item/gun/ballistic/shotgun/police
 	backpack_contents = list(
+		/obj/effect/spawner/lootdrop/f13/ncr_c_ration = 1,
 		/obj/item/gun/ballistic/automatic/pistol/m1911 = 1,
 		/obj/item/ammo_box/magazine/pistol45 = 3,
 		/obj/item/storage/bag/money/small/ncrenlisted = 1,
@@ -901,6 +913,7 @@ Access
 	suit_store = /obj/item/gun/ballistic/automatic/m1carbine/compact
 	box_two = /obj/item/storage/survivalkit/medical/adv
 	backpack_contents = list(
+		/obj/item/storage/box/ration/menu_five = 1,
 		/obj/item/ammo_box/magazine/pistol10mm = 2,
 		/obj/item/storage/bag/money/small/ncrenlisted = 1,
 		/obj/item/storage/firstaid/regular = 1,
@@ -994,7 +1007,7 @@ Access
 		/obj/item/ammo_box/magazine/m556/rifle = 2,
 		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
 		/obj/item/ammo_box/magazine/pistol9mm/doublestack = 1,
-		/obj/item/storage/box/ration/menu_two = 1
+		/obj/item/storage/box/ration/menu_seven = 1
 		)
 
 /datum/outfit/loadout/corporalcqc		//I think this one sucks, personally.
@@ -1002,7 +1015,7 @@ Access
 	suit_store = /obj/item/gun/ballistic/shotgun/hunting
 	backpack_contents = list(
 		/obj/item/ammo_box/shotgun/buck = 2,
-		/obj/item/storage/box/ration/menu_one = 1,
+		/obj/item/storage/box/ration/menu_eleven = 1,
 		/obj/item/stack/sheet/mineral/sandbags = 6
 		)
 
@@ -1014,7 +1027,7 @@ Access
 		/obj/item/binoculars = 1,
 		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
 		/obj/item/ammo_box/magazine/pistol9mm/doublestack = 1,
-		/obj/item/storage/box/ration/menu_one = 1
+		/obj/item/storage/box/ration/menu_four = 1
 		)
 
 // TROOPER
@@ -1075,7 +1088,7 @@ Access
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556/rifle = 3,
 		/obj/item/melee/onehanded/knife/bayonet = 1,
-		/obj/item/storage/box/ration/menu_two = 1
+		/obj/item/storage/box/ration/menu_one = 1
 		)
 
 /datum/outfit/loadout/trooperfiresupport
@@ -1084,7 +1097,7 @@ Access
 	backpack_contents = list(
 		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/stack/sheet/mineral/sandbags = 10,
-		/obj/item/storage/box/ration/menu_eight = 1
+		/obj/item/storage/box/ration/menu_ten = 1
 		)
 
 /datum/outfit/loadout/trooperhunting
@@ -1093,7 +1106,7 @@ Access
 	backpack_contents = list(
 		/obj/item/ammo_box/stripper/a308 = 2,
 		/obj/item/stack/sheet/mineral/sandbags = 7,
-		/obj/item/storage/box/ration/menu_eight = 1
+		/obj/item/storage/box/ration/menu_six = 1
 		)
 
 /////////////////
@@ -1202,12 +1215,6 @@ Access
 		/obj/item/reagent_containers/food/drinks/bottle/f13nukacola = 1,
 		/obj/item/storage/bag/money/small/ncrofficers = 1
 		)
-
-/datum/outfit/job/ncr/f13offdutyncr/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tailor/ncruniform)
 
 // NCR Citizen
 // Really only used for ID console

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -857,7 +857,7 @@ Access
 	backpack = /obj/item/storage/backpack/satchel/trekker
 	suit_store = /obj/item/gun/ballistic/shotgun/police
 	backpack_contents = list(
-		/obj/effect/spawner/lootdrop/f13/ncr_c_ration = 1,
+		/obj/item/storage/box/ration/menu_three = 1,
 		/obj/item/gun/ballistic/automatic/pistol/m1911 = 1,
 		/obj/item/ammo_box/magazine/pistol45 = 3,
 		/obj/item/storage/bag/money/small/ncrenlisted = 1,

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -203,11 +203,12 @@ Access
 	belt = /obj/item/storage/belt/military/ncr
 	r_pocket = /obj/item/binoculars
 	backpack_contents = list(
+		/obj/item/storage/lockbox/medal = 1,
 		/obj/item/storage/bag/money/small/ncr = 1,
 		/obj/item/megaphone = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 3,
 		/obj/item/lighter = 1,
-		/obj/item/reagent_containers/food/snacks/grown/tobacco/dried = 1,
+		/obj/item/reagent_containers/food/snacks/grown/tobacco/dried = 2,
 		/obj/item/melee/onehanded/knife/trench = 1
 		)
 


### PR DESCRIPTION
## About The Pull Request
Adds back sierra PA for the Colonel, shame to let the sprites go to waste
Gives every NCR Role a ration
Changes the Government Agent to OSI Agent because "Government Agent" didn't seem to make much sense when there was a Senator loadout so I changed it up to a more unique, maybe forgotten Organisation within the NCR

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added a medal lockbox to the Captain of the NCR for some RP
add: Added sierra PA back and gave it to the Colonel
add: Added rations to every single NCR Loadout and if they had no loadout to their starting backpacks
add: Added the ability to all NCR to tailor their uniform, if theirs is somehow destroyed
del: Removed some useless code that should fix
tweak: Tweaked all the medal accessories to fit their more IRL counterparts and the NCR Agent badge is now a Congressional ID
tweak: Tweaked the Government Agent loadout of the NCR Rep to now be OSI Agent with a labcoat, a pocket protector and a Medal of Science
tweak: Tweaked the medal lockbox access to Captain and Colonel only
fx: fixed the HT loadouts because he spawned with a bowie knife in both of them so I just gave him the bowie knife in the start
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
