### PR TITLE
Makes Liquid BP rarer

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -112,7 +112,6 @@
 	points = 1
 	merge_type = /obj/item/stack/ore/blackpowder
 	custom_materials = list(/datum/material/blackpowder=MINERAL_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/blackpowder = 50)
 	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/stack/ore/blackpowder/fifty

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -83,12 +83,13 @@
 				C.IgniteMob()
 	..()
 
-
+/*
 /datum/chemical_reaction/blackpowder
 	name = "Black Powder"
 	id = /datum/reagent/blackpowder
 	results = list(/datum/reagent/blackpowder = 3)
 	required_reagents = list(/datum/reagent/saltpetre = 1, /datum/reagent/medicine/charcoal = 1, /datum/reagent/sulfur = 1)
+*/
 
 /datum/chemical_reaction/reagent_explosion/blackpowder_explosion
 	name = "Black Powder Kaboom"


### PR DESCRIPTION
## About The Pull Request
Liquid blackpowder, currently, is banned from use by admin ruling. It's used primarily in clusterbombs or as a primer/booster for mass-grief, high AoE bombs, which are, again, against the rules. Liquid Blackpowder can no longer be obtained via chemistry or via grinding - it still spawns, rarely, in a 30u bottle form, and can be, with a lot of work, grown in Botany. This resolves the issue of people powergaming by stacking blackpowder to create potent clusterbombs whilst still allowing people to make recipes / drinks / items that require BP in a liquid form.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: BP can no longer be made liquid.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
