### PR TITLE
nuka years resolution: return to PRs

### DIFF
--- a/code/modules/fallout/reagents/drinks.dm
+++ b/code/modules/fallout/reagents/drinks.dm
@@ -14,8 +14,8 @@
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
 	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
-		M.adjustBruteLoss(-0.05)
-		M.adjustFireLoss(-0.05)
+		M.adjustBruteLoss(-0.125)
+		M.adjustFireLoss(-0.125)
 	..()
 
 /datum/reagent/consumable/nuka_cola/overdose_start(mob/living/M)
@@ -141,6 +141,10 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.075)
+		M.adjustFireLoss(-0.075)
+
 	..()
 	. = TRUE
 
@@ -158,6 +162,9 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.075)
+		M.adjustFireLoss(-0.075)
 	..()
 	. = TRUE
 
@@ -174,6 +181,9 @@
 	M.adjustToxLoss(-0.1*REAGENTS_EFFECT_MULTIPLIER, 0)
 	M.drowsyness = 0
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.075)
+		M.adjustFireLoss(-0.075)
 	..()
 	. = TRUE
 
@@ -191,6 +201,9 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.2)
+		M.adjustFireLoss(-0.2)
 	..()
 	. = TRUE
 
@@ -202,14 +215,14 @@
 	glass_icon_state = "nukaiceglass"
 	glass_name = "Iced Nuka"
 	glass_desc = "Nuka. Stay frosty."
-	
+
 /datum/reagent/consumable/nukaice/on_mob_life(mob/living/carbon/M)
 	M.adjust_bodytemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT, T0C) //310.15 is the normal bodytemp.
 	M.drowsyness = 0
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
 	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
-		M.adjustBruteLoss(-0.075)
-		M.adjustFireLoss(-0.075)
+		M.adjustBruteLoss(-0.2)
+		M.adjustFireLoss(-0.2)
 	..()
 	. = TRUE
 
@@ -233,6 +246,9 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.2)
+		M.adjustFireLoss(-0.2)
 	..()
 	. = TRUE
 
@@ -265,6 +281,8 @@
 	glass_icon_state = "nukaberryglass"
 	glass_name = "Nuka Berry"
 	glass_desc = "Nuka-Cola with a Berry Aftertaste."
+
+
 
 /datum/reagent/consumable/nukacooler
 	name = "Nuka Cooler"
@@ -328,6 +346,15 @@
 	glass_name = "Nuka Float"
 	glass_desc = "A delicious blend of ice-cream and classic Nuka-Cola!"
 
+/datum/reagent/consumable/nukafloat/on_mob_life(mob/living/carbon/M)
+	M.drowsyness = 0
+	M.AdjustSleeping(-40, FALSE)
+	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.125)
+		M.adjustFireLoss(-0.125)
+	..()
+
 /datum/reagent/consumable/sunsetfloat
 	name = "Sunset Float"
 	description = "A delicious blend of ice-cream and classic Sunset Sass!"
@@ -337,6 +364,14 @@
 	glass_icon_state = "sunsetfloatglass"
 	glass_name = "Sunset Float"
 	glass_desc = "A delicious blend of ice-cream and classic Sunset Sass!"
+
+/datum/reagent/consumable/sunsetfloat/on_mob_life(mob/living/carbon/M)
+	M.drowsyness = 0
+	M.AdjustSleeping(-40, FALSE)
+	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustToxLoss(0.1)
+	..()
 
 /datum/reagent/consumable/bawlsshake
 	name = "Bawls Shake"

--- a/code/modules/fallout/reagents/drinks.dm
+++ b/code/modules/fallout/reagents/drinks.dm
@@ -37,6 +37,8 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustToxLoss(0.1)
 	..()
 	. = TRUE
 
@@ -58,6 +60,8 @@
 	M.adjust_bodytemperature(25 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, BODYTEMP_NORMAL)
 	if(holder?.has_reagent(/datum/reagent/consumable/frostoil))
 		holder.remove_reagent(/datum/reagent/consumable/frostoil, 5)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustToxLoss(0.2) //FAKE COLA!!!
 	..()
 	. = TRUE
 
@@ -103,6 +107,8 @@
 	M.adjust_bodytemperature(25 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, BODYTEMP_NORMAL)
 	if(holder?.has_reagent(/datum/reagent/consumable/frostoil))
 		holder.remove_reagent(/datum/reagent/consumable/frostoil, 5)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(0.1) //it adjusts toxin loss, so it will damage you via brute instead
 	..()
 	. = TRUE
 
@@ -122,6 +128,8 @@
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
 	//310.15 is the normal bodytemp.
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustToxLoss(0.1)
 	..()
 	. = TRUE
 
@@ -314,6 +322,8 @@
 	M.nutrition = max(M.nutrition - 3, 0)
 	M.overeatduration = 0
 	M.drowsyness = 0
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustToxLoss(0.25) //no sugar
 	..()
 	. = TRUE
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
took a short break, but back in the drivers seat

starting the year with some buffs to nuka fiend, it was deliberately underpowered when it was introduced to prevent stacking nuka cola with tricord and bicard to create cheap ghetto healing
but it was so weak that it was rarely worth the effort to do so

nuka healing: 0.05 per tick > 0.125 per tick
iced nuka healing: 0.075 per tick > 0.2 per tick
nukafloat, nuka cherry, nuka grape, and nuka quartz all provide varying levels of healing

drinking sunset sarsparilla float is now mildly toxic, your body rejects it
drinking vim is a bit more toxic, fake cola

it would now be possible to combine all the drinks in tandem with stimpaks to get ghetto regeneration, but you did spend 2 quirk points on nuka fiend
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: nuka fiend related drinks
tweak: sunset float is now bad for your body if its adapted to nuka cola
tweak: vim is now bad for your body, its not real cola
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
