### PR TITLE
Circuits cannot be weaponised

### DIFF
--- a/code/modules/integrated_electronics/subtypes/weaponized.dm
+++ b/code/modules/integrated_electronics/subtypes/weaponized.dm
@@ -1,6 +1,7 @@
 /obj/item/integrated_circuit/weaponized
 	category_text = "Weaponized"
 
+/*
 /obj/item/integrated_circuit/weaponized/weapon_firing
 	name = "weapon firing mechanism"
 	desc = "This somewhat complicated system allows one to slot in a gun, direct it towards a position, and remotely fire it."
@@ -349,3 +350,5 @@
 		H.forcesay(GLOB.hit_appends)
 
 	return 1
+
+*/


### PR DESCRIPTION
## About The Pull Request
Circuits can't be weaponised. They're still in the game and can be used for anything but PVP. We have balance and staff issues related to people being able to instantly kill other players by abusing bomb drones / multi-hitting guns / literal aimbot. Fixes that.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Circuits cannot be weaponised.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
