### PR TITLE
Gives Paladins junior loadouts like Knights and Scribes

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -466,8 +466,10 @@ Paladin
 	minimal_access = list(ACCESS_BROTHERHOOD_COMMAND,ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_BOS1, ACCESS_BOS2, ACCESS_PUBLIC)
 
 	loadout_options = list(
-	/datum/outfit/loadout/paladinc, //AER9 and AEP7
-	/datum/outfit/loadout/paladind //AEP7 and fist
+	/datum/outfit/loadout/paladina, //AER9 and AEP7
+	/datum/outfit/loadout/paladinc, //AEP9 and AEP7 J
+	/datum/outfit/loadout/paladinb, //AEP7 and fist
+	/datum/outfit/loadout/paladind	//AEP7 and fist J
 	)
 
 	outfit = /datum/outfit/job/bos/f13paladin
@@ -500,7 +502,6 @@ Paladin
 	suit =	/obj/item/clothing/suit/armor/power_armor/t45d/bos
 	head =	/obj/item/clothing/head/helmet/f13/power_armor/t45d
 	uniform =	/obj/item/clothing/under/f13/recon
-	accessory = /obj/item/clothing/accessory/bos/paladin
 	mask =	/obj/item/clothing/mask/gas/sechailer
 	belt =	/obj/item/storage/belt/military/army
 	neck =	/obj/item/clothing/neck/mantle/bos/paladin
@@ -509,18 +510,39 @@ Paladin
 		/obj/item/melee/onehanded/knife/hunting = 1
 	)
 
-/datum/outfit/loadout/paladinc
+/datum/outfit/loadout/paladina
 	name = "Frontline Paladin"
 	backpack_contents = list(
+		/obj/item/clothing/accessory/bos/paladin = 1,
 		/obj/item/gun/energy/laser/aer9 = 1,
 		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/stock_parts/cell/ammo/mfc = 2,
 		/obj/item/stock_parts/cell/ammo/ec = 2
 		)
 
-/datum/outfit/loadout/paladind
+/datum/outfit/loadout/paladinc
+	name = "Junior Frontline Paladin"
+	backpack_contents = list(
+		/obj/item/clothing/accessory/bos/juniorpaladin = 1,
+		/obj/item/gun/energy/laser/aer9 = 1,
+		/obj/item/gun/energy/laser/pistol = 1,
+		/obj/item/stock_parts/cell/ammo/mfc = 2,
+		/obj/item/stock_parts/cell/ammo/ec = 2
+		)
+
+/datum/outfit/loadout/paladinb
 	name = "Melee Specialist"
 	backpack_contents = list(
+		/obj/item/clothing/accessory/bos/paladin = 1,
+		/obj/item/melee/unarmed/powerfist = 1,
+		/obj/item/gun/energy/laser/pistol = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2
+		)
+
+/datum/outfit/loadout/paladind
+	name = "Junior Melee Specialist"
+	backpack_contents = list(
+		/obj/item/clothing/accessory/bos/juniorpaladin = 1,
 		/obj/item/melee/unarmed/powerfist = 1,
 		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 2


### PR DESCRIPTION
## About The Pull Request
This was asked of me by my very good friend and BoS main @ErwinSnowden , everyone please give him a round of applause

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Duplicated the paladin loadouts and added a junior/normal paladin accessory to them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
