### PR TITLE
Replaces spiders with Cockroaches.

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -515,7 +515,7 @@
 
 /**
  * Plant Death Proc.
- * Cleans up various stats for the plant upon death, including pests, harvestability, and plant health.
+ * Cleans up various stats for the plant upon death, including pests(Cockroaches), harvestability, and plant health.
  */
 /obj/machinery/hydroponics/proc/plantdies()
 	plant_health = 0
@@ -530,10 +530,10 @@
 
 /obj/machinery/hydroponics/proc/mutatepest(mob/user)
 	if(pestlevel > 5)
-		message_admins("[ADMIN_LOOKUPFLW(user)] caused spiderling pests to spawn in a hydro tray")
-		log_game("[key_name(user)] caused spiderling pests to spawn in a hydro tray")
+		message_admins("[ADMIN_LOOKUPFLW(user)] caused cockroaches to spawn in a hydro tray")
+		log_game("[key_name(user)] caused cockroaches pests to spawn in a hydro tray")
 		visible_message(span_warning("The pests seem to behave oddly..."))
-		spawn_atom_to_turf(/obj/structure/spider/spiderling/hunter, src, 3, FALSE)
+		spawn_atom_to_turf(/mob/living/simple_animal/cockroach src, 3, FALSE)
 	else
 		to_chat(user, span_warning("The pests seem to behave oddly, but quickly settle down..."))
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -533,7 +533,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] caused cockroaches to spawn in a hydro tray")
 		log_game("[key_name(user)] caused cockroaches pests to spawn in a hydro tray")
 		visible_message(span_warning("The pests seem to behave oddly..."))
-		spawn_atom_to_turf(/mob/living/simple_animal/cockroach src, 3, FALSE)
+		spawn_atom_to_turf(/mob/living/simple_animal/cockroach, src, 3, FALSE)
 	else
 		to_chat(user, span_warning("The pests seem to behave oddly, but quickly settle down..."))
 


### PR DESCRIPTION
## About The Pull Request
Basically hydroponics can spawn in spiders, but now you can spawn in cockroaches. 
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: hydroponics code to spawn in cockroaches instead of spiders so no more spider canons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
