### PR TITLE
The Balancing Part 1

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -688,18 +688,6 @@
 	subcategory = CAT_WEAPON
 	always_available = FALSE
 
-/datum/crafting_recipe/dks
-	name = "DKS Sniper Rifle"
-	result = /obj/item/gun/ballistic/automatic/sniper
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/advanced_crafting_components/receiver = 1,
-				/obj/item/advanced_crafting_components/assembly = 1,
-				/obj/item/stack/crafting/metalparts = 2)
-	time = 120
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-	always_available = FALSE
-
 /datum/crafting_recipe/policepistol
 	name = ".357 Police Pistol"
 	result = /obj/item/gun/ballistic/revolver/police
@@ -1161,7 +1149,7 @@
 	always_available = FALSE
 
 //sniper
-/datum/crafting_recipe/sniper
+/datum/crafting_recipe/dks
 	name = "DKS Sniper Rifle"
 	result = /obj/item/gun/ballistic/automatic/sniper
 	reqs = list(/obj/item/stack/sheet/metal = 5,

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -914,6 +914,7 @@
 				/obj/effect/spawner/bundle/f13/brushgun = 15,
 				/obj/effect/spawner/bundle/f13/m14 = 5,
 				/obj/effect/spawner/bundle/f13/assault_carbine = 5,
+				/obj/effect/spawner/bundle/f13/magnumrevolver = 15,
 				/obj/effect/spawner/bundle/f13/dkssniper = 15,
 				/obj/effect/spawner/bundle/f13/pistol14 = 15,
 				/obj/item/gun/ballistic/revolver/grenadelauncher = 5,
@@ -1360,6 +1361,13 @@ obj/effect/spawner/bundle/f13/combat_rifle
 	items = list(
 				/obj/item/gun/ballistic/automatic/sniper,
 				/obj/item/ammo_box/magazine/w308
+	)
+
+/obj/effect/spawner/bundle/f13/magnumrevolver
+	name = "magnum revolver and ammo spawner"
+	items = list(
+				/obj/item/gun/ballistic/revolver/m2405,
+				/obj/item/ammo_box/loader/rev308
 	)
 
 /obj/effect/spawner/bundle/f13/rangemaster
@@ -2339,6 +2347,7 @@ obj/effect/spawner/bundle/f13/combat_rifle
 		/obj/item/book/granter/crafting_recipe/blueprint/smg10mm,
 		/obj/item/book/granter/crafting_recipe/blueprint/aep7,
 		/obj/item/book/granter/crafting_recipe/blueprint/scoutcarbine,
+		/obj/item/book/granter/crafting_recipe/blueprint/magnum_revolver,
 		/obj/item/book/granter/crafting_recipe/blueprint/sniper,
 	)
 

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -762,7 +762,12 @@ obj/item/book/granter/crafting_recipe/energy
 /obj/item/book/granter/crafting_recipe/blueprint/sniper
 	name = "sniper rifle blueprint"
 	icon_state = "blueprint2"
-	crafting_recipe_types = list(/datum/crafting_recipe/sniper)
+	crafting_recipe_types = list(/datum/crafting_recipe/dks)
+
+/obj/item/book/granter/crafting_recipe/blueprint/magnum_revolver
+	name = "M2045 magnum revolver rifle blueprint"
+	icon_state = "blueprint2"
+	crafting_recipe_types = list(/datum/crafting_recipe/m2405)
 
 /obj/item/book/granter/crafting_recipe/blueprint/deagle
 	name = "desert eagle blueprint"

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -168,6 +168,8 @@ Access
 		/obj/item/restraints/legcuffs/bola = 1,
 		/obj/item/storage/bag/money/small/legion = 1,
 		/obj/item/warpaint_bowl = 1,
+		/obj/item/ammo_box/loader/a357 = 1,
+		/obj/item/gun/ballistic/revolver/colt357 = 1,
 		/obj/item/binoculars = 1
 		)
 
@@ -175,10 +177,11 @@ Access
 	name = "Paladin-Slayer Centurion"
 	suit = /obj/item/clothing/suit/armor/heavy/legion/palacent
 	head = /obj/item/clothing/head/helmet/f13/legion/palacent
-	suit_store = /obj/item/gun/energy/ionrifle
+	suit_store = /obj/item/gun/ballistic/automatic/bar
 	backpack_contents = list(
 		/obj/item/storage/belt/holster = 1,
-		/obj/item/grenade/empgrenade = 3,
+		/obj/item/ammo_box/magazine/m762 = 3,
+		/obj/item/melee/unarmed/powerfist/goliath = 1,
 		/obj/item/gun/ballistic/automatic/pistol/n99/crusader = 1,
 		/obj/item/ammo_box/magazine/pistol10mm = 2
 		)
