### PR TITLE
Powerfist Buff

### DIFF
--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -12,7 +12,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	hitsound = 'sound/weapons/resonator_blast.ogg'
 	attack_speed = MELEE_SPEED_NORMAL
-	force = 40
+	force = 28
 	armour_penetration = 0.5
 	throwforce = 10
 	throw_range = 3
@@ -60,7 +60,7 @@
 //	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
 	icon_state = "goliath"
 	item_state = "goliath"
-	force = 50
+	force = 31
 	throw_distance = 3
 
 

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -13,7 +13,7 @@
 	hitsound = 'sound/weapons/resonator_blast.ogg'
 	attack_speed = MELEE_SPEED_NORMAL
 	force = 28
-	armour_penetration = 0.5
+	armour_penetration = 0.35
 	throwforce = 10
 	throw_range = 3
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -12,7 +12,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	hitsound = 'sound/weapons/resonator_blast.ogg'
 	attack_speed = MELEE_SPEED_NORMAL
-	force = 22
+	force = 40
+	armour_penetration = 0.5
 	throwforce = 10
 	throw_range = 3
 	w_class = WEIGHT_CLASS_NORMAL
@@ -59,7 +60,7 @@
 //	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
 	icon_state = "goliath"
 	item_state = "goliath"
-	force = 25
+	force = 50
 	throw_distance = 3
 
 


### PR DESCRIPTION
## About The Pull Request
Adds 6 to the starting force of both the Power First and Goliath, gives both 35% AP. At the moment, they're both. Incredibly underwhelming - the powerfist, currently, deals *twenty-two* damage unwrenched with no AP. Using combat armour as a baseline, with 25 melee protection, this means it deals roughly 16.5 damage per hit. Wrenched, it deals 44 - again, with 25 melee protection, it deals 33 damage. This is incredibly underwhelming for a very rare loot drop, and the same goes for the Centurion's Goliath. Weapons of the same tier are dealing anywhere from 50 to 60 damage, not factoring in the AP some weapons have.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: powerfist was buffed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
