### PR TITLE
Revert "Circuits cannot be weaponised"

### DIFF
--- a/code/modules/integrated_electronics/subtypes/weaponized.dm
+++ b/code/modules/integrated_electronics/subtypes/weaponized.dm
@@ -1,7 +1,6 @@
 /obj/item/integrated_circuit/weaponized
 	category_text = "Weaponized"
 
-/*
 /obj/item/integrated_circuit/weaponized/weapon_firing
 	name = "weapon firing mechanism"
 	desc = "This somewhat complicated system allows one to slot in a gun, direct it towards a position, and remotely fire it."
@@ -350,5 +349,3 @@
 		H.forcesay(GLOB.hit_appends)
 
 	return 1
-
-*/


### PR DESCRIPTION
Reverts AtomBombf13/AtomBomb#467

Revert the circuit changes, they were made by someone acting in bad faith who wants to just remove circuits as a whole and is going to keep chipping away at them until they don't exist.
If you actually want to fix circuits properly sit down with the people that use them identify the problems and work to fix them instead of just ripping things out.
Or if you really want to rip out features start replacing them with other things.