@@ -201,7 +204,6 @@ Access
 	head = /obj/item/clothing/head/helmet/f13/legion/centurion
 	suit_store = /obj/item/gun/ballistic/automatic/shotgun/citykiller
 	backpack_contents = list(
-		/obj/item/melee/unarmed/powerfist/goliath = 1,
 		/obj/item/storage/belt/holster = 1,
 		/obj/item/gun/ballistic/automatic/pistol/pistol14 = 1,
 		/obj/item/ammo_box/magazine/pistol14mm = 2,
@@ -593,9 +595,9 @@ Access
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13explorer
 	exp_requirements = 150
 
-	loadout_options = list(	// ALL: .45 Revolver
-		/datum/outfit/loadout/expscout,	// Throwing spears, Gladius, Extra Medicine
-		/datum/outfit/loadout/expsniper	// Hunting Rifle, Machete, C4
+	loadout_options = list(	// ALL: .45 Revolver, Machete
+		/datum/outfit/loadout/expambusher,	// Lever-action shotgun, Bottlecap mine, MP5
+		/datum/outfit/loadout/expsniper	// Hunting Rifle, Smokebomb, C4
 		)
 
 	access = list(ACCESS_PUBLIC, ACCESS_LEGION, ACCESS_LEGION2)
@@ -632,16 +634,18 @@ Access
 		/obj/item/ammo_box/loader/acp45 = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
 		/obj/item/storage/bag/money/small/legenlisted = 1,
-		/obj/item/grenade/smokebomb = 1,
+		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/restraints/handcuffs = 1
 		)
 
-/datum/outfit/loadout/expscout
-	name = "Scout"
-	belt = /obj/item/storage/backpack/spearquiver
+/datum/outfit/loadout/expambusher
+	name = "Ambusher"
+	suit_store = /obj/item/gun/ballistic/automatic/smg/mp5
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/patch/healpoultice = 2,
-		/obj/item/melee/onehanded/machete/gladius = 1,
+		/obj/item/ammo_box/magazine/uzim9mm = 2,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever = 1,
+		/obj/item/bottlecap_mine = 1,
+		/obj/item/grenade/smokebomb = 1,
 		/obj/item/restraints/legcuffs/bola/tactical = 1
 		)
 
@@ -650,7 +654,7 @@ Access
 	suit_store = /obj/item/gun/ballistic/rifle/hunting
 	backpack_contents = list(
 		/obj/item/ammo_box/stripper/a308 = 3,
-		/obj/item/melee/onehanded/machete = 1,
+		/obj/item/grenade/smokebomb = 1,
 		/obj/item/gun_upgrade/scope/watchman = 1,
 		/obj/item/grenade/plastic/c4 = 1
 		)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -135,9 +135,9 @@ Access
 	minimal_access = list(ACCESS_PUBLIC, ACCESS_LEGION, ACCESS_LEGION3, ACCESS_LEGION_COMMAND, ACCESS_LEGION2, ACCESS_CHANGE_IDS, ACCESS_LEGION1, ACCESS_LEGION4)
 
 	loadout_options = list(
-		/datum/outfit/loadout/palacent,		// Pulse rifle, EMP grenades, 10mm pistol
+		/datum/outfit/loadout/palacent,		// BAR, Goliath, 10mm pistol
 		/datum/outfit/loadout/rangerhunter,	// Hunting revolver, Sniper, Spatha
-		/datum/outfit/loadout/centurion,	// City-Killer shotgun, Goliath, 14mm pistol
+		/datum/outfit/loadout/centurion,	// City-Killer shotgun, 14mm pistol
 		)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13centurion/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -597,7 +597,7 @@ Access
 
 	loadout_options = list(	// ALL: .45 Revolver, Machete
 		/datum/outfit/loadout/expambusher,	// Lever-action shotgun, Bottlecap mine, MP5
-		/datum/outfit/loadout/expsniper	// Hunting Rifle, Smokebomb, C4
+		/datum/outfit/loadout/expsniper	// Commando Carbine, Smokebomb, C4
 		)
 
 	access = list(ACCESS_PUBLIC, ACCESS_LEGION, ACCESS_LEGION2)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -135,9 +135,9 @@ Access
 	minimal_access = list(ACCESS_PUBLIC, ACCESS_LEGION, ACCESS_LEGION3, ACCESS_LEGION_COMMAND, ACCESS_LEGION2, ACCESS_CHANGE_IDS, ACCESS_LEGION1, ACCESS_LEGION4)
 
 	loadout_options = list(
-		/datum/outfit/loadout/palacent,		// BAR, Goliath, 10mm pistol
+		/datum/outfit/loadout/palacent,		// Pulse rifle, EMP grenades, 10mm pistol
 		/datum/outfit/loadout/rangerhunter,	// Hunting revolver, Sniper, Spatha
-		/datum/outfit/loadout/centurion,	// City-Killer shotgun, 14mm pistol
+		/datum/outfit/loadout/centurion,	// City-Killer shotgun, Goliath, 14mm pistol
 		)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13centurion/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -168,8 +168,6 @@ Access
 		/obj/item/restraints/legcuffs/bola = 1,
 		/obj/item/storage/bag/money/small/legion = 1,
 		/obj/item/warpaint_bowl = 1,
