### PR TITLE
nerfs ESD rounds

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -505,7 +505,7 @@
 /obj/item/projectile/bullet/m5mm/shock
 	name = "5mm shock bullet"
 	damage = BULLET_DAMAGE_RIFLE_LIGHT * BULLET_SURPLUS_MULT * BULLET_DAMAGE_SHOCK
-	stamina = RUBBERY_STAMINA_RIFLE_LIGHT * BULLET_SURPLUS_MULT * BULLET_STAMINA_SHOCK
+	stamina = RUBBERY_STAMINA_RIFLE_LIGHT * BULLET_SURPLUS_MULT
 	spread = BULLET_SPREAD_SURPLUS
 	damage_type = BURN // still checks bullet resist
 	recoil = BULLET_RECOIL_RIFLE_LIGHT


### PR DESCRIPTION
## About The Pull Request
ESD rounds, currently, stamcrit in about 5-6 shots due to the fact that stamina ignores all armour. This seems balanced - until you realise all the 5mm guns in the game are fully automatic or burst weapons, and the *minigun* is chambered in 5mm and has one of the largest ammo capacities and highest sustained fire-rates in the game. You see where this is is going. It does a lot less, now. Like. A lot.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: 5mm ESD does way less stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
