### PR TITLE
Nerfs the Veteran Ranger's Sequoia

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -645,7 +645,7 @@
 	force = GUN_MELEE_FORCE_PISTOL_HEAVY
 	weapon_weight = GUN_ONE_HAND_ONLY
 	draw_time = GUN_DRAW_QUICK
-	damage_multiplier = GUN_EXTRA_DAMAGE_T1
+	damage_multiplier = GUN_LESS_DAMAGE_T1
 	init_recoil = HANDGUN_RECOIL(1.2)
 	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 


### PR DESCRIPTION
## About The Pull Request
It's ridiculous, I'll be honest. The Ranger's Sequoia has one of the fastest projectiles in-game, carries six shots, each of which deal the same damage as the actual longarm, the brush-gun, has a faster fire-rate than said brush-gun and has high accuracy even when fired over and over. This puts it back down to the Hunting Revolver's level, maintaining its lesser recoil whilst having its damaged reduced two levels, back down to the 50~ brute ranges. Nobody enjoys the two-hit-crit funne gun.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Sequoia nerfed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