-		/obj/item/ammo_box/loader/a357 = 1,
-		/obj/item/gun/ballistic/revolver/colt357 = 1,
 		/obj/item/binoculars = 1
 		)
 
@@ -177,11 +175,10 @@ Access
 	name = "Paladin-Slayer Centurion"
 	suit = /obj/item/clothing/suit/armor/heavy/legion/palacent
 	head = /obj/item/clothing/head/helmet/f13/legion/palacent
-	suit_store = /obj/item/gun/ballistic/automatic/bar
+	suit_store = /obj/item/gun/energy/ionrifle
 	backpack_contents = list(
 		/obj/item/storage/belt/holster = 1,
-		/obj/item/ammo_box/magazine/m762 = 3,
-		/obj/item/melee/unarmed/powerfist/goliath = 1,
+		/obj/item/grenade/empgrenade = 3,
 		/obj/item/gun/ballistic/automatic/pistol/n99/crusader = 1,
 		/obj/item/ammo_box/magazine/pistol10mm = 2
 		)
@@ -204,6 +201,7 @@ Access
 	head = /obj/item/clothing/head/helmet/f13/legion/centurion
 	suit_store = /obj/item/gun/ballistic/automatic/shotgun/citykiller
 	backpack_contents = list(
+		/obj/item/melee/unarmed/powerfist/goliath = 1,
 		/obj/item/storage/belt/holster = 1,
 		/obj/item/gun/ballistic/automatic/pistol/pistol14 = 1,
 		/obj/item/ammo_box/magazine/pistol14mm = 2,
@@ -595,9 +593,9 @@ Access
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13explorer
 	exp_requirements = 150
 
-	loadout_options = list(	// ALL: .45 Revolver, Machete
-		/datum/outfit/loadout/expambusher,	// Lever-action shotgun, Bottlecap mine, MP5
-		/datum/outfit/loadout/expsniper	// Commando Carbine, Smokebomb, C4
+	loadout_options = list(	// ALL: .45 Revolver
+		/datum/outfit/loadout/expscout,	// Throwing spears, Gladius, Extra Medicine
+		/datum/outfit/loadout/expsniper	// Hunting Rifle, Machete, C4
 		)
 
 	access = list(ACCESS_PUBLIC, ACCESS_LEGION, ACCESS_LEGION2)
@@ -634,18 +632,16 @@ Access
 		/obj/item/ammo_box/loader/acp45 = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
 		/obj/item/storage/bag/money/small/legenlisted = 1,
-		/obj/item/melee/onehanded/machete = 1,
+		/obj/item/grenade/smokebomb = 1,
 		/obj/item/restraints/handcuffs = 1
 		)
 
-/datum/outfit/loadout/expambusher
-	name = "Ambusher"
-	suit_store = /obj/item/gun/ballistic/automatic/smg/mp5
+/datum/outfit/loadout/expscout
+	name = "Scout"
+	belt = /obj/item/storage/backpack/spearquiver
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/uzim9mm = 2,
-		/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever = 1,
-		/obj/item/bottlecap_mine = 1,
-		/obj/item/grenade/smokebomb = 1,
+		/obj/item/reagent_containers/pill/patch/healpoultice = 2,
+		/obj/item/melee/onehanded/machete/gladius = 1,
 		/obj/item/restraints/legcuffs/bola/tactical = 1
 		)
 
@@ -654,7 +650,7 @@ Access
 	suit_store = /obj/item/gun/ballistic/rifle/hunting
 	backpack_contents = list(
 		/obj/item/ammo_box/stripper/a308 = 3,
-		/obj/item/grenade/smokebomb = 1,
+		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/gun_upgrade/scope/watchman = 1,
 		/obj/item/grenade/plastic/c4 = 1
 		)


### PR DESCRIPTION
## About The Pull Request
~~The Paladin-Hunter is now a Paladin counter.
An Explorer main said the MP5 loadout sucked so now it's just throwing spears with meds and a gladius.~~
The M2405 has no reason not to be in circulation, so I added it in the same pool as the DKS in both blueprint and spawner.

Another guy wants to change the Legion loadouts and he can be my guest. I'll update the NCR Armors on a later update.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added the M2405 Magnum Revolver into circulation.\
del: Removed an duplicate DKS crafting recipe.
~~del: Removed the .357 from the Centurion since all his loadouts have a secondary.
balance: rebalanced the Explorer Loadouts, the MP5 loadout now has Throwing spears, Extra Meds and a Gladius and adds a normal Machete to the other loadout. Also gave the Explorer a standard smokebomb since both his loadouts spawned with one.
balance: rebalanced the Paladin-Hunter, he now starts with 3 EMP Grenades, a Pulse Rifle and the Crusader pistol, so now he actually has the direct equipment to counter a Paladin. Also gave the Goliath to the normal Centurion.~~
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
