### PR TITLE
Bluespace to Ultracite

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -133,8 +133,8 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 ///Can cause bluespace effects on use. (Teleportation) (Not yet implemented)
 /datum/material/bluespace
-	name = "quantum mesh"
-	desc = "Crystals with bluespace properties"
+	name = "ultracite crystals"
+	desc = "Crystals with high energy capabilities"
 	color = list(119/255, 217/255, 396/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	integrity_modifier = 0.2 //these things shatter when thrown.
 	alpha = 200

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -224,7 +224,7 @@
 				<b>Nuka Quartz:</b> Nuka Cola 5u + Sugar 5u + Silicon 5u.<br>
 				<b>Nuka Cherry:</b> Nuka Cola 3u + Cherry Jelly 1u<br>
 				<b>Nuka Love:</b> Nuka Cherry 5u + Nuka Quartz 5u<br>
-				<b>Nuka Quantum:</b> Nuka Cola 2u + Uranium 1u + Bluespace Dust 1u + Blue Cherry Jelly 1u<br>
+				<b>Nuka Quantum:</b> Nuka Cola 2u + Uranium 1u + Ultracite Dust 1u + Blue Cherry Jelly 1u<br>
 				<b>Nuka Grape:</b> Nuka Cola 5u + Grape Juice 5u<br>
 				<b>Nuka Dark:</b> Nuka Cola 5u + Rum 5u<br>
 				<b>Nuka Orange:</b> Nuka Cola 5u + Orange Juice 5u<br>

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -1,10 +1,10 @@
 //Bluespace crystals, used in telescience and when crushed it will blink you to a random turf.
 /obj/item/stack/ore/bluespace_crystal
-	name = "quantum mesh"
-	desc = "A glowing quantum mesh, not much is known about how they work. It looks very delicate."
+	name = "ultracite ore"
+	desc = "A radioactive glass-like ore, it houses an incredibly potent source of energy."
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "bluespace_crystal"
-	singular_name = "quantum mesh"
+	singular_name = "ultracite ore"
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/bluespace=MINERAL_MATERIAL_AMOUNT)
 	points = 50
@@ -14,7 +14,7 @@
 	merge_type = /obj/item/stack/ore/bluespace_crystal
 
 /obj/item/stack/ore/bluespace_crystal/refined
-	name = "refined quantum mesh"
+	name = "refined ultracite"
 	points = 0
 	refined_type = null
 	merge_type = /obj/item/stack/ore/bluespace_crystal/refined
@@ -32,8 +32,8 @@
 
 //Artificial bluespace crystal, doesn't give you much research.
 /obj/item/stack/ore/bluespace_crystal/artificial
-	name = "artificial quantum mesh"
-	desc = "An artificially made quantum mesh, it looks delicate."
+	name = "artificial ultracite"
+	desc = "An artificially made ultracite, it looks delicate."
 	custom_materials = list(/datum/material/bluespace=MINERAL_MATERIAL_AMOUNT*0.5)
 	blink_range = 4 // Not as good as the organic stuff!
 	points = 0 //nice try
@@ -43,14 +43,14 @@
 
 //Polycrystals, aka stacks
 /obj/item/stack/sheet/bluespace_crystal
-	name = "quantum polymesh"
+	name = "stable ultracite"
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "polycrystal"
 	item_state = "sheet-polycrystal"
-	singular_name = "bluespace polycrystal"
+	singular_name = "stable ultracite"
 	desc = "A stable polycrystal, made of fused-together quantum mesh. You could probably break one off."
 	custom_materials = list(/datum/material/bluespace=MINERAL_MATERIAL_AMOUNT)
-	attack_verb = list("bluespace polybashed", "bluespace polybattered", "bluespace polybludgeoned", "bluespace polythrashed", "bluespace polysmashed")
+	attack_verb = list("futured", "scienced", "crystalized", "empowered", "energized")
 	novariants = TRUE
 	grind_results = list(/datum/reagent/bluespace = 20)
 	point_value = 30
@@ -58,7 +58,7 @@
 	merge_type = /obj/item/stack/sheet/bluespace_crystal
 
 /obj/item/stack/sheet/bluespace_crystal/attack_self(mob/user)// to prevent the construction menu from ever happening
-	to_chat(user, span_warning("You cannot crush the polycrystal in-hand, try breaking one off."))
+	to_chat(user, span_warning("You cannot crush the ultracite in-hand, try breaking one off."))
 
 /obj/item/stack/sheet/bluespace_crystal/on_attack_hand(mob/user, act_intent = user.a_intent, unarmed_attack_flags)
 	if(user.get_inactive_held_item() == src)
@@ -68,8 +68,8 @@
 		user.put_in_hands(BC)
 		use(1)
 		if(!amount)
-			to_chat(user, span_notice("You break the final crystal off."))
+			to_chat(user, span_notice("You break the final piece of ultracite off."))
 		else
-			to_chat(user, span_notice("You break off a crystal."))
+			to_chat(user, span_notice("You break off a piece of ultracite."))
 	else
 		..()

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -552,7 +552,7 @@
 
 /obj/item/clothing/suit/hooded/wintercoat/captain
 	name = "captain's winter coat"
-	desc = "A luxurious winter coat, stuffed with the down of the endangered Uka bird and trimmed with genuine sable. The fabric is an indulgently soft micro-fiber, and the deep ultramarine color is only one that could be achieved with minute amounts of crystalline bluespace dust woven into the thread between the plectrums. Extremely lavish, and extremely durable. The tiny flakes of protective material make it nothing short of extremely light lamellar armor."
+	desc = "A luxurious winter coat, stuffed with the down of the endangered Uka bird and trimmed with genuine sable. The fabric is an indulgently soft micro-fiber, and the deep ultramarine color is only one that could be achieved with minute amounts of crystalline ultracite dust woven into the thread between the plectrums. Extremely lavish, and extremely durable. The tiny flakes of protective material make it nothing short of extremely light lamellar armor."
 	icon_state = "coatcaptain"
 	item_state = "coatcaptain"
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/captain

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1359,11 +1359,11 @@
 		mytray.adjustToxic(round(chems.get_reagent_amount(src.type) * 2))
 
 /datum/reagent/bluespace
-	name = "Bluespace Dust"
-	description = "A dust composed of microscopic bluespace crystals, with minor space-warping properties."
+	name = "Ultracite Dust"
+	description = "A dust composed of microscopic ultracite crystals, with dense unstable energy properties."
 	reagent_state = SOLID
 	color = "#0000CC"
-	taste_description = "fizzling blue"
+	taste_description = "fizzling energy"
 	pH = 12
 	value = REAGENT_VALUE_RARE
 	material = /datum/material/bluespace


### PR DESCRIPTION
## About The Pull Request
Bluespace crystals are dumb and don't exist in Fallout this fixes that, changed only names so shit shouldn't mess with anything
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaked bluespace/quantum mesh names to Ultracite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
