### PR TITLE
steel helmet quick fix

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -456,11 +456,13 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
 	icon_state = "armyhelmet"
 	item_state = "armyhelmet"
-	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T1)
+	armor = ARMOR_VALUE_METAL_ARMOR
+	armor_tokens = list(ARMOR_MODIFIER_UP_DT_T3,ARMOR_MODIFIER_DOWN_MELEE_T1,ARMOR_MODIFIER_DOWN_LASER_T1)
 
 /obj/item/clothing/head/helmet/armyhelmet/heavy
 	name = "heavy steel helmet"
 	desc = "a steel helmet, inspired by several pre-war designs. This one has been modified by Eastwood roadies to provide more protection to the face and neck."
 	icon_state = "armyhelmetheavy"
 	item_state = "armyhelmetheavy"
-	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T2, ARMOR_MODIFIER_UP_BULLET_T3)
+	armor = ARMOR_VALUE_REINFORCED_METAL_ARMOR
+	armor_tokens = list(ARMOR_MODIFIER_UP_DT_T3,ARMOR_MODIFIER_DOWN_MELEE_T1,ARMOR_MODIFIER_DOWN_LASER_T1)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
nobody wanted to do anything because it was OP as heck

caused due to an oversight in adjusting armor values but not helmet values

steel helmets are now identical to the respective steel bibs
## Changelog
:cl:
fix: 85% bullet resist on a steelpot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